### PR TITLE
Fix gcc/clang shadow warnings.

### DIFF
--- a/include/boost/thread/future.hpp
+++ b/include/boost/thread/future.hpp
@@ -901,7 +901,7 @@ namespace boost
             };
 
             boost::condition_variable_any cv;
-            std::vector<registered_waiter> futures;
+            std::vector<registered_waiter> futures_;
             count_type future_count;
 
         public:
@@ -916,7 +916,7 @@ namespace boost
                 {
                   registered_waiter waiter(f.future_,f.future_->notify_when_ready(cv),future_count);
                   try {
-                      futures.push_back(waiter);
+                    futures_.push_back(waiter);
                   } catch(...) {
                     f.future_->unnotify_when_ready(waiter.handle);
                     throw;
@@ -935,14 +935,14 @@ namespace boost
 
             count_type wait()
             {
-                all_futures_lock lk(futures);
+                all_futures_lock lk(futures_);
                 for(;;)
                 {
-                    for(count_type i=0;i<futures.size();++i)
+                    for(count_type i=0;i<futures_.size();++i)
                     {
-                        if(futures[i].future_->done)
+                        if(futures_[i].future_->done)
                         {
-                            return futures[i].index;
+                            return futures_[i].index;
                         }
                     }
                     cv.wait(lk);
@@ -951,9 +951,9 @@ namespace boost
 
             ~future_waiter()
             {
-                for(count_type i=0;i<futures.size();++i)
+                for(count_type i=0;i<futures_.size();++i)
                 {
-                    futures[i].future_->unnotify_when_ready(futures[i].handle);
+                    futures_[i].future_->unnotify_when_ready(futures_[i].handle);
                 }
             }
         };

--- a/include/boost/thread/futures/wait_for_any.hpp
+++ b/include/boost/thread/futures/wait_for_any.hpp
@@ -81,7 +81,7 @@ namespace boost
       };
 
       boost::condition_variable_any cv;
-      std::vector<registered_waiter> waiters;
+      std::vector<registered_waiter> waiters_;
       count_type future_count;
 
     public:
@@ -98,7 +98,7 @@ namespace boost
           registered_waiter waiter(f, f.notify_when_ready(cv), future_count);
           try
           {
-            waiters.push_back(waiter);
+            waiters_.push_back(waiter);
           }
           catch (...)
           {
@@ -120,14 +120,14 @@ namespace boost
 
       count_type wait()
       {
-        all_futures_lock lk(waiters);
+        all_futures_lock lk(waiters_);
         for (;;)
         {
-          for (count_type i = 0; i < waiters.size(); ++i)
+          for (count_type i = 0; i < waiters_.size(); ++i)
           {
-            if (waiters[i].future_->is_ready(lk.locks[i]))
+            if (waiters_[i].future_->is_ready(lk.locks[i]))
             {
-              return waiters[i].index;
+              return waiters_[i].index;
             }
           }
           cv.wait(lk);
@@ -136,9 +136,9 @@ namespace boost
 
       ~waiter_for_any_in_seq()
       {
-        for (count_type i = 0; i < waiters.size(); ++i)
+        for (count_type i = 0; i < waiters_.size(); ++i)
         {
-          waiters[i].future_->unnotify_when_ready(waiters[i].handle);
+          waiters_[i].future_->unnotify_when_ready(waiters_[i].handle);
         }
       }
     };


### PR DESCRIPTION
The variable names are re-used in the all_futures_lock() functions.

```
.../boost/boost/thread/futures/wait_for_any.hpp:60:58: warning: declaration shadows a field of 'waiter_for_any_in_seq<Future>' [-Wshadow]
        all_futures_lock(std::vector<registered_waiter>& waiters) :
```
and
```
.../boost/boost/thread/future.hpp:880:66: warning: declaration shadows a field of 'boost::detail::future_waiter' [-Wshadow]
                all_futures_lock(std::vector<registered_waiter>& futures):
```