### PR TITLE
fix crash in regression tests because of tls

### DIFF
--- a/src/pthread/thread.cpp
+++ b/src/pthread/thread.cpp
@@ -126,7 +126,9 @@ namespace boost
                     const boost::once_flag uninitialized = BOOST_ONCE_INIT;
                     if (memcmp(&current_thread_tls_init_flag, &uninitialized, sizeof(boost::once_flag)))
                     {
-                        tls_destructor(pthread_getspecific(current_thread_tls_key));
+                        boost::detail::thread_data_base* data = (boost::detail::thread_data_base*)pthread_getspecific(current_thread_tls_key);
+                        if (data)
+                          tls_destructor(data);
                         pthread_key_delete(current_thread_tls_key);
                     }
                 }


### PR DESCRIPTION
HI,

Thanks for your answer on #80. This patch seems to fix the regression you found.

Once again, I only tested it on boost 1.61b1 on linux.