### PR TITLE
Do not include same header twice

### DIFF
--- a/include/boost/thread/pthread/shared_mutex.hpp
+++ b/include/boost/thread/pthread/shared_mutex.hpp
@@ -20,7 +20,6 @@
 #include <boost/chrono/ceil.hpp>
 #endif
 #include <boost/thread/detail/delete.hpp>
-#include <boost/assert.hpp>
 
 #include <boost/config/abi_prefix.hpp>
 


### PR DESCRIPTION
Remove <boost/assert.hpp>, since this header was included twice.
File: include/boost/thread/pthread/shared_mutex.hpp