### PR TITLE
Fix typo

### DIFF
--- a/include/boost/thread/win32/thread_primitives.hpp
+++ b/include/boost/thread/win32/thread_primitives.hpp
@@ -59,7 +59,7 @@ namespace boost
             using ::CreateSemaphoreExW;
 # endif
             using ::OpenEventW;
-            using ::GetModuleGandleW;
+            using ::GetModuleHandleW;
 # else
             using ::CreateMutexA;
             using ::CreateEventA;


### PR DESCRIPTION
There was a typo in the code with both BOOST_USE_WINDOWS_H and BOOST_NO_ANSI_APIS defined.