### PR TITLE
Catch boost::lock_error in destructor as destructors may not throw

### DIFF
--- a/include/boost/thread/lock_types.hpp
+++ b/include/boost/thread/lock_types.hpp
@@ -330,7 +330,7 @@ namespace boost
       {
         try {
           m->unlock();
-        } catch (boost::lock_error) {
+        } catch (const boost::lock_error&) {
           //destructors may not throw
         }
       }

--- a/include/boost/thread/lock_types.hpp
+++ b/include/boost/thread/lock_types.hpp
@@ -328,7 +328,11 @@ namespace boost
     {
       if (owns_lock())
       {
-        m->unlock();
+        try {
+          m->unlock();
+        } catch (boost::lock_error) {
+          //destructors may not throw
+        }
       }
     }
     void lock()


### PR DESCRIPTION
This is intended to prevent the possibility of ~unique_lock throwing a lock_error, which would terminate any program in which it occurred.