### PR TITLE
fix increasing memory usage / unjoined threads in .then()

### DIFF
--- a/include/boost/thread/future.hpp
+++ b/include/boost/thread/future.hpp
@@ -4245,6 +4245,8 @@ namespace detail
       } catch(...) {
         this->mark_exceptional_finish();
       }
+      // make sure parent is really cleared to prevent memory "leaks"
+      this->parent = F();
     }
 
     static void run(shared_ptr<boost::detail::shared_state_base> that_)
@@ -4282,6 +4284,8 @@ namespace detail
       } catch(...) {
         this->mark_exceptional_finish();
       }
+      // make sure parent is really cleared to prevent memory "leaks"
+      this->parent = F();
     }
 
     static void run(shared_ptr<boost::detail::shared_state_base> that_)
@@ -4487,6 +4491,8 @@ namespace detail {
       } catch (...) {
         this->mark_exceptional_finish_internal(current_exception(), lck);
       }
+      // make sure parent is really cleared to prevent memory "leaks"
+      this->parent = F();
     }
   };
 
@@ -4523,6 +4529,8 @@ namespace detail {
       } catch (...) {
         this->mark_exceptional_finish_internal(current_exception(), lck);
       }
+      // make sure parent is really cleared to prevent memory "leaks"
+      this->parent = F();
     }
   };
 
@@ -4560,6 +4568,8 @@ namespace detail {
       } catch (...) {
         this->mark_exceptional_finish_internal(current_exception(), lck);
       }
+      // make sure parent is really cleared to prevent memory "leaks"
+      this->parent = F();
     }
   };
 
@@ -4593,6 +4603,8 @@ namespace detail {
       } catch (...) {
         this->mark_exceptional_finish_internal(current_exception(), lck);
       }
+      // make sure parent is really cleared to prevent memory "leaks"
+      this->parent = F();
     }
   };
 


### PR DESCRIPTION
- in a long list of .then().then()...then() calls the most outer future
  kept all parents (including threads) alive; for future<void> and
  launch::async this also leaks the threads as usually you wouldn't call
  wait() on them
- don't keep parent future around after continuation was run
- drop centinel - similar to parent it just keeps the parent state alive;
  889c178173ae27515d216553b5d3e5a610641958 doesn't mention how this
  centinel would fix any problem.