### PR TITLE
Moved function calls out of the BOOST_VERIFY macro

### DIFF
--- a/include/boost/thread/pthread/pthread_mutex_scoped_lock.hpp
+++ b/include/boost/thread/pthread/pthread_mutex_scoped_lock.hpp
@@ -23,11 +23,13 @@ namespace boost
             explicit pthread_mutex_scoped_lock(pthread_mutex_t* m_):
                 m(m_),locked(true)
             {
-                BOOST_VERIFY(!pthread_mutex_lock(m));
+                int error_code = pthread_mutex_lock(m);
+                BOOST_VERIFY(!error_code);
             }
             void unlock()
             {
-                BOOST_VERIFY(!pthread_mutex_unlock(m));
+                int error_code = pthread_mutex_unlock(m);
+                BOOST_VERIFY(!error_code);
                 locked=false;
             }
             
@@ -48,11 +50,13 @@ namespace boost
             explicit pthread_mutex_scoped_unlock(pthread_mutex_t* m_):
                 m(m_)
             {
-                BOOST_VERIFY(!pthread_mutex_unlock(m));
+                int error_code = pthread_mutex_unlock(m);
+                BOOST_VERIFY(!error_code);
             }
             ~pthread_mutex_scoped_unlock()
             {
-                BOOST_VERIFY(!pthread_mutex_lock(m));
+                int error_code = pthread_mutex_lock(m);
+                BOOST_VERIFY(!error_code);
             }
             
         };

--- a/include/boost/thread/pthread/thread_data.hpp
+++ b/include/boost/thread/pthread/thread_data.hpp
@@ -194,25 +194,29 @@ namespace boost
                     check_for_interruption();
                     thread_info->cond_mutex=cond_mutex;
                     thread_info->current_cond=cond;
-                    BOOST_VERIFY(!pthread_mutex_lock(m));
+                    int error_code = pthread_mutex_lock(m);
+                    BOOST_VERIFY(!error_code);
                 }
                 else
                 {
-                    BOOST_VERIFY(!pthread_mutex_lock(m));
+                    int error_code = pthread_mutex_lock(m);
+                    BOOST_VERIFY(!error_code);
                 }
             }
             ~interruption_checker()
             {
                 if(set)
                 {
-                    BOOST_VERIFY(!pthread_mutex_unlock(m));
+                    int error_code = pthread_mutex_unlock(m);
+                    BOOST_VERIFY(!error_code);
                     lock_guard<mutex> guard(thread_info->data_mutex);
                     thread_info->cond_mutex=NULL;
                     thread_info->current_cond=NULL;
                 }
                 else
                 {
-                    BOOST_VERIFY(!pthread_mutex_unlock(m));
+                    int error_code = pthread_mutex_unlock(m);
+                    BOOST_VERIFY(!error_code);
                 }
             }
         };


### PR DESCRIPTION
Due to the structure of some of the "assert" macros used by BOOST_VERIFY, it is unsafe to pass it function calls that are not idempotent (and thus good practice to not pass it function calls in general). In this particular instance, the pthread_mutex_lock call would be duplicated on a non-zero return from pthread_mutex_lock, resulting in a possible double lock. This issue was uncovered with Coverity.