### PR TITLE
No comment after preprocessor continuation for msvc-12.0

### DIFF
--- a/src/win32/thread.cpp
+++ b/src/win32/thread.cpp
@@ -529,8 +529,9 @@ namespace boost
 
     unsigned thread::physical_concurrency() BOOST_NOEXCEPT
     {
+// a bit too strict: Windows XP with SP3 would be sufficient
 #if BOOST_PLAT_WINDOWS_RUNTIME                                    \
-    || ( BOOST_USE_WINAPI_VERSION <= BOOST_WINAPI_VERSION_WINXP ) \  // a bit too strict: Windows XP with SP3 would be sufficient
+    || ( BOOST_USE_WINAPI_VERSION <= BOOST_WINAPI_VERSION_WINXP ) \
     || ( defined(__MINGW32__) && !defined(__MINGW64__) )
         return 0;
 #else


### PR DESCRIPTION
msvc does not like comment after macros continuation markers. This was broken in 14c5cff2eeb1454130b4313c8f22f1853c1f6acd and all tests are failing for all msvc versions since.
