### PR TITLE
fix relational operators of boost::synchronized_value<>

### DIFF
--- a/include/boost/thread/synchronized_value.hpp
+++ b/include/boost/thread/synchronized_value.hpp
@@ -971,22 +971,22 @@ namespace boost
   template <typename T, typename L>
   bool operator<(T const& lhs, synchronized_value<T,L> const&rhs)
   {
-    return rhs>=lhs;
+    return rhs>lhs;
   }
   template <typename T, typename L>
   bool operator<=(T const& lhs, synchronized_value<T,L> const&rhs)
   {
-    return rhs>lhs;
+    return rhs>=lhs;
   }
   template <typename T, typename L>
   bool operator>(T const& lhs, synchronized_value<T,L> const&rhs)
   {
-    return rhs<=lhs;
+    return rhs<lhs;
   }
   template <typename T, typename L>
   bool operator>=(T const& lhs, synchronized_value<T,L> const&rhs)
   {
-    return rhs<lhs;
+    return rhs<=lhs;
   }
 
   /**


### PR DESCRIPTION
fix incorrect relational operators.