### PR TITLE
Remove wrong MSVC version check

### DIFF
--- a/src/win32/tss_pe.cpp
+++ b/src/win32/tss_pe.cpp
@@ -112,15 +112,9 @@ extern BOOL (WINAPI * const _pDefaultRawDllMainOrig)(HANDLE, DWORD, LPVOID) = NU
 
     //Definitions required by implementation
 
-    #if (_MSC_VER < 1300) || (_MSC_VER > 2000) // 1300 == VC++ 7.0, 1900 == VC++ 14.0
-        typedef void (__cdecl *_PVFV)();
-        #define INIRETSUCCESS
-        #define PVAPI void __cdecl
-    #else
-        typedef int (__cdecl *_PVFV)();
-        #define INIRETSUCCESS 0
-        #define PVAPI int __cdecl
-    #endif
+    typedef int (__cdecl *_PVFV)();
+    #define INIRETSUCCESS 0
+    #define PVAPI int __cdecl
 
     typedef void (NTAPI* _TLSCB)(HINSTANCE, DWORD, PVOID);
 


### PR DESCRIPTION
There is no compiler with `(_MSC_VER > 2000)` and taking the legacy codepath would probably break compilation again when there is. As `(_MSC_VER < 1300)` (that would be MSVC up to 6.0 from 1998) is not supported by Boost anymore anyway and cannot compile Boost.Thread, this codepath can just be removed completely.