### PR TITLE
fix a mistake in boost::completion_latch

### DIFF
--- a/include/boost/thread/completion_latch.hpp
+++ b/include/boost/thread/completion_latch.hpp
@@ -96,7 +96,6 @@ namespace boost
     leavers_(0)
     {
     }
-    template <typename F>
     completion_latch(std::size_t count, void(*funct)()) :
       count_(count), funct_(funct), waiters_(0), leavers_(0)
     {


### PR DESCRIPTION
The constructor `completion_latch(std::size_t count, void(*funct)())` does not use any template arguments.