### PR TITLE
Fixed warning C4100 on Windows: Unreferenced Formal Parameter

### DIFF
--- a/include/boost/thread/future.hpp
+++ b/include/boost/thread/future.hpp
@@ -407,7 +407,7 @@ namespace boost
                 return policy_;
             }
 
-            future_state::state get_state(boost::unique_lock<boost::mutex>& lk) const
+            future_state::state get_state(boost::unique_lock<boost::mutex>&) const
             {
                 if(!done)
                 {


### PR DESCRIPTION
lk wasn't used here.