### PR TITLE
 Consistent Android build by including limits.h

### DIFF
--- a/include/boost/thread/pthread/thread_data.hpp
+++ b/include/boost/thread/pthread/thread_data.hpp
@@ -25,9 +25,7 @@
 #include <utility>
 
 #if defined(__ANDROID__)
-# ifndef PAGE_SIZE
-#  define PAGE_SIZE 4096
-# endif
+#include <limits.h>
 #endif
 
 #include <pthread.h>


### PR DESCRIPTION
Including <limits.h> instead of manually defining PAGE_SIZE.

The old way of including <asm/page.h> was made unavailable since https://android-review.googlesource.com/#/c/83299/ and fixed by defining PAGE_SIZE manually. The question arises whether it would be more consistent to include limits.h which I hereby put up for discussion.