### PR TITLE
fix a mistake in sync_timed_queue<>::pull_until()

### DIFF
--- a/include/boost/thread/concurrent_queues/sync_timed_queue.hpp
+++ b/include/boost/thread/concurrent_queues/sync_timed_queue.hpp
@@ -260,7 +260,7 @@ namespace detail
     while (time_not_reached(lk))
     {
       super::throw_if_closed(lk);
-      if (queue_op_status::timeout == super::not_empty_.wait_until(lk, tpmin)) {
+      if (cv_status::timeout == super::not_empty_.wait_until(lk, tpmin)) {
         if (time_not_reached(lk)) return queue_op_status::not_ready;
         return queue_op_status::timeout;
       }


### PR DESCRIPTION
The type of `super::not_empty_` in `sync_timed_queue<>` is `boost::condition_variable`, and the return type of `wait_until()` is `boost::cv_status`.