### PR TITLE
Remove duplicate conditional check.

### DIFF
--- a/src/pthread/thread.cpp
+++ b/src/pthread/thread.cpp
@@ -110,10 +110,7 @@ namespace boost
                                 thread_info->tss_data.erase(current);
                             }
                         }
-                        if (thread_info) // fixme: should we test this?
-                        {
-                          thread_info->self.reset();
-                        }
+                        thread_info->self.reset();
                     }
                 }
             }


### PR DESCRIPTION
thread_info already checked against Null at line no 86, no need to check again.