### PR TITLE
Fix sleep_until() to use a realtime clock

### DIFF
--- a/src/pthread/thread.cpp
+++ b/src/pthread/thread.cpp
@@ -459,7 +459,7 @@ namespace boost
 
           void BOOST_THREAD_DECL sleep_until(const timespec& ts)
           {
-                timespec now = boost::detail::timespec_now();
+                timespec now = boost::detail::timespec_now_realtime();
                 if (boost::detail::timespec_gt(ts, now))
                 {
                   for (int foo=0; foo < 5; ++foo)
@@ -479,7 +479,7 @@ namespace boost
                     condition_variable cond;
                     cond.do_wait_until(lock, ts);
     #   endif
-                    timespec now2 = boost::detail::timespec_now();
+                    timespec now2 = boost::detail::timespec_now_realtime();
                     if (boost::detail::timespec_ge(now2, ts))
                     {
                       return;


### PR DESCRIPTION
boost::this_thread::no_interruption_point::hidden::sleep_until() takes an absolute time as a parameter and converts it to a duration for the length of time to sleep.  But the current time that the absolute time is compared against came from timespec_now(), which, on Linux at least, uses CLOCK_MONOTONIC, which "represents monotonic time since some unspecified starting point."  Since timespec_now() may have a different starting point than the time that was passed to sleep_until(), that can result in sleep_until() sleeping for an *extremely* long time, causing the program to appear to hang.

Change sleep_until() to get the current time from timespec_now_realtime(), which uses CLOCK_REALTIME, which has the same epoch as the time that is passed to sleep_until().