### PR TITLE
Updates to fix interruption-point inconsistencies.

### DIFF
--- a/include/boost/thread/v2/thread.hpp
+++ b/include/boost/thread/v2/thread.hpp
@@ -23,33 +23,6 @@ namespace boost
     {
 #ifdef BOOST_THREAD_USES_CHRONO
 
-#if !defined BOOST_THREAD_SLEEP_FOR_IS_STEADY
-    template <class Duration>
-    void sleep_until(const chrono::time_point<thread_detail::internal_clock_t, Duration>& t)
-    {
-      using namespace chrono;
-      mutex mut;
-      condition_variable cv;
-      unique_lock<mutex> lk(mut);
-      while (thread_detail::internal_clock_t::now() < t)
-      {
-        cv.wait_until(lk, t);
-      }
-    }
-    template <class Clock, class Duration>
-    void sleep_until(const chrono::time_point<Clock, Duration>& t)
-    {
-      using namespace chrono;
-      Duration d = t - Clock::now();
-      while (d > Duration::zero())
-      {
-        Duration d100 = (std::min)(d, Duration(milliseconds(100)));
-        sleep_until(thread_detail::internal_clock_t::now() + ceil<nanoseconds>(d100));
-        d = t - Clock::now();
-      }
-    }
-#endif
-
 // Use pthread_delay_np or nanosleep whenever possible here in the no_interruption_point
 // namespace because they do not provide an interruption point.
 #if defined BOOST_THREAD_SLEEP_FOR_IS_STEADY
@@ -96,6 +69,7 @@ namespace boost
     }
 
 #else
+
     template <class Rep, class Period>
     void sleep_for(const chrono::duration<Rep, Period>& d)
     {
@@ -103,6 +77,32 @@ namespace boost
       if (d > duration<Rep, Period>::zero())
       {
         sleep_until(steady_clock::now() + d);
+      }
+    }
+
+    template <class Duration>
+    void sleep_until(const chrono::time_point<thread_detail::internal_clock_t, Duration>& t)
+    {
+      using namespace chrono;
+      mutex mut;
+      condition_variable cv;
+      unique_lock<mutex> lk(mut);
+      while (thread_detail::internal_clock_t::now() < t)
+      {
+        cv.wait_until(lk, t);
+      }
+    }
+
+    template <class Clock, class Duration>
+    void sleep_until(const chrono::time_point<Clock, Duration>& t)
+    {
+      using namespace chrono;
+      Duration d = t - Clock::now();
+      while (d > Duration::zero())
+      {
+        Duration d100 = (std::min)(d, Duration(milliseconds(100)));
+        sleep_until(thread_detail::internal_clock_t::now() + ceil<nanoseconds>(d100));
+        d = t - Clock::now();
       }
     }
 
@@ -124,6 +124,7 @@ namespace boost
         cv.wait_until(lk, t);
       }
     }
+
     template <class Clock, class Duration>
     void sleep_until(const chrono::time_point<Clock, Duration>& t)
     {
@@ -136,6 +137,7 @@ namespace boost
         d = t - Clock::now();
       }
     }
+
     template <class Rep, class Period>
     void sleep_for(const chrono::duration<Rep, Period>& d)
     {

--- a/include/boost/thread/v2/thread.hpp
+++ b/include/boost/thread/v2/thread.hpp
@@ -23,6 +23,7 @@ namespace boost
     {
 #ifdef BOOST_THREAD_USES_CHRONO
 
+#if !defined BOOST_THREAD_SLEEP_FOR_IS_STEADY
     template <class Duration>
     void sleep_until(const chrono::time_point<thread_detail::internal_clock_t, Duration>& t)
     {
@@ -47,7 +48,11 @@ namespace boost
         d = t - Clock::now();
       }
     }
-#if defined BOOST_THREAD_SLEEP_FOR_IS_STEADY && !defined BOOST_THREAD_HAS_CONDATTR_SET_CLOCK_MONOTONIC
+#endif
+
+// Use pthread_delay_np or nanosleep whenever possible here in the no_interruption_point
+// namespace because they do not provide an interruption point.
+#if defined BOOST_THREAD_SLEEP_FOR_IS_STEADY
 
     template <class Rep, class Period>
     void sleep_for(const chrono::duration<Rep, Period>& d)
@@ -76,6 +81,20 @@ namespace boost
       using namespace chrono;
       sleep_for(t - steady_clock::now());
     }
+
+    template <class Clock, class Duration>
+    void sleep_until(const chrono::time_point<Clock, Duration>& t)
+    {
+      using namespace chrono;
+      Duration d = t - Clock::now();
+      while (d > Duration::zero())
+      {
+        Duration d100 = (std::min)(d, Duration(milliseconds(100)));
+        sleep_for(d100);
+        d = t - Clock::now();
+      }
+    }
+
 #else
     template <class Rep, class Period>
     void sleep_for(const chrono::duration<Rep, Period>& d)
@@ -117,38 +136,6 @@ namespace boost
         d = t - Clock::now();
       }
     }
-
-#if defined BOOST_THREAD_SLEEP_FOR_IS_STEADY && !defined BOOST_THREAD_HAS_CONDATTR_SET_CLOCK_MONOTONIC
-
-    template <class Rep, class Period>
-    void sleep_for(const chrono::duration<Rep, Period>& d)
-    {
-      using namespace chrono;
-      if (d > duration<Rep, Period>::zero())
-      {
-          const duration<long double> Max = (nanoseconds::max)();
-          nanoseconds ns;
-          if (d < Max)
-          {
-              ns = ceil<nanoseconds>(d);
-          }
-          else
-          {
-              // fixme: it is normal to sleep less than requested? Shouldn't we need to iterate until d has been elapsed?
-              ns = (nanoseconds::max)();
-          }
-          sleep_for(ns);
-      }
-    }
-
-    template <class Duration>
-    inline BOOST_SYMBOL_VISIBLE
-    void sleep_until(const chrono::time_point<chrono::steady_clock, Duration>& t)
-    {
-      using namespace chrono;
-      sleep_for(t - steady_clock::now());
-    }
-#else
     template <class Rep, class Period>
     void sleep_for(const chrono::duration<Rep, Period>& d)
     {
@@ -159,7 +146,6 @@ namespace boost
       }
     }
 
-#endif
 #endif
   }
 }


### PR DESCRIPTION
* Fixed the interruption-point versions of sleep_for/sleep_until() to always use condition variables.
* Fixed the no-interruption-point versions of sleep_for/sleep_until() to use pthread_delay_np or nanosleep whenever possible.
* Updated hidden::sleep_for() to always use a condition variable.
* Updated no_interruption_point::hidden::sleep_for() to use pthread_delay_np or nanosleep whenever possible.

NOTE: These changes also fix the two test failures with sleep_for/sleep_until when BOOST_THREAD_HAS_CONDATTR_SET_CLOCK_MONOTONIC is disabled.