### PR TITLE
Updated namespace to call no_interruption_point sleep_for

### DIFF
--- a/include/boost/thread/pthread/thread_data.hpp
+++ b/include/boost/thread/pthread/thread_data.hpp
@@ -250,7 +250,7 @@ namespace boost
           inline
           void BOOST_SYMBOL_VISIBLE sleep_for(const chrono::nanoseconds& ns)
           {
-              return boost::this_thread::hiden::sleep_for(boost::detail::to_timespec(ns));
+              return boost::this_thread::no_interruption_point::hiden::sleep_for(boost::detail::to_timespec(ns));
           }
     #endif
     #endif // BOOST_THREAD_USES_CHRONO


### PR DESCRIPTION
Updating the namespace seems to fix the following issue:

https://svn.boost.org/trac/boost/ticket/6787
