### PR TITLE
Cleanup

### DIFF
--- a/include/boost/thread/pthread/condition_variable_fwd.hpp
+++ b/include/boost/thread/pthread/condition_variable_fwd.hpp
@@ -61,12 +61,6 @@ namespace boost
           }
           return true;
         }
-        bool do_wait_for(
-            unique_lock<mutex>& lock,
-            detail::timespec_duration const &timeout)
-        {
-            return do_wait_until(lock, timeout + detail::internal_timespec_clock::now());
-        }
 
     public:
       BOOST_THREAD_NO_COPYABLE(condition_variable)

--- a/include/boost/thread/pthread/thread_data.hpp
+++ b/include/boost/thread/pthread/thread_data.hpp
@@ -244,19 +244,6 @@ namespace boost
           void BOOST_THREAD_DECL sleep_for(const detail::timespec_duration& ts);
         }
 
-#ifdef BOOST_THREAD_USES_CHRONO
-        template <class Rep, class Period>
-        void sleep_for(const chrono::duration<Rep, Period>& d);
-#ifdef BOOST_THREAD_SLEEP_FOR_IS_STEADY
-
-        inline
-        void BOOST_SYMBOL_VISIBLE sleep_for(const chrono::nanoseconds& ns)
-        {
-            return boost::this_thread::hidden::sleep_for(detail::timespec_duration(ns));
-        }
-#endif
-#endif // BOOST_THREAD_USES_CHRONO
-
         namespace no_interruption_point
         {
           namespace hidden

--- a/include/boost/thread/pthread/thread_data.hpp
+++ b/include/boost/thread/pthread/thread_data.hpp
@@ -111,8 +111,6 @@ namespace boost
             pthread_t thread_handle;
             boost::mutex data_mutex;
             boost::condition_variable done_condition;
-            boost::mutex sleep_mutex;
-            boost::condition_variable sleep_condition;
             bool done;
             bool join_started;
             bool joined;
@@ -244,7 +242,6 @@ namespace boost
         namespace hidden
         {
           void BOOST_THREAD_DECL sleep_for(const detail::timespec_duration& ts);
-          void BOOST_THREAD_DECL sleep_until(const detail::internal_timespec_timepoint& ts);
         }
 
 #ifdef BOOST_THREAD_USES_CHRONO
@@ -265,7 +262,6 @@ namespace boost
           namespace hidden
           {
             void BOOST_THREAD_DECL sleep_for(const detail::timespec_duration& ts);
-            void BOOST_THREAD_DECL sleep_until(const detail::internal_timespec_timepoint& ts);
           }
 
     #ifdef BOOST_THREAD_USES_CHRONO
@@ -292,9 +288,6 @@ namespace boost
 #endif
         inline void sleep(system_time const& abs_time)
         {
-#if 0
-            boost::this_thread::hidden::sleep_until(detail::internal_timespec_timepoint(abs_time));
-#else
             const detail::real_timespec_timepoint ts(abs_time);
             mutex mx;
             unique_lock<mutex> lock(mx);
@@ -313,7 +306,6 @@ namespace boost
             }
 #else
             while (cond.do_wait_until(lock, ts)) {}
-#endif
 #endif
         }
 

--- a/include/boost/thread/v2/thread.hpp
+++ b/include/boost/thread/v2/thread.hpp
@@ -87,10 +87,7 @@ namespace boost
       mutex mut;
       condition_variable cv;
       unique_lock<mutex> lk(mut);
-      while (thread_detail::internal_clock_t::now() < t)
-      {
-        cv.wait_until(lk, t);
-      }
+      while (cv_status::no_timeout == cv.wait_until(lk, t)) {}
     }
 
     template <class Clock, class Duration>
@@ -119,10 +116,7 @@ namespace boost
       mutex mut;
       condition_variable cv;
       unique_lock<mutex> lk(mut);
-      while (thread_detail::internal_clock_t::now() < t)
-      {
-        cv.wait_until(lk, t);
-      }
+      while (cv_status::no_timeout == cv.wait_until(lk, t)) {}
     }
 
     template <class Clock, class Duration>

--- a/include/boost/thread/win32/thread_data.hpp
+++ b/include/boost/thread/win32/thread_data.hpp
@@ -280,13 +280,6 @@ namespace boost
         {
             interruptible_wait(abs_time);
         }
-// #11322   sleep_for() nanoseconds overload will always return too early on windows
-//#ifdef BOOST_THREAD_USES_CHRONO
-//        inline void BOOST_SYMBOL_VISIBLE sleep_for(const chrono::nanoseconds& ns)
-//        {
-//          interruptible_wait(chrono::duration_cast<chrono::milliseconds>(ns).count());
-//        }
-//#endif
         namespace no_interruption_point
         {
           bool BOOST_THREAD_DECL non_interruptible_wait(detail::win32::handle handle_to_wait_for,detail::timeout target_time);
@@ -307,13 +300,6 @@ namespace boost
           {
             non_interruptible_wait(abs_time);
           }
-// #11322   sleep_for() nanoseconds overload will always return too early on windows
-//#ifdef BOOST_THREAD_USES_CHRONO
-//          inline void BOOST_SYMBOL_VISIBLE sleep_for(const chrono::nanoseconds& ns)
-//          {
-//            non_interruptible_wait(chrono::duration_cast<chrono::milliseconds>(ns).count());
-//          }
-//#endif
         }
     }
 


### PR DESCRIPTION
* Deleted a couple of unnecessary calls to internal_clock_t::now() in v2/thread.hpp.
* Deleted the hidden::sleep_until() functions, which are no longer being used.
* Deleted the condition_variable::do_wait_for() function, which is no longer being used.
* Deleted the sleep_mutex and sleep_condition variables in pthread/thread_data.hpp, which are no longer being used.

I re-ran the tests and, as expected, there are no changes to the results from this PR.