### PR TITLE
win32: compile fix for msvc2015

### DIFF
--- a/src/win32/tss_pe.cpp
+++ b/src/win32/tss_pe.cpp
@@ -112,7 +112,7 @@ extern BOOL (WINAPI * const _pDefaultRawDllMainOrig)(HANDLE, DWORD, LPVOID) = NU
 
     //Definitions required by implementation
 
-    #if (_MSC_VER < 1300) // 1300 == VC++ 7.0
+    #if (_MSC_VER < 1300) || (_MSC_VER > 1900) // 1300 == VC++ 7.0, 1900 == VC++ 14.0
         typedef void (__cdecl *_PVFV)();
         #define INIRETSUCCESS
         #define PVAPI void __cdecl


### PR DESCRIPTION
i had to use this patch to compile against msvc2015