### PR TITLE
Fix minor possibility of loosing the notify

### DIFF
--- a/include/boost/thread/pthread/condition_variable.hpp
+++ b/include/boost/thread/pthread/condition_variable.hpp
@@ -73,14 +73,12 @@ namespace boost
 #else
             pthread_mutex_t* the_mutex = m.mutex()->native_handle();
 #endif
-            do {
-              res = pthread_cond_wait(&cond,the_mutex);
-            } while (res == EINTR);
+            res = pthread_cond_wait(&cond,the_mutex);
         }
 #if defined BOOST_THREAD_PROVIDES_INTERRUPTIONS
         this_thread::interruption_point();
 #endif
-        if(res)
+        if(res && res != EINTR)
         {
             boost::throw_exception(condition_error(res, "boost::condition_variable::wait failed in pthread_cond_wait"));
         }


### PR DESCRIPTION

Notification can be send during pthread_cond_wait wakeup from EINTR and the `while (res == EINTR)` will ignore the signal without rechecking the condition:

```
Thread 1                                    Thread 2
---------------------------------------------------------------------------------------
m.lock()
flag=false
m.unlock()
                                            m.lock()
                                            while(!flag)
                                            condition_variable::wait(m)
                                            res = pthread_cond_wait(&cond,the_mutex); // waits
m.lock()                                    // waits
flag=true                                   // waits
m.unlock()                                  // waits
                                            res = pthread_cond_wait(&cond,the_mutex); // # wakes up, does not locks the the_mutex yet
condition_variable::notify_one() // lost
                                            res = pthread_cond_wait(&cond,the_mutex); // #locks the the_mutex, returnes EINTR
                                            } while (res == EINTR);
                                            
                                            res = pthread_cond_wait(&cond,the_mutex); // waits for infinity
```