### PR TITLE
Add shared_lock_guard to the included lock types

### DIFF
--- a/include/boost/thread/locks.hpp
+++ b/include/boost/thread/locks.hpp
@@ -10,6 +10,7 @@
 #include <boost/thread/lock_algorithms.hpp>
 #include <boost/thread/lock_types.hpp>
 #include <boost/thread/lock_guard.hpp>
+#include <boost/thread/shared_lock_guard.hpp>
 #include <boost/thread/lockable_traits.hpp>
 #include <boost/thread/lock_options.hpp>
 


### PR DESCRIPTION
Currently locks.hpp includes all lock types except shared_lock_guard. This PR adds the missing include.