### PR TITLE
prevent ~unique_lock from throwing exceptions

### DIFF
--- a/include/boost/thread/lock_types.hpp
+++ b/include/boost/thread/lock_types.hpp
@@ -328,7 +328,11 @@ namespace boost
     {
       if (owns_lock())
       {
-        m->unlock();
+        try {
+          m->unlock();
+        } catch (boost::lock_error) {
+          //destructors may not throw
+        }
       }
     }
     void lock()


### PR DESCRIPTION
~unique_lock() calls unlock(), which can throw an exception. Destructors may not throw exceptions on pain of immediately terminating the program, so we have to catch the exception.
