### PR TITLE
Disable thread safety analysis / avoid confusing clang on OS X

### DIFF
--- a/include/boost/thread/pthread/condition_variable.hpp
+++ b/include/boost/thread/pthread/condition_variable.hpp
@@ -40,8 +40,11 @@ namespace boost
                 m(0)
             {}
 
-            void activate(MutexType& m_)
+            // airtime:start
+            // remove attribute when OS X clang is not confused by this
+            void activate(MutexType& m_) __attribute__((no_thread_safety_analysis))
             {
+            // airtime:end
                 m_.unlock();
                 m=&m_;
             }

--- a/include/boost/thread/pthread/condition_variable.hpp
+++ b/include/boost/thread/pthread/condition_variable.hpp
@@ -40,11 +40,9 @@ namespace boost
                 m(0)
             {}
 
-            // airtime:start
             // remove attribute when OS X clang is not confused by this
             void activate(MutexType& m_) __attribute__((no_thread_safety_analysis))
             {
-            // airtime:end
                 m_.unlock();
                 m=&m_;
             }


### PR DESCRIPTION
Original description, from thughes:

This particular path confuses clang on OSX (seems to work fine with clang 3.5 on Linux).
