### PR TITLE
Fix leak in tls

### DIFF
--- a/src/pthread/thread.cpp
+++ b/src/pthread/thread.cpp
@@ -126,6 +126,7 @@ namespace boost
                     const boost::once_flag uninitialized = BOOST_ONCE_INIT;
                     if (memcmp(&current_thread_tls_init_flag, &uninitialized, sizeof(boost::once_flag)))
                     {
+                        tls_destructor(pthread_getspecific(current_thread_tls_key));
                         pthread_key_delete(current_thread_tls_key);
                     }
                 }


### PR DESCRIPTION
Hi,

I am experimenting memory leaks with this simple program:

```cpp
#include <boost/thread.hpp>

boost::thread_specific_ptr<int> p;

int main(int argc, char *argv[])
{
  p.reset(new int);
  return 0;
}
```

I compiled boost with gcc 5.3 and the program with clang 3.8, and I linked with boost 1.60 statically. I ran the program through valgrind (clang sanitizer doesn't see all the leaks, I think this is because I didn't compile boost with the sanitizer).

If the code in BOOST_THREAD_PATCH is commented out, I have 6 allocations leaking. If it is enabled, I have only 2. Then with my patch, all boost thread allocations are freed.

May I know why this BOOST_THREAD_PATCH thing exists, and why has it been removed and then restored?

EDIT: I forgot to say that I didn't test this patch on git boost, only on boost 1.60.