### PR TITLE
Fix GetTickCount return type

### DIFF
--- a/include/boost/thread/win32/thread_primitives.hpp
+++ b/include/boost/thread/win32/thread_primitives.hpp
@@ -226,7 +226,7 @@ namespace boost
 #else
                 __declspec(dllimport) void * __stdcall GetModuleHandleW(const wchar_t *);
 #endif
-                int __stdcall GetTickCount();
+                __declspec(dllimport) unsigned long __stdcall GetTickCount();
 #ifdef _MSC_VER
                 long _InterlockedCompareExchange(long volatile *, long, long);
 #pragma intrinsic(_InterlockedCompareExchange)


### PR DESCRIPTION
int as a return type results in a signed/unsigned mismatch warning with MSVC (although disabled by default), and it doesn't even compile with clang-cl if the definiton from the Windows header was included before.

Tested with MSVC 12, 14, and clang-cl.
