### PR TITLE
Check for _POSIX_TIMEOUTS more neatly.

### DIFF
--- a/include/boost/thread/pthread/mutex.hpp
+++ b/include/boost/thread/pthread/mutex.hpp
@@ -27,7 +27,7 @@
 #include <boost/thread/detail/delete.hpp>
 
 #ifdef _POSIX_TIMEOUTS
-#if _POSIX_TIMEOUTS >= 0 && _POSIX_TIMEOUTS>=200112L
+#if (_POSIX_TIMEOUTS - 0) >= 200112L
 #ifndef BOOST_PTHREAD_HAS_TIMEDLOCK
 #define BOOST_PTHREAD_HAS_TIMEDLOCK
 #endif

--- a/include/boost/thread/pthread/recursive_mutex.hpp
+++ b/include/boost/thread/pthread/recursive_mutex.hpp
@@ -28,7 +28,7 @@
 #include <boost/thread/detail/delete.hpp>
 
 #ifdef _POSIX_TIMEOUTS
-#if _POSIX_TIMEOUTS >= 0 && _POSIX_TIMEOUTS>=200112L
+#if (_POSIX_TIMEOUTS - 0) >= 200112L
 #ifndef BOOST_PTHREAD_HAS_TIMEDLOCK
 #define BOOST_PTHREAD_HAS_TIMEDLOCK
 #endif


### PR DESCRIPTION
The present code do twice checking using "&&" operator.
Making the check more neat. 
Refer : https://sourceware.org/git/?p=glibc.git;a=blob;f=include/features.h 
258 #if (_POSIX_C_SOURCE - 0) >= 200112L
Also Refer : http://man7.org/linux/man-pages/man7/feature_test_macros.7.html for explanation of feature test macros.
