### PR TITLE
Change _pRawDllMain and related types to use HINSTANCE instead of HANDLE

### DIFF
--- a/include/boost/thread/win32/mfc_thread_init.hpp
+++ b/include/boost/thread/win32/mfc_thread_init.hpp
@@ -27,12 +27,12 @@ inline BOOL WINAPI ExtRawDllMain(HINSTANCE, DWORD dwReason, LPVOID)
   return TRUE; // ok
 }
 
-extern "C" __declspec(selectany) BOOL (WINAPI * const _pRawDllMainOrig)(HANDLE, DWORD, LPVOID) = &ExtRawDllMain;
+extern "C" __declspec(selectany) BOOL (WINAPI * const _pRawDllMainOrig)(HINSTANCE, DWORD, LPVOID) = &ExtRawDllMain;
 
 # elif defined(_USRDLL)
 
-extern "C" BOOL WINAPI RawDllMain(HANDLE, DWORD dwReason, LPVOID);
-extern "C" __declspec(selectany) BOOL (WINAPI * const _pRawDllMainOrig)(HANDLE, DWORD, LPVOID) = &RawDllMain;
+extern "C" BOOL WINAPI RawDllMain(HINSTANCE, DWORD dwReason, LPVOID);
+extern "C" __declspec(selectany) BOOL (WINAPI * const _pRawDllMainOrig)(HINSTANCE, DWORD, LPVOID) = &RawDllMain;
 
 # endif
 #endif

--- a/src/win32/tss_pe.cpp
+++ b/src/win32/tss_pe.cpp
@@ -94,8 +94,8 @@ extern "C" const IMAGE_TLS_DIRECTORY32 _tls_used __attribute__ ((section(".rdata
 #if (_MSC_VER >= 1500)
 
 extern "C" {
-extern BOOL (WINAPI * const _pRawDllMainOrig)(HANDLE, DWORD, LPVOID);
-extern BOOL (WINAPI * const _pDefaultRawDllMainOrig)(HANDLE, DWORD, LPVOID) = NULL;
+extern BOOL (WINAPI * const _pRawDllMainOrig)(HINSTANCE, DWORD, LPVOID);
+extern BOOL (WINAPI * const _pDefaultRawDllMainOrig)(HINSTANCE, DWORD, LPVOID) = NULL;
 #if defined (_M_IX86)
 #pragma comment(linker, "/alternatename:__pRawDllMainOrig=__pDefaultRawDllMainOrig")
 #elif defined (_M_X64) || defined (_M_ARM)
@@ -283,9 +283,9 @@ extern BOOL (WINAPI * const _pDefaultRawDllMainOrig)(HANDLE, DWORD, LPVOID) = NU
         }
 
 #if (_MSC_VER >= 1500)
-        BOOL WINAPI dll_callback(HANDLE hInstance, DWORD dwReason, LPVOID lpReserved)
+        BOOL WINAPI dll_callback(HINSTANCE hInstance, DWORD dwReason, LPVOID lpReserved)
 #else
-        BOOL WINAPI dll_callback(HANDLE, DWORD dwReason, LPVOID)
+        BOOL WINAPI dll_callback(HINSTANCE, DWORD dwReason, LPVOID)
 #endif
         {
             switch (dwReason)
@@ -310,7 +310,7 @@ extern BOOL (WINAPI * const _pDefaultRawDllMainOrig)(HANDLE, DWORD, LPVOID) = NU
 
 extern "C"
 {
-    extern BOOL (WINAPI * const _pRawDllMain)(HANDLE, DWORD, LPVOID)=&dll_callback;
+    extern BOOL (WINAPI * const _pRawDllMain)(HINSTANCE, DWORD, LPVOID)=&dll_callback;
 }
 namespace boost
 {


### PR DESCRIPTION
In MSVC-9 MFC sources, _pRawDllMain and ExtRawDllMain accept HINSTANCE as
the first argument, not HANDLE. In strict mode these are different types,
which creates the potential for ODR errors. This commit resolves that
inconsistency.

Resolves https://svn.boost.org/trac10/ticket/12323.
