### PR TITLE
Fix linking with Boost.Thread on Windows.

### DIFF
--- a/include/boost/thread/win32/gettickcount64.hpp
+++ b/include/boost/thread/win32/gettickcount64.hpp
@@ -18,7 +18,7 @@ namespace boost
       typedef unsigned long long ticks_type;
       typedef ticks_type (__stdcall *gettickcount64fn)();
       typedef unsigned long (__stdcall *gettickcount32fn)();
-      ticks_type GetTickCount64();
+      BOOST_THREAD_DECL ticks_type GetTickCount64();
     }
   }
 }

--- a/src/win32/gettickcount64.cpp
+++ b/src/win32/gettickcount64.cpp
@@ -38,7 +38,7 @@ namespace boost
         }
       }
 
-      ticks_type GetTickCount64()
+      BOOST_THREAD_DECL ticks_type GetTickCount64()
       {
         ::boost::call_once(&init_gettickcount64, initfnonce);
         return gettickcount64 ? gettickcount64() : static_cast<ticks_type> (gettickcount32());


### PR DESCRIPTION
Other libraries are failing to link with Boost.Thread on Windows because GetTickCount64 is not marked with __declspec(dllimport).
