### PR TITLE
Fix to get Thread lib building with Oracle C++

### DIFF
--- a/include/boost/thread/pthread/once_atomic.hpp
+++ b/include/boost/thread/pthread/once_atomic.hpp
@@ -233,7 +233,7 @@ namespace boost
       thread_detail::commit_once_region(flag);
     }
   }
-
+#if !(defined(__SUNPRO_CC) && BOOST_WORKAROUND(__SUNPRO_CC, <= 0x5130))
   template<typename Function, typename T1>
   inline void call_once(once_flag& flag, BOOST_THREAD_RV_REF(Function) f, BOOST_THREAD_RV_REF(T1) p1)
   {
@@ -302,7 +302,7 @@ namespace boost
     }
   }
 
-
+#endif // __SUNPRO_CC
 
 #endif
 }


### PR DESCRIPTION
See https://svn.boost.org/trac/boost/ticket/11550

This gets Thread building with Oracle C++, there are still test failures, but they're unrelated.