### PR TITLE
Use BOOST_MAY_ALIAS from Boost.Config.

### DIFF
--- a/include/boost/thread/detail/config.hpp
+++ b/include/boost/thread/detail/config.hpp
@@ -17,16 +17,14 @@
 //#define BOOST_THREAD_DONT_PROVIDE_INTERRUPTIONS
 // ATTRIBUTE_MAY_ALIAS
 
-#if defined(__GNUC__) && !defined(__INTEL_COMPILER)
+#if !defined(BOOST_NO_MAY_ALIAS)
 
-  // GCC since 3.3 has may_alias attribute that helps to alleviate optimizer issues with
-  // regard to violation of the strict aliasing rules.
+  // GCC since 3.3 and some other compilers have may_alias attribute that helps
+  // to alleviate optimizer issues with regard to violation of the strict aliasing rules.
 
   #define BOOST_THREAD_DETAIL_USE_ATTRIBUTE_MAY_ALIAS
-  #define BOOST_THREAD_ATTRIBUTE_MAY_ALIAS __attribute__((__may_alias__))
-#else
-  #define BOOST_THREAD_ATTRIBUTE_MAY_ALIAS
 #endif
+#define BOOST_THREAD_ATTRIBUTE_MAY_ALIAS BOOST_MAY_ALIAS
 
 
 #if defined BOOST_THREAD_THROW_IF_PRECONDITION_NOT_SATISFIED


### PR DESCRIPTION
Boost.Config adds support for more compilers that provide the may_alias attribute.