### PR TITLE
Change members order in win32 thread_data_base to match ctor initializer...

### DIFF
--- a/include/boost/thread/win32/thread_data.hpp
+++ b/include/boost/thread/win32/thread_data.hpp
@@ -105,8 +105,8 @@ namespace boost
 #endif
 
             boost::detail::thread_exit_callback_node* thread_exit_callbacks;
-            std::map<void const*,boost::detail::tss_data_node> tss_data;
             unsigned id;
+            std::map<void const*,boost::detail::tss_data_node> tss_data;
             typedef std::vector<std::pair<condition_variable*, mutex*>
             //, hidden_allocator<std::pair<condition_variable*, mutex*> >
             > notify_list_t;


### PR DESCRIPTION
... list.

The purpose of this PR is to silence the compiler warnings.

I wasn't sure which member should go first, id or tss_data. I've choosen the smaller one but the first should probably be the one which may be used more often.
