### PR TITLE
Fix Issues with BOOST_THREAD_HAS_CONDATTR_SET_CLOCK_MONOTONIC

### DIFF
--- a/include/boost/thread/detail/thread.hpp
+++ b/include/boost/thread/detail/thread.hpp
@@ -155,15 +155,6 @@ namespace boost
         };
 #endif
     }
-namespace thread_detail {
-#ifdef BOOST_THREAD_USES_CHRONO
-#if defined(BOOST_THREAD_HAS_CONDATTR_SET_CLOCK_MONOTONIC) || defined(BOOST_THREAD_PLATFORM_WIN32)
-        typedef chrono::steady_clock internal_clock_t;
-#else
-        typedef chrono::system_clock internal_clock_t;
-#endif
-#endif
-}
     class BOOST_THREAD_DECL thread
     {
     public:
@@ -487,19 +478,9 @@ namespace thread_detail {
         template <class Rep, class Period>
         bool try_join_for(const chrono::duration<Rep, Period>& rel_time)
         {
-          return try_join_until(thread_detail::internal_clock_t::now() + rel_time);
+          return do_try_join_until(boost::detail::to_abs_internal_timespec(rel_time));
         }
 #endif
-
-        template <class Clock, class Duration>
-        bool try_join_until(const chrono::time_point<Clock, Duration>& t)
-        {
-          using namespace chrono;
-          thread_detail::internal_clock_t::time_point     s_now = thread_detail::internal_clock_t::now();
-          typename Clock::duration   d = ceil<nanoseconds>(t-Clock::now());
-          if (d <= Clock::duration::zero()) return false; // in case the Clock::time_point t is already reached
-          return try_join_until(s_now + d);
-        }
 #endif
 #if defined(BOOST_THREAD_PLATFORM_WIN32)
     private:
@@ -512,10 +493,10 @@ namespace thread_detail {
         //}
 
 #ifdef BOOST_THREAD_USES_CHRONO
-        template <class Duration>
-        bool try_join_until(const chrono::time_point<thread_detail::internal_clock_t, Duration>& tp)
+        template <class Clock, class Duration>
+        bool try_join_until(const chrono::time_point<Clock, Duration>& tp)
         {
-          chrono::milliseconds rel_time= chrono::ceil<chrono::milliseconds>(tp-thread_detail::internal_clock_t::now());
+          chrono::milliseconds rel_time= chrono::ceil<chrono::milliseconds>(tp-Clock::now());
           return do_try_join_until(rel_time.count());
         }
 #endif
@@ -529,14 +510,14 @@ namespace thread_detail {
 #if defined BOOST_THREAD_USES_DATETIME
         bool timed_join(const system_time& abs_time)
         {
-          return do_try_join_until(detail::timespec_to_internal_clock(abs_time));
+          return do_try_join_until(boost::detail::to_abs_internal_timespec(abs_time));
         }
 #endif
 #ifdef BOOST_THREAD_USES_CHRONO
-        template <class Duration>
-        bool try_join_until(const chrono::time_point<thread_detail::internal_clock_t, Duration>& tp)
+        template <class Clock, class Duration>
+        bool try_join_until(const chrono::time_point<Clock, Duration>& tp)
         {
-          return do_try_join_until(boost::detail::to_timespec(tp.time_since_epoch()));
+          return do_try_join_until(boost::detail::to_abs_internal_timespec(tp));
         }
 #endif
 
@@ -547,7 +528,7 @@ namespace thread_detail {
         template<typename TimeDuration>
         inline bool timed_join(TimeDuration const& rel_time)
         {
-            return do_try_join_until(detail::timespec_plus_internal_clock(rel_time));
+            return timed_join(get_system_time()+rel_time);
         }
 #endif
         void detach();

--- a/include/boost/thread/pthread/condition_variable.hpp
+++ b/include/boost/thread/pthread/condition_variable.hpp
@@ -169,14 +169,6 @@ namespace boost
         pthread_mutex_t internal_mutex;
         pthread_cond_t cond;
 
-#ifdef BOOST_THREAD_USES_CHRONO
-#ifdef BOOST_THREAD_HAS_CONDATTR_SET_CLOCK_MONOTONIC
-        typedef chrono::steady_clock internal_clock_t;
-#else
-        typedef chrono::system_clock internal_clock_t;
-#endif
-#endif
-
     public:
         BOOST_THREAD_NO_COPYABLE(condition_variable_any)
         condition_variable_any()
@@ -186,11 +178,11 @@ namespace boost
             {
                 boost::throw_exception(thread_resource_error(res, "boost::condition_variable_any::condition_variable_any() failed in pthread_mutex_init"));
             }
-            int const res2 = detail::monotonic_pthread_cond_init(cond);
+            int const res2=boost::detail::cond_init(cond);
             if(res2)
             {
                 BOOST_VERIFY(!pthread_mutex_destroy(&internal_mutex));
-                boost::throw_exception(thread_resource_error(res2, "boost::condition_variable_any::condition_variable_any() failed in detail::monotonic_pthread_cond_init"));
+                boost::throw_exception(thread_resource_error(res2, "boost::condition_variable_any::condition_variable_any() failed in boost::detail::cond_init"));
             }
         }
         ~condition_variable_any()
@@ -234,7 +226,7 @@ namespace boost
         template<typename lock_type>
         bool timed_wait(lock_type& m,boost::system_time const& abs_time)
         {
-            return do_wait_until(m,detail::timespec_to_internal_clock(abs_time));
+            return do_wait_until(m,boost::detail::to_abs_internal_timespec(abs_time));
         }
         template<typename lock_type>
         bool timed_wait(lock_type& m,xtime const& abs_time)
@@ -254,13 +246,13 @@ namespace boost
             {
                 return true;
             }
-            return do_wait_until(m,detail::timespec_plus_internal_clock(wait_duration));
+            return do_wait_until(m,boost::detail::to_abs_internal_timespec(wait_duration));
         }
 
         template<typename lock_type,typename predicate_type>
         bool timed_wait(lock_type& m,boost::system_time const& abs_time, predicate_type pred)
         {
-            return do_wait_until(m,detail::timespec_to_internal_clock(abs_time),pred);
+            return do_wait_until(m,boost::detail::to_abs_internal_timespec(abs_time),pred);
         }
 
         template<typename lock_type,typename predicate_type>
@@ -284,31 +276,19 @@ namespace boost
             {
                 return pred();
             }
-            return do_wait_until(m,detail::timespec_plus_internal_clock(wait_duration),pred);
+            return do_wait_until(m,boost::detail::to_abs_internal_timespec(wait_duration),pred);
         }
 #endif // defined BOOST_THREAD_USES_DATETIME
 
 #ifdef BOOST_THREAD_USES_CHRONO
-        template <class lock_type,class Duration>
-        cv_status
-        wait_until(
-                lock_type& lock,
-                const chrono::time_point<internal_clock_t, Duration>& t)
-        {
-          return do_wait_until(lock, boost::detail::to_timespec(t.time_since_epoch()))
-            ? cv_status::no_timeout : cv_status::timeout;
-        }
-
         template <class lock_type, class Clock, class Duration>
         cv_status
         wait_until(
                 lock_type& lock,
                 const chrono::time_point<Clock, Duration>& t)
         {
-          using namespace chrono;
-          internal_clock_t::time_point s_now = internal_clock_t::now();
-          typename Clock::time_point  c_now = Clock::now();
-          return wait_until(lock, s_now + ceil<nanoseconds>(t - c_now));
+          return do_wait_until(lock, boost::detail::to_abs_internal_timespec(t))
+            ? cv_status::no_timeout : cv_status::timeout;
         }
 
         template <class lock_type, class Rep, class Period>
@@ -317,17 +297,8 @@ namespace boost
                 lock_type& lock,
                 const chrono::duration<Rep, Period>& d)
         {
-          return wait_until(lock, internal_clock_t::now() + d);
-        }
-
-        template <class lock_type, class Duration, class Predicate>
-        bool
-        wait_until(
-                lock_type& lock,
-                const chrono::time_point<internal_clock_t, Duration>& t,
-                Predicate pred)
-        {
-            return do_wait_until(lock, boost::detail::to_timespec(t.time_since_epoch()), boost::move(pred));
+          return do_wait_until(lock, boost::detail::to_abs_internal_timespec(d))
+            ? cv_status::no_timeout : cv_status::timeout;
         }
 
         template <class lock_type, class Clock, class Duration, class Predicate>
@@ -337,10 +308,7 @@ namespace boost
                 const chrono::time_point<Clock, Duration>& t,
                 Predicate pred)
         {
-            using namespace chrono;
-            internal_clock_t::time_point s_now = internal_clock_t::now();
-            typename Clock::time_point  c_now = Clock::now();
-            return wait_until(lock, s_now + ceil<nanoseconds>(t - c_now), boost::move(pred));
+          return do_wait_until(lock, boost::detail::to_abs_internal_timespec(t), boost::move(pred));
         }
 
         template <class lock_type, class Rep, class Period, class Predicate>
@@ -350,7 +318,7 @@ namespace boost
                 const chrono::duration<Rep, Period>& d,
                 Predicate pred)
         {
-          return wait_until(lock, internal_clock_t::now() + d, boost::move(pred));
+          return do_wait_until(lock, boost::detail::to_abs_internal_timespec(d), boost::move(pred));
         }
 #endif // defined BOOST_THREAD_USES_CHRONO
 

--- a/include/boost/thread/pthread/condition_variable_fwd.hpp
+++ b/include/boost/thread/pthread/condition_variable_fwd.hpp
@@ -29,27 +29,6 @@
 
 namespace boost
 {
-  namespace detail {
-    inline int monotonic_pthread_cond_init(pthread_cond_t& cond) {
-
-#ifdef BOOST_THREAD_HAS_CONDATTR_SET_CLOCK_MONOTONIC
-            pthread_condattr_t attr;
-            int res = pthread_condattr_init(&attr);
-            if (res)
-            {
-              return res;
-            }
-            pthread_condattr_setclock(&attr, CLOCK_MONOTONIC);
-            res=pthread_cond_init(&cond,&attr);
-            pthread_condattr_destroy(&attr);
-            return res;
-#else
-            return pthread_cond_init(&cond,NULL);
-#endif
-
-    }
-  }
-
     class condition_variable
     {
     private:
@@ -57,14 +36,6 @@ namespace boost
         pthread_mutex_t internal_mutex;
 //#endif
         pthread_cond_t cond;
-
-#ifdef BOOST_THREAD_USES_CHRONO
-#ifdef BOOST_THREAD_HAS_CONDATTR_SET_CLOCK_MONOTONIC
-        typedef chrono::steady_clock internal_clock_t;
-#else
-        typedef chrono::system_clock internal_clock_t;
-#endif
-#endif
 
     public:
     //private: // used by boost::thread::try_join_until
@@ -95,14 +66,14 @@ namespace boost
                 boost::throw_exception(thread_resource_error(res, "boost::condition_variable::condition_variable() constructor failed in pthread_mutex_init"));
             }
 //#endif
-            res = detail::monotonic_pthread_cond_init(cond);
+            res=boost::detail::cond_init(cond);
             if (res)
             {
 //#if defined BOOST_THREAD_PROVIDES_INTERRUPTIONS
                 // ditto
                 BOOST_VERIFY(!pthread_mutex_destroy(&internal_mutex));
 //#endif
-                boost::throw_exception(thread_resource_error(res, "boost::condition_variable::condition_variable() constructor failed in detail::monotonic_pthread_cond_init"));
+                boost::throw_exception(thread_resource_error(res, "boost::condition_variable::condition_variable() constructor failed in boost::detail::cond_init"));
             }
         }
         ~condition_variable()
@@ -135,9 +106,9 @@ namespace boost
             boost::system_time const& abs_time)
         {
 #if defined BOOST_THREAD_WAIT_BUG
-            return do_wait_until(m,detail::timespec_to_internal_clock(abs_time + BOOST_THREAD_WAIT_BUG));
+            return do_wait_until(m,boost::detail::to_abs_internal_timespec(abs_time + BOOST_THREAD_WAIT_BUG));
 #else
-            return do_wait_until(m,detail::timespec_to_internal_clock(abs_time));
+            return do_wait_until(m,boost::detail::to_abs_internal_timespec(abs_time));
 #endif
         }
         bool timed_wait(
@@ -161,7 +132,7 @@ namespace boost
             {
                 return true;
             }
-            return do_wait_until(m,detail::timespec_plus_internal_clock(wait_duration));
+            return do_wait_until(m,boost::detail::to_abs_internal_timespec(wait_duration));
         }
 
         template<typename predicate_type>
@@ -169,7 +140,7 @@ namespace boost
             unique_lock<mutex>& m,
             boost::system_time const& abs_time,predicate_type pred)
         {
-            return do_wait_until(m,detail::timespec_to_internal_clock(abs_time),pred);
+            return do_wait_until(m,boost::detail::to_abs_internal_timespec(abs_time),pred);
         }
 
         template<typename predicate_type>
@@ -197,21 +168,11 @@ namespace boost
             {
                 return pred();
             }
-            return do_wait_until(m,detail::timespec_plus_internal_clock(wait_duration),pred);
+            return do_wait_until(m,boost::detail::to_abs_internal_timespec(wait_duration),pred);
         }
 #endif // defined BOOST_THREAD_USES_DATETIME
 
 #ifdef BOOST_THREAD_USES_CHRONO
-
-        template <class Duration>
-        cv_status
-        wait_until(
-                unique_lock<mutex>& lock,
-                const chrono::time_point<internal_clock_t, Duration>& t)
-        {
-          return do_wait_until(lock, boost::detail::to_timespec(t.time_since_epoch()))
-            ? cv_status::no_timeout : cv_status::timeout;
-        }
 
         template <class Clock, class Duration>
         cv_status
@@ -219,13 +180,9 @@ namespace boost
                 unique_lock<mutex>& lock,
                 const chrono::time_point<Clock, Duration>& t)
         {
-          using namespace chrono;
-          internal_clock_t::time_point s_now = internal_clock_t::now();
-          typename Clock::time_point  c_now = Clock::now();
-          return wait_until(lock, s_now + ceil<nanoseconds>(t - c_now));
+          return do_wait_until(lock, boost::detail::to_abs_internal_timespec(t))
+            ? cv_status::no_timeout : cv_status::timeout;
         }
-
-
 
         template <class Rep, class Period>
         cv_status
@@ -233,17 +190,8 @@ namespace boost
                 unique_lock<mutex>& lock,
                 const chrono::duration<Rep, Period>& d)
         {
-          return wait_until(lock, internal_clock_t::now() + d);
-        }
-
-        template <class Duration, class Predicate>
-        bool
-        wait_until(
-                unique_lock<mutex>& lock,
-                const chrono::time_point<internal_clock_t, Duration>& t,
-                Predicate pred)
-        {
-            return do_wait_until(lock, boost::detail::to_timespec(t.time_since_epoch()), boost::move(pred));
+          return do_wait_until(lock, boost::detail::to_abs_internal_timespec(d))
+            ? cv_status::no_timeout : cv_status::timeout;
         }
 
         template <class Clock, class Duration, class Predicate>
@@ -253,10 +201,7 @@ namespace boost
                 const chrono::time_point<Clock, Duration>& t,
                 Predicate pred)
         {
-            using namespace chrono;
-            internal_clock_t::time_point s_now = internal_clock_t::now();
-            typename Clock::time_point  c_now = Clock::now();
-            return wait_until(lock, s_now + ceil<nanoseconds>(t - c_now), boost::move(pred));
+          return do_wait_until(lock, boost::detail::to_abs_internal_timespec(t), boost::move(pred));
         }
 
         template <class Rep, class Period, class Predicate>
@@ -266,7 +211,7 @@ namespace boost
                 const chrono::duration<Rep, Period>& d,
                 Predicate pred)
         {
-          return wait_until(lock, internal_clock_t::now() + d, boost::move(pred));
+          return do_wait_until(lock, boost::detail::to_abs_internal_timespec(d), boost::move(pred));
         }
 #endif // defined BOOST_THREAD_USES_CHRONO
 

--- a/include/boost/thread/pthread/mutex.hpp
+++ b/include/boost/thread/pthread/mutex.hpp
@@ -36,12 +36,13 @@
 #endif
 #endif
 
-// CLOCK_MONOTONIC only works with pthread_cond_timedwait(), not with pthread_mutex_timedlock()
-#ifdef BOOST_THREAD_HAS_CONDATTR_SET_CLOCK_MONOTONIC
-#undef BOOST_PTHREAD_HAS_TIMEDLOCK
-#endif
 
 #include <boost/config/abi_prefix.hpp>
+
+// CLOCK_MONOTONIC only works with pthread_cond_timedwait(), not with pthread_mutex_timedlock()
+#if defined(BOOST_PTHREAD_HAS_TIMEDLOCK) && !defined(BOOST_THREAD_HAS_CONDATTR_SET_CLOCK_MONOTONIC)
+#define BOOST_PTHREAD_HAS_TIMEDLOCK_LOCAL
+#endif
 
 #ifndef BOOST_THREAD_HAS_NO_EINTR_BUG
 #define BOOST_THREAD_HAS_EINTR_BUG
@@ -171,19 +172,10 @@ namespace boost
     {
     private:
         pthread_mutex_t m;
-#ifndef BOOST_PTHREAD_HAS_TIMEDLOCK
+#ifndef BOOST_PTHREAD_HAS_TIMEDLOCK_LOCAL
         pthread_cond_t cond;
         bool is_locked;
 #endif
-
-#ifdef BOOST_THREAD_USES_CHRONO
-#ifdef BOOST_THREAD_HAS_CONDATTR_SET_CLOCK_MONOTONIC
-        typedef chrono::steady_clock internal_clock_t;
-#else
-        typedef chrono::system_clock internal_clock_t;
-#endif
-#endif
-
     public:
         BOOST_THREAD_NO_COPYABLE(timed_mutex)
         timed_mutex()
@@ -193,32 +185,21 @@ namespace boost
             {
                 boost::throw_exception(thread_resource_error(res, "boost:: timed_mutex constructor failed in pthread_mutex_init"));
             }
-#ifndef BOOST_PTHREAD_HAS_TIMEDLOCK
-#ifdef BOOST_THREAD_HAS_CONDATTR_SET_CLOCK_MONOTONIC
-            pthread_condattr_t attr;
-            int res2=pthread_condattr_init(&attr);
-            if (!res2)
-            {
-                pthread_condattr_setclock(&attr, CLOCK_MONOTONIC);
-                res2=pthread_cond_init(&cond,&attr);
-                pthread_condattr_destroy(&attr);
-            }
-#else
-            int const res2=pthread_cond_init(&cond,NULL);
-#endif
+#ifndef BOOST_PTHREAD_HAS_TIMEDLOCK_LOCAL
+            int const res2=boost::detail::cond_init(cond);
             if(res2)
             {
                 BOOST_VERIFY(!posix::pthread_mutex_destroy(&m));
                 //BOOST_VERIFY(!pthread_mutex_destroy(&m));
-                boost::throw_exception(thread_resource_error(res2, "boost:: timed_mutex constructor failed in pthread_cond_init"));
+                boost::throw_exception(thread_resource_error(res2, "boost:: timed_mutex constructor failed in boost::detail::cond_init"));
             }
             is_locked=false;
-#endif // !defined BOOST_PTHREAD_HAS_TIMEDLOCK
+#endif // !defined BOOST_PTHREAD_HAS_TIMEDLOCK_LOCAL
         }
         ~timed_mutex()
         {
             BOOST_VERIFY(!posix::pthread_mutex_destroy(&m));
-#ifndef BOOST_PTHREAD_HAS_TIMEDLOCK
+#ifndef BOOST_PTHREAD_HAS_TIMEDLOCK_LOCAL
             BOOST_VERIFY(!pthread_cond_destroy(&cond));
 #endif
         }
@@ -227,14 +208,14 @@ namespace boost
         template<typename TimeDuration>
         bool timed_lock(TimeDuration const & relative_time)
         {
-            return do_try_lock_until(boost::detail::timespec_plus_internal_clock(relative_time));
+            return do_try_lock_until(boost::detail::to_abs_internal_timespec(relative_time));
         }
         bool timed_lock(boost::xtime const & absolute_time)
         {
             return timed_lock(system_time(absolute_time));
         }
 #endif
-#ifdef BOOST_PTHREAD_HAS_TIMEDLOCK
+#ifdef BOOST_PTHREAD_HAS_TIMEDLOCK_LOCAL
         void lock()
         {
             int res = posix::pthread_mutex_lock(&m);
@@ -280,7 +261,7 @@ namespace boost
         }
     public:
 
-#else // !defined BOOST_PTHREAD_HAS_TIMEDLOCK
+#else // !defined BOOST_PTHREAD_HAS_TIMEDLOCK_LOCAL
         void lock()
         {
             boost::pthread::pthread_mutex_scoped_lock const local_lock(&m);
@@ -326,32 +307,24 @@ namespace boost
             return true;
         }
     public:
-#endif // !defined BOOST_PTHREAD_HAS_TIMEDLOCK
+#endif // !defined BOOST_PTHREAD_HAS_TIMEDLOCK_LOCAL
 
 #if defined BOOST_THREAD_USES_DATETIME
         bool timed_lock(system_time const & abs_time)
         {
-            return do_try_lock_until(boost::detail::timespec_to_internal_clock(abs_time));
+            return do_try_lock_until(boost::detail::to_abs_internal_timespec(abs_time));
         }
 #endif
 #ifdef BOOST_THREAD_USES_CHRONO
         template <class Rep, class Period>
         bool try_lock_for(const chrono::duration<Rep, Period>& rel_time)
         {
-          return try_lock_until(internal_clock_t::now() + rel_time);
+          return do_try_lock_until(boost::detail::to_abs_internal_timespec(rel_time));
         }
         template <class Clock, class Duration>
         bool try_lock_until(const chrono::time_point<Clock, Duration>& t)
         {
-          using namespace chrono;
-          internal_clock_t::time_point s_now = internal_clock_t::now();
-          typename Clock::time_point  c_now = Clock::now();
-          return try_lock_until(s_now + ceil<nanoseconds>(t - c_now));
-        }
-        template <class Duration>
-        bool try_lock_until(const chrono::time_point<internal_clock_t, Duration>& t)
-        {
-          return do_try_lock_until(boost::detail::to_timespec(t.time_since_epoch()));
+          return do_try_lock_until(boost::detail::to_abs_internal_timespec(t));
         }
 #endif // defined BOOST_THREAD_USES_CHRONO
 
@@ -370,6 +343,8 @@ namespace boost
     };
 
 }
+
+#undef BOOST_PTHREAD_HAS_TIMEDLOCK_LOCAL
 
 #include <boost/config/abi_suffix.hpp>
 

--- a/include/boost/thread/pthread/thread_data.hpp
+++ b/include/boost/thread/pthread/thread_data.hpp
@@ -292,13 +292,13 @@ namespace boost
 #endif
         inline void sleep(system_time const& abs_time)
         {
-          return boost::this_thread::hidden::sleep_until_realtime(boost::detail::to_timespec(abs_time));
+          boost::this_thread::hidden::sleep_until_realtime(boost::detail::to_timespec(abs_time));
         }
 
         template<typename TimeDuration>
         inline BOOST_SYMBOL_VISIBLE void sleep(TimeDuration const& rel_time)
         {
-            this_thread::sleep(get_system_time()+rel_time);
+          boost::this_thread::hidden::sleep_for(boost::detail::to_timespec(rel_time));
         }
 #endif // BOOST_THREAD_USES_DATETIME
     } // this_thread

--- a/src/pthread/thread.cpp
+++ b/src/pthread/thread.cpp
@@ -449,7 +449,7 @@ namespace boost
                   //  an absolute time.
                   nanosleep(&ts, 0);
     #   else
-                  const timespec ts2 = boost::detail::timespec_plus_internal_clock(ts);
+                  const timespec ts2 = boost::detail::duration_to_abs_internal_timespec(ts);
                   mutex mx;
                   unique_lock<mutex> lock(mx);
                   condition_variable cond;
@@ -483,7 +483,7 @@ namespace boost
                     }
                   }
     # else
-                  const timespec ts2 = boost::detail::timespec_to_internal_clock(ts);
+                  const timespec ts2 = boost::detail::real_to_abs_internal_timespec(ts);
                   mutex mx;
                   unique_lock<mutex> lock(mx);
                   condition_variable cond;
@@ -501,7 +501,7 @@ namespace boost
 
             if(thread_info)
             {
-              const timespec ts2 = boost::detail::timespec_plus_internal_clock(ts);
+              const timespec ts2 = boost::detail::duration_to_abs_internal_timespec(ts);
               unique_lock<mutex> lk(thread_info->sleep_mutex);
               while(thread_info->sleep_condition.do_wait_until(lk,ts2)) {}
             }
@@ -517,7 +517,7 @@ namespace boost
 
             if(thread_info)
             {
-              const timespec ts2 = boost::detail::timespec_to_internal_clock(ts);
+              const timespec ts2 = boost::detail::real_to_abs_internal_timespec(ts);
               unique_lock<mutex> lk(thread_info->sleep_mutex);
               while(thread_info->sleep_condition.do_wait_until(lk,ts2)) {}
             }


### PR DESCRIPTION
* Fixed https://svn.boost.org/trac10/ticket/12727 (maybe - not tested)
* Fixed the following functions in the pthread implementation to behave correctly when BOOST_THREAD_HAS_CONDATTR_SET_CLOCK_MONOTONIC is enabled and the system time changes:
    * boost::this_thread::sleep_until() with a system clock time
    * boost::thread::try_join_until() with a system clock time
    * boost::condition_variable::wait_until() with a system clock time and predicate
    * boost::condition_variable_any::wait_until() with a system clock time and predicate
    * boost::shared_mutex::try_lock_until() with a system clock time
    * boost::upgrade_mutex::try_lock_until() with a system clock time
    * boost::timed_mutex::try_lock_for()
    * boost::timed_mutex::try_lock_until()
    * boost::recursive_timed_mutex::try_lock_for()
    * boost::recursive_timed_mutex::try_lock_until()
* Fixed the following deprecated functions in the pthread implementation to behave correctly (some would hang) when BOOST_THREAD_HAS_CONDATTR_SET_CLOCK_MONOTONIC is enabled:
    * boost::this_thread::sleep()
    * boost::thread::timed_join()
    * boost::condition_variable::timed_wait()
    * boost::condition_variable_any::timed_wait()
    * boost::shared_mutex::timed_lock()
    * boost::upgrade_mutex::timed_lock()
    * boost::timed_mutex::timed_lock()
    * boost::recursive_timed_mutex::timed_lock()
* Fixed boost::condition_variable_any::timed_wait() in the pthread implementation to correctly handle is_pos_infinity() and is_special() durations.