### PR TITLE
fix boost::synchronized_value<>::load()

### DIFF
--- a/include/boost/thread/synchronized_value.hpp
+++ b/include/boost/thread/synchronized_value.hpp
@@ -827,7 +827,7 @@ namespace boost
      * @effects loads the value type from the input stream @c is.
      */
     template <typename IStream>
-    void load(IStream& is) const
+    void load(IStream& is)
     {
       strict_lock<mutex_type> lk(mtx_);
       is >> value_;
@@ -999,7 +999,7 @@ namespace boost
     return os;
   }
   template <typename IStream, typename T, typename L>
-  inline IStream& operator>>(IStream& is, synchronized_value<T,L> const& rhs)
+  inline IStream& operator>>(IStream& is, synchronized_value<T,L>t& rhs)
   {
     rhs.load(is);
     return is;


### PR DESCRIPTION
The data member `boost::synchronized_value<>::value_` is not mutable, so boost::synchronized_value<>::load() could not be const.