### PR TITLE
Fix Visual Studio 2010 error C2440: 'initializing' : cannot convert from...

### DIFF
--- a/include/boost/thread/win32/mfc_thread_init.hpp
+++ b/include/boost/thread/win32/mfc_thread_init.hpp
@@ -13,7 +13,7 @@
 
 // can't use ExtRawDllMain from afxdllx.h as it also defines the symbol _pRawDllMain
 extern "C"
-inline BOOL WINAPI ExtRawDllMain(HINSTANCE, DWORD dwReason, LPVOID)
+inline BOOL WINAPI ExtRawDllMain(HANDLE, DWORD dwReason, LPVOID)
 {
   if (dwReason == DLL_PROCESS_ATTACH)
   {


### PR DESCRIPTION
... 'BOOL (__stdcall *)(HINSTANCE,DWORD,LPVOID)' to 'BOOL (__stdcall *const )(HANDLE,DWORD,LPVOID)' This conversion requires a reinterpret_cast, a C-style cast or function-style cast
