### PR TITLE
Fixed compilation with MSVC-8.

### DIFF
--- a/build/Jamfile.v2
+++ b/build/Jamfile.v2
@@ -126,6 +126,8 @@ project boost/thread
         <toolset>msvc:<cxxflags>/wd4512
         <toolset>msvc:<cxxflags>/wd6246
 
+        <target-os>windows:<define>WIN32_LEAN_AND_MEAN
+        <target-os>windows:<define>BOOST_USE_WINDOWS_H
 
     # : default-build <threading>multi
     : usage-requirements  # pass these requirement to dependents (i.e. users)

--- a/src/win32/thread.cpp
+++ b/src/win32/thread.cpp
@@ -7,6 +7,7 @@
 
 //#define BOOST_THREAD_VERSION 3
 
+#include <boost/detail/winapi/config.hpp>
 #include <boost/thread/thread_only.hpp>
 #include <boost/thread/once.hpp>
 #include <boost/thread/tss.hpp>
@@ -28,7 +29,6 @@
 #include <stdio.h>
 #include <windows.h>
 #include <boost/predef/platform.h>
-#include <boost/detail/winapi/config.hpp>
 
 #if BOOST_PLAT_WINDOWS_RUNTIME
 #include <mutex>

--- a/src/win32/tss_dll.cpp
+++ b/src/win32/tss_dll.cpp
@@ -3,6 +3,7 @@
 // Boost Software License, Version 1.0. (See accompanying file
 // LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
+#include <boost/detail/winapi/config.hpp>
 #include <boost/thread/detail/config.hpp>
 
 
@@ -10,7 +11,6 @@
 
     #include <boost/thread/detail/tss_hooks.hpp>
 
-    #define WIN32_LEAN_AND_MEAN
     #include <windows.h>
 
     #if defined(__BORLANDC__)

--- a/src/win32/tss_pe.cpp
+++ b/src/win32/tss_pe.cpp
@@ -7,6 +7,7 @@
 // Boost Software License, Version 1.0. (See accompanying file
 // LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
+#include <boost/detail/winapi/config.hpp>
 #include <boost/thread/detail/config.hpp>
 
 #if defined(BOOST_HAS_WINTHREADS) && defined(BOOST_THREAD_BUILD_LIB) 
@@ -77,7 +78,6 @@ extern "C" const IMAGE_TLS_DIRECTORY32 _tls_used __attribute__ ((section(".rdata
 
     #include <stdlib.h>
 
-    #define WIN32_LEAN_AND_MEAN
     #include <windows.h>
 
 


### PR DESCRIPTION
Make sure _WIN32_WINNT is defined when windows.h is included. This is
achieved by (a) making sure boost/detail/winapi/config.hpp is included
before any other headers and (b) BOOST_USE_WINDOWS_H is defined so that
the header defines _WIN32_WINNT based on the default target Windows
version. This ensures that all APIs used by the implementation are
available.

Also extracted WIN32_LEAN_AND_MEAN definition to the Jamfile so that it is
consistently defined for all translation units instead of only tss*.cpp.