### PR TITLE
Fix GCC warnings about initialization order

### DIFF
--- a/include/boost/thread/win32/thread_data.hpp
+++ b/include/boost/thread/win32/thread_data.hpp
@@ -125,8 +125,8 @@ namespace boost
             thread_data_base():
                 count(0),
                 thread_handle(),
-                id(0),
                 thread_exit_callbacks(0),
+                id(0),
                 tss_data(),
                 notify(),
                 async_states_()


### PR DESCRIPTION
The warnings can be seen here:

http://www.boost.org/development/tests/develop/developer/output/MinGW-w64-4-4%20jc-bell-boost-bin-v2-libs-atomic-test-atomicity-test-gcc-mingw-4-4-7-debug-threading-multi.html
