### PR TITLE
fix compile failed with boost::user_scheduler

### DIFF
--- a/include/boost/thread/user_scheduler.hpp
+++ b/include/boost/thread/user_scheduler.hpp
@@ -23,7 +23,7 @@ namespace boost
   class user_scheduler
   {
     /// type-erasure to store the works to do
-    typedef  thread_detail::work work;
+    typedef  executors::work work;
 
     /// the thread safe work queue
     sync_queue<work > work_queue;


### PR DESCRIPTION
The `work` is not in namespace `boost::thread_detail` anymore.