### PR TITLE
thread::physical_concurrency() always returns 0 on PowerPC

### DIFF
--- a/src/pthread/thread.cpp
+++ b/src/pthread/thread.cpp
@@ -572,9 +572,6 @@ namespace boost
     unsigned thread::physical_concurrency() BOOST_NOEXCEPT
     {
 #ifdef __linux__
-#ifdef __powerpc__
-        return hardware_concurrency();
-#endif
         try {
             using namespace std;
 
@@ -597,7 +594,7 @@ namespace boost
                 boost::split(key_val, line, boost::is_any_of(":"));
 
                 if (key_val.size() != 2)
-                    return 0;
+                    return hardware_concurrency();
 
                 string key   = key_val[0];
                 string value = key_val[1];
@@ -615,9 +612,12 @@ namespace boost
                     continue;
                 }
             }
-            return cores.size();
+            // Fall back to hardware_concurrency() in case
+            // /proc/cpuinfo is formatted differently than
+            // we expect.
+            return cores.size() != 0 ? cores.size() : hardware_concurrency();
         } catch(...) {
-            return 0;
+            return hardware_concurrency();
         }
 #elif defined(__APPLE__)
         int count;


### PR DESCRIPTION
The thread::physical_concurrency() function, located in src/pthread/thread.cpp, always returns 0 on the PowerPC platform. I believe this is because /proc/cpuinfo, which the function uses (on linux platforms) to determine the number of processors/cores on the machine, is formatted differently on PowerPC than it is on x86 and other platforms. Here is an example from the machine I am testing on (Ubuntu 14.04 LTS ppc64le):

```
$ cat /proc/cpuinfo
processor   : 0
cpu     : POWER7 (raw), altivec supported
clock       : 3220.000000MHz
revision    : 2.3 (pvr 003f 0203)

processor   : 1
cpu     : POWER7 (raw), altivec supported
clock       : 3220.000000MHz
revision    : 2.3 (pvr 003f 0203)

processor   : 2
cpu     : POWER7 (raw), altivec supported
clock       : 3220.000000MHz
revision    : 2.3 (pvr 003f 0203)

processor   : 3
cpu     : POWER7 (raw), altivec supported
clock       : 3220.000000MHz
revision    : 2.3 (pvr 003f 0203)

processor   : 4
cpu     : POWER7 (raw), altivec supported
clock       : 3220.000000MHz
revision    : 2.3 (pvr 003f 0203)

processor   : 5
cpu     : POWER7 (raw), altivec supported
clock       : 3220.000000MHz
revision    : 2.3 (pvr 003f 0203)

processor   : 6
cpu     : POWER7 (raw), altivec supported
clock       : 3220.000000MHz
revision    : 2.3 (pvr 003f 0203)

processor   : 7
cpu     : POWER7 (raw), altivec supported
clock       : 3220.000000MHz
revision    : 2.3 (pvr 003f 0203)

timebase    : 512000000
platform    : pSeries
model       : IBM pSeries (emulated by qemu)
machine     : CHRP IBM pSeries (emulated by qemu)
```

Note that the "physical id" and "core id" lines that the function expects are not present. The function does not account for this, and returns 0 as the number of processors/cores on the system. This causes test_physical_concurrency_lib.test and test_physical_concurrency.test to fail.

I have created a pull request with a tentative fix, which uses the hardware_concurrency() function in the same file to determine the number of processors/cores on Power systems. It seems to resolve the two failing test cases without any regressions.
