### PR TITLE
Fix Windows version problems

### DIFF
--- a/include/boost/thread/win32/thread_primitives.hpp
+++ b/include/boost/thread/win32/thread_primitives.hpp
@@ -16,6 +16,7 @@
 #include <boost/assert.hpp>
 #include <boost/thread/exceptions.hpp>
 #include <boost/detail/interlocked.hpp>
+#include <boost/detail/winapi/config.hpp>
 //#include <boost/detail/winapi/synchronization.hpp>
 #include <algorithm>
 
@@ -156,7 +157,7 @@ namespace boost
             {
                 struct _SECURITY_ATTRIBUTES;
 # ifdef BOOST_NO_ANSI_APIS
-# if defined(BOOST_USE_WINAPI_VERSION) && ( BOOST_USE_WINAPI_VERSION < BOOST_WINAPI_VERSION_VISTA )
+# if BOOST_USE_WINAPI_VERSION < BOOST_WINAPI_VERSION_VISTA
                 __declspec(dllimport) void* __stdcall CreateMutexW(_SECURITY_ATTRIBUTES*,int,wchar_t const*);
                 __declspec(dllimport) void* __stdcall CreateSemaphoreW(_SECURITY_ATTRIBUTES*,long,long,wchar_t const*);
                 __declspec(dllimport) void* __stdcall CreateEventW(_SECURITY_ATTRIBUTES*,int,int,wchar_t const*);
@@ -339,7 +340,7 @@ namespace boost
             {
 #if !defined(BOOST_NO_ANSI_APIS)
                 handle const res = win32::CreateEventA(0, type, state, mutex_name);
-#elif defined(BOOST_USE_WINAPI_VERSION) && ( BOOST_USE_WINAPI_VERSION < BOOST_WINAPI_VERSION_VISTA )
+#elif BOOST_USE_WINAPI_VERSION < BOOST_WINAPI_VERSION_VISTA
                 handle const res = win32::CreateEventW(0, type, state, mutex_name);
 #else
                 handle const res = win32::CreateEventExW(
@@ -366,7 +367,7 @@ namespace boost
 #if !defined(BOOST_NO_ANSI_APIS)
                 handle const res=win32::CreateSemaphoreA(0,initial_count,max_count,0);
 #else
-#if defined(BOOST_USE_WINAPI_VERSION) && ( BOOST_USE_WINAPI_VERSION < BOOST_WINAPI_VERSION_VISTA )
+#if BOOST_USE_WINAPI_VERSION < BOOST_WINAPI_VERSION_VISTA
                 handle const res=win32::CreateSemaphoreEx(0,initial_count,max_count,0,0);
 #else
                 handle const res=win32::CreateSemaphoreExW(0,initial_count,max_count,0,0,semaphore_all_access);

--- a/src/win32/thread.cpp
+++ b/src/win32/thread.cpp
@@ -5,13 +5,6 @@
 // (C) Copyright 2007 David Deakins
 // (C) Copyright 2011-2013 Vicente J. Botet Escriba
 
-#ifndef _WIN32_WINNT
-#define _WIN32_WINNT 0x400
-#endif
-
-#ifndef WINVER
-#define WINVER 0x400
-#endif
 //#define BOOST_THREAD_VERSION 3
 
 #include <boost/thread/thread_only.hpp>
@@ -35,6 +28,7 @@
 #include <stdio.h>
 #include <windows.h>
 #include <boost/predef/platform.h>
+#include <boost/detail/winapi/config.hpp>
 
 #if BOOST_PLAT_WINDOWS_RUNTIME
 #include <mutex>
@@ -530,7 +524,7 @@ namespace boost
     {
       // a bit too strict: Windows XP with SP3 would be sufficient
 #if BOOST_PLAT_WINDOWS_RUNTIME                                    \
-    || ( defined(BOOST_USE_WINAPI_VERSION) && ( BOOST_USE_WINAPI_VERSION <= BOOST_WINAPI_VERSION_WINXP ) ) \
+    || ( BOOST_USE_WINAPI_VERSION <= BOOST_WINAPI_VERSION_WINXP ) \
     || ( ( defined(__MINGW32__) && !defined(__MINGW64__) ) && _WIN32_WINNT < 0x0600)
         return 0;
 #else


### PR DESCRIPTION
- the target Windows version was hardcoded to Windows 95
  in thread.cpp if not already defined
- the include for BOOST_USE_WINAPI_VERSION was missing

Tested with Visual Studio 2015.