### PR TITLE
fix bugs in boost::barrier

### DIFF
--- a/include/boost/thread/barrier.hpp
+++ b/include/boost/thread/barrier.hpp
@@ -145,7 +145,7 @@ namespace boost
         unsigned int count,
         BOOST_THREAD_RV_REF(F) funct,
         typename enable_if<
-        typename is_void<typename result_of<F>::type>::type, dummy*
+        typename is_void<typename result_of<F()>::type>::type, dummy*
         >::type=0
     )
     : m_count(check_counter(count)),
@@ -160,7 +160,7 @@ namespace boost
         unsigned int count,
         F &funct,
         typename enable_if<
-        typename is_void<typename result_of<F>::type>::type, dummy*
+        typename is_void<typename result_of<F()>::type>::type, dummy*
         >::type=0
     )
     : m_count(check_counter(count)),
@@ -176,7 +176,7 @@ namespace boost
         unsigned int count,
         BOOST_THREAD_RV_REF(F) funct,
         typename enable_if<
-        typename is_same<typename result_of<F>::type, unsigned int>::type, dummy*
+        typename is_same<typename result_of<F()>::type, unsigned int>::type, dummy*
         >::type=0
     )
     : m_count(check_counter(count)),
@@ -189,7 +189,7 @@ namespace boost
         unsigned int count,
         F& funct,
         typename enable_if<
-        typename is_same<typename result_of<F>::type, unsigned int>::type, dummy*
+        typename is_same<typename result_of<F()>::type, unsigned int>::type, dummy*
         >::type=0
     )
     : m_count(check_counter(count)),


### PR DESCRIPTION
fixes that `type` in `struct boost::result_of<F>` does not name a type.

This is my test code: http://coliru.stacked-crooked.com/a/617f35360b4e1544