### PR TITLE
Fix sync_bounded_queue<>::size()

### DIFF
--- a/include/boost/thread/concurrent_queues/sync_bounded_queue.hpp
+++ b/include/boost/thread/concurrent_queues/sync_bounded_queue.hpp
@@ -127,7 +127,7 @@ namespace concurrent
     inline size_type size(lock_guard<mutex>& lk) const BOOST_NOEXCEPT
     {
       if (full(lk)) return capacity(lk);
-      return ((out_+capacity(lk)-in_) % capacity(lk));
+      return ((in_+capacity(lk)-out_) % capacity(lk));
     }
 
     inline void throw_if_closed(unique_lock<mutex>&);

--- a/test/sync/mutual_exclusion/sync_bounded_queue/single_thread_pass.cpp
+++ b/test/sync/mutual_exclusion/sync_bounded_queue/single_thread_pass.cpp
@@ -89,12 +89,15 @@ int main()
   }
   {
     // empty queue push rvalue succeeds
-      boost::sync_bounded_queue<int> q(2);
+      boost::sync_bounded_queue<int> q(3);
       q.push(1);
+      BOOST_TEST_EQ(q.size(), 1u);
       q.push(2);
+      BOOST_TEST_EQ(q.size(), 2u);
+      q.push(2);
+      BOOST_TEST_EQ(q.size(), 3u);
       BOOST_TEST(! q.empty());
       BOOST_TEST( q.full());
-      BOOST_TEST_EQ(q.size(), 2u);
       BOOST_TEST(! q.closed());
   }
   {
@@ -317,12 +320,15 @@ int main()
   }
   {
     // empty queue push rvalue succeeds
-      boost::sync_bounded_queue<int> q(2);
+      boost::sync_bounded_queue<int> q(3);
       q.push_back(1);
+      BOOST_TEST_EQ(q.size(), 1u);
       q.push_back(2);
+      BOOST_TEST_EQ(q.size(), 2u);
+      q.push_back(3);
+      BOOST_TEST_EQ(q.size(), 3u);
       BOOST_TEST(! q.empty());
       BOOST_TEST( q.full());
-      BOOST_TEST_EQ(q.size(), 2u);
       BOOST_TEST(! q.closed());
   }
   {


### PR DESCRIPTION
I create a sync_bounded_queue with capacity 10 and then push 1 item into the queue. The size() functions will get 9, but it should be 1.