### PR TITLE
thread::try_join_until: Avoid busy wait if system clock changes

### DIFF
--- a/include/boost/thread/detail/thread.hpp
+++ b/include/boost/thread/detail/thread.hpp
@@ -485,9 +485,9 @@ namespace boost
         bool try_join_until(const chrono::time_point<Clock, Duration>& t)
         {
           using namespace chrono;
-          system_clock::time_point     s_now = system_clock::now();
           bool joined= false;
           do {
+            system_clock::time_point   s_now = system_clock::now();
             typename Clock::duration   d = ceil<nanoseconds>(t-Clock::now());
             if (d <= Clock::duration::zero()) return false; // in case the Clock::time_point t is already reached
             joined = try_join_until(s_now + d);


### PR DESCRIPTION
If system clock changes by an amount larger than the outstanding duration
according to the supplied clock then the code loops around again but
continues to pass a time point based on the original value of the system
clock to the system_clock variant of try_join.

If we're going to recalculate the outstanding duration in the loop then it
is necessary to get the current time according to the system clock to use
with this duration.

Signed-off-by: Mike Crowe <mac@mcrowe.com>