### PR TITLE
Avoid deprecated auto_ptr

### DIFF
--- a/include/boost/thread/detail/thread_group.hpp
+++ b/include/boost/thread/detail/thread_group.hpp
@@ -6,6 +6,7 @@
 // (C) Copyright 2007-9 Anthony Williams
 
 #include <list>
+#include <boost/thread/csbl/memory/unique_ptr.hpp>
 #include <boost/thread/shared_mutex.hpp>
 #include <boost/thread/mutex.hpp>
 #include <boost/thread/lock_guard.hpp>
@@ -75,7 +76,7 @@ namespace boost
         thread* create_thread(F threadfunc)
         {
             boost::lock_guard<shared_mutex> guard(m);
-            std::auto_ptr<thread> new_thread(new thread(threadfunc));
+            boost::csbl::unique_ptr<thread> new_thread(new thread(threadfunc));
             threads.push_back(new_thread.get());
             return new_thread.release();
         }

--- a/src/win32/thread.cpp
+++ b/src/win32/thread.cpp
@@ -25,6 +25,7 @@
 #if defined BOOST_THREAD_USES_DATETIME
 #include <boost/date_time/posix_time/conversion.hpp>
 #endif
+#include <boost/thread/csbl/memory/unique_ptr.hpp>
 #include <memory>
 #include <algorithm>
 #ifndef UNDER_CE
@@ -153,7 +154,7 @@ namespace boost
 
         DWORD WINAPI ThreadProxy(LPVOID args)
         {
-            std::auto_ptr<ThreadProxyData> data(reinterpret_cast<ThreadProxyData*>(args));
+            boost::csbl::unique_ptr<ThreadProxyData> data(reinterpret_cast<ThreadProxyData*>(args));
             DWORD ret=data->start_address_(data->arglist_);
             return ret;
         }


### PR DESCRIPTION
This fixes the issue described in https://svn.boost.org/trac/boost/ticket/11672 ("Should use unique_ptr, not auto_ptr").

EDIT: I forgot to mention: It passes all regression tests. (`fix-auto-ptr/master` also passes all regression tests.)

This PR is against develop. In case you want a PR against master, see https://github.com/BenWiederhake/thread/tree/fix-auto-ptr/master