### PR TITLE
Fix warnings about redefining a defined macro

### DIFF
--- a/include/boost/thread/detail/config.hpp
+++ b/include/boost/thread/detail/config.hpp
@@ -379,7 +379,9 @@
 // compatibility with the rest of Boost's auto-linking code:
 #if defined(BOOST_THREAD_DYN_LINK) || defined(BOOST_ALL_DYN_LINK)
 # undef  BOOST_THREAD_USE_LIB
-# define BOOST_THREAD_USE_DLL
+# if !defined(BOOST_THREAD_USE_DLL)
+#  define BOOST_THREAD_USE_DLL
+# endif
 #endif
 
 #if defined(BOOST_THREAD_BUILD_DLL)   //Build dll


### PR DESCRIPTION
The warnings appear when a dependent project (e.g. Boost.Log tests and examples) builds with link=shared and defines BOOST_ALL_DYN_LINK macro. In this case BOOST_THREAD_USE_DLL is defined by both thread/build/Jamfile.v2 and boost/thread/detail/config.hpp. This commit makes sure that doesn't happen.
