### PR TITLE
Chrono-related optimizations

### DIFF
--- a/include/boost/thread/detail/thread.hpp
+++ b/include/boost/thread/detail/thread.hpp
@@ -493,7 +493,7 @@ namespace boost
             thread_detail::internal_clock_t::time_point     s_now = thread_detail::internal_clock_t::now();
             typedef typename common_type<Duration, typename Clock::duration>::type CD;
             CD d = t - Clock::now();
-            if (d <= Clock::duration::zero()) return false; // in case the Clock::time_point t is already reached
+            if (d <= CD::zero()) return false; // in case the Clock::time_point t is already reached
             joined = try_join_until(s_now + d);
           } while (! joined);
           return true;

--- a/include/boost/thread/detail/thread.hpp
+++ b/include/boost/thread/detail/thread.hpp
@@ -497,13 +497,6 @@ namespace boost
           } while (! joined);
           return true;
         }
-        template <class Duration>
-        bool try_join_until(const chrono::time_point<thread_detail::internal_clock_t, Duration>& t)
-        {
-          using namespace chrono;
-          typedef time_point<thread_detail::internal_clock_t, nanoseconds> nano_sys_tmpt;
-          return try_join_until(nano_sys_tmpt(ceil<nanoseconds>(t.time_since_epoch())));
-        }
 #endif
 #if defined(BOOST_THREAD_PLATFORM_WIN32)
     private:
@@ -516,9 +509,10 @@ namespace boost
         //}
 
 #ifdef BOOST_THREAD_USES_CHRONO
-        bool try_join_until(const chrono::time_point<thread_detail::internal_clock_t, chrono::nanoseconds>& tp)
+        template <class Duration>
+        bool try_join_until(const chrono::time_point<thread_detail::internal_clock_t, Duration>& t)
         {
-          chrono::milliseconds rel_time= chrono::ceil<chrono::milliseconds>(tp-thread_detail::internal_clock_t::now());
+          chrono::milliseconds rel_time= chrono::ceil<chrono::milliseconds>(t-thread_detail::internal_clock_t::now());
           return do_try_join_for(rel_time.count());
         }
 #endif
@@ -537,9 +531,10 @@ namespace boost
         }
 #endif
 #ifdef BOOST_THREAD_USES_CHRONO
-        bool try_join_until(const chrono::time_point<thread_detail::internal_clock_t, chrono::nanoseconds>& tp)
+        template <class Duration>
+        bool try_join_until(const chrono::time_point<thread_detail::internal_clock_t, Duration>& t)
         {
-          const boost::detail::internal_timespec_timepoint ts = tp;
+          const boost::detail::internal_timespec_timepoint ts = t;
           return do_try_join_until(ts);
         }
 #endif // defined(BOOST_THREAD_PLATFORM_WIN32)

--- a/include/boost/thread/detail/thread.hpp
+++ b/include/boost/thread/detail/thread.hpp
@@ -491,7 +491,8 @@ namespace boost
           bool joined= false;
           do {
             thread_detail::internal_clock_t::time_point     s_now = thread_detail::internal_clock_t::now();
-            typename Clock::duration   d = t-Clock::now();
+            typedef typename common_type<Duration, typename Clock::duration>::type CD;
+            CD d = t - Clock::now();
             if (d <= Clock::duration::zero()) return false; // in case the Clock::time_point t is already reached
             joined = try_join_until(s_now + d);
           } while (! joined);

--- a/include/boost/thread/pthread/condition_variable.hpp
+++ b/include/boost/thread/pthread/condition_variable.hpp
@@ -297,14 +297,15 @@ namespace boost
                 const chrono::time_point<Clock, Duration>& t)
         {
           using namespace chrono;
-          Duration d = t - Clock::now();
-          if ( d <= Duration::zero() ) return cv_status::timeout;
-          d = (std::min)(d, Duration(milliseconds(100)));
+          typedef typename common_type<Duration, typename Clock::duration>::type CD;
+          CD d = t - Clock::now();
+          if ( d <= CD::zero() ) return cv_status::timeout;
+          d = (std::min)(d, CD(milliseconds(100)));
           while (cv_status::timeout == wait_until(lock, thread_detail::internal_clock_t::now() + d))
           {
               d = t - Clock::now();
-              if ( d <= Duration::zero() ) return cv_status::timeout;
-              d = (std::min)(d, Duration(milliseconds(100)));
+              if ( d <= CD::zero() ) return cv_status::timeout;
+              d = (std::min)(d, CD(milliseconds(100)));
           }
           return cv_status::no_timeout;
         }

--- a/include/boost/thread/pthread/condition_variable.hpp
+++ b/include/boost/thread/pthread/condition_variable.hpp
@@ -285,10 +285,9 @@ namespace boost
                 lock_type& lock,
                 const chrono::time_point<thread_detail::internal_clock_t, Duration>& t)
         {
-          using namespace chrono;
-          typedef time_point<thread_detail::internal_clock_t, nanoseconds> nano_sys_tmpt;
-          return wait_until(lock,
-                        nano_sys_tmpt(ceil<nanoseconds>(t.time_since_epoch())));
+          boost::detail::internal_timespec_timepoint ts = t;
+          if (do_wait_until(lock, ts)) return cv_status::no_timeout;
+          else return cv_status::timeout;
         }
 
         template <class lock_type, class Clock, class Duration>
@@ -301,7 +300,7 @@ namespace boost
           Duration d = t - Clock::now();
           if ( d <= Duration::zero() ) return cv_status::timeout;
           d = (std::min)(d, Duration(milliseconds(100)));
-          while (cv_status::timeout == wait_until(lock, thread_detail::internal_clock_t::now() + ceil<nanoseconds>(d)))
+          while (cv_status::timeout == wait_until(lock, thread_detail::internal_clock_t::now() + d))
           {
               d = t - Clock::now();
               if ( d <= Duration::zero() ) return cv_status::timeout;
@@ -317,16 +316,6 @@ namespace boost
                 const chrono::duration<Rep, Period>& d)
         {
           return wait_until(lock, chrono::steady_clock::now() + d);
-        }
-
-        template <class lock_type>
-        cv_status wait_until(
-            lock_type& lk,
-            chrono::time_point<thread_detail::internal_clock_t, chrono::nanoseconds> tp)
-        {
-            boost::detail::internal_timespec_timepoint ts = tp;
-            if (do_wait_until(lk, ts)) return cv_status::no_timeout;
-            else return cv_status::timeout;
         }
 
         template <class lock_type, class Clock, class Duration, class Predicate>

--- a/include/boost/thread/pthread/condition_variable_fwd.hpp
+++ b/include/boost/thread/pthread/condition_variable_fwd.hpp
@@ -217,14 +217,15 @@ namespace boost
                 const chrono::time_point<Clock, Duration>& t)
         {
           using namespace chrono;
-          Duration d = t - Clock::now();
-          if ( d <= Duration::zero() ) return cv_status::timeout;
-          d = (std::min)(d, Duration(milliseconds(100)));
+          typedef typename common_type<Duration, typename Clock::duration>::type CD;
+          CD d = t - Clock::now();
+          if ( d <= CD::zero() ) return cv_status::timeout;
+          d = (std::min)(d, CD(milliseconds(100)));
           while (cv_status::timeout == wait_until(lock, thread_detail::internal_clock_t::now() + d))
           {
               d = t - Clock::now();
-              if ( d <= Duration::zero() ) return cv_status::timeout;
-              d = (std::min)(d, Duration(milliseconds(100)));
+              if ( d <= CD::zero() ) return cv_status::timeout;
+              d = (std::min)(d, CD(milliseconds(100)));
           }
           return cv_status::no_timeout;
         }

--- a/include/boost/thread/pthread/mutex.hpp
+++ b/include/boost/thread/pthread/mutex.hpp
@@ -318,7 +318,7 @@ namespace boost
           Duration d = t - Clock::now();
           if ( d <= Duration::zero() ) return false;
           d = (std::min)(d, Duration(milliseconds(100)));
-          while ( ! try_lock_until(thread_detail::internal_clock_t::now() + ceil<nanoseconds>(d)))
+          while ( ! try_lock_until(thread_detail::internal_clock_t::now() + d))
           {
               d = t - Clock::now();
               if ( d <= Duration::zero() ) return false;
@@ -329,13 +329,7 @@ namespace boost
         template <class Duration>
         bool try_lock_until(const chrono::time_point<thread_detail::internal_clock_t, Duration>& t)
         {
-          using namespace chrono;
-          typedef time_point<thread_detail::internal_clock_t, nanoseconds> nano_sys_tmpt;
-          return try_lock_until(nano_sys_tmpt(ceil<nanoseconds>(t.time_since_epoch())));
-        }
-        bool try_lock_until(const chrono::time_point<thread_detail::internal_clock_t, chrono::nanoseconds>& tp)
-        {
-          detail::internal_timespec_timepoint ts = tp;
+          detail::internal_timespec_timepoint ts = t;
           return do_try_lock_until(ts);
         }
 #endif

--- a/include/boost/thread/pthread/mutex.hpp
+++ b/include/boost/thread/pthread/mutex.hpp
@@ -315,14 +315,15 @@ namespace boost
         bool try_lock_until(const chrono::time_point<Clock, Duration>& t)
         {
           using namespace chrono;
-          Duration d = t - Clock::now();
-          if ( d <= Duration::zero() ) return false;
-          d = (std::min)(d, Duration(milliseconds(100)));
+          typedef typename common_type<Duration, typename Clock::duration>::type CD;
+          CD d = t - Clock::now();
+          if ( d <= CD::zero() ) return false;
+          d = (std::min)(d, CD(milliseconds(100)));
           while ( ! try_lock_until(thread_detail::internal_clock_t::now() + d))
           {
               d = t - Clock::now();
-              if ( d <= Duration::zero() ) return false;
-              d = (std::min)(d, Duration(milliseconds(100)));
+              if ( d <= CD::zero() ) return false;
+              d = (std::min)(d, CD(milliseconds(100)));
           }
           return true;
         }

--- a/include/boost/thread/pthread/recursive_mutex.hpp
+++ b/include/boost/thread/pthread/recursive_mutex.hpp
@@ -362,7 +362,7 @@ namespace boost
           Duration d = t - Clock::now();
           if ( d <= Duration::zero() ) return false;
           d = (std::min)(d, Duration(milliseconds(100)));
-          while ( ! try_lock_until(thread_detail::internal_clock_t::now() + ceil<nanoseconds>(d)))
+          while ( ! try_lock_until(thread_detail::internal_clock_t::now() + d))
           {
               d = t - Clock::now();
               if ( d <= Duration::zero() ) return false;
@@ -374,13 +374,7 @@ namespace boost
         template <class Duration>
         bool try_lock_until(const chrono::time_point<thread_detail::internal_clock_t, Duration>& t)
         {
-          using namespace chrono;
-          typedef time_point<thread_detail::internal_clock_t, nanoseconds> nano_sys_tmpt;
-          return try_lock_until(nano_sys_tmpt(ceil<nanoseconds>(t.time_since_epoch())));
-        }
-        bool try_lock_until(const chrono::time_point<thread_detail::internal_clock_t, chrono::nanoseconds>& tp)
-        {
-          detail::internal_timespec_timepoint ts = tp;
+          detail::internal_timespec_timepoint ts = t;
           return do_try_lock_until(ts);
         }
 #endif

--- a/include/boost/thread/pthread/recursive_mutex.hpp
+++ b/include/boost/thread/pthread/recursive_mutex.hpp
@@ -359,14 +359,15 @@ namespace boost
         bool try_lock_until(const chrono::time_point<Clock, Duration>& t)
         {
           using namespace chrono;
-          Duration d = t - Clock::now();
-          if ( d <= Duration::zero() ) return false;
-          d = (std::min)(d, Duration(milliseconds(100)));
+          typedef typename common_type<Duration, typename Clock::duration>::type CD;
+          CD d = t - Clock::now();
+          if ( d <= CD::zero() ) return false;
+          d = (std::min)(d, CD(milliseconds(100)));
           while ( ! try_lock_until(thread_detail::internal_clock_t::now() + d))
           {
               d = t - Clock::now();
-              if ( d <= Duration::zero() ) return false;
-              d = (std::min)(d, Duration(milliseconds(100)));
+              if ( d <= CD::zero() ) return false;
+              d = (std::min)(d, CD(milliseconds(100)));
           }
           return true;
 

--- a/include/boost/thread/pthread/thread_data.hpp
+++ b/include/boost/thread/pthread/thread_data.hpp
@@ -252,14 +252,11 @@ namespace boost
           }
 
     #ifdef BOOST_THREAD_USES_CHRONO
-          template <class Rep, class Period>
-          void sleep_for(const chrono::duration<Rep, Period>& d);
     #ifdef BOOST_THREAD_SLEEP_FOR_IS_STEADY
-
-          inline
-          void BOOST_SYMBOL_VISIBLE sleep_for(const chrono::nanoseconds& ns)
+          template <class Rep, class Period>
+          void sleep_for(const chrono::duration<Rep, Period>& d)
           {
-              return boost::this_thread::no_interruption_point::hidden::sleep_for(detail::timespec_duration(ns));
+              return boost::this_thread::no_interruption_point::hidden::sleep_for(detail::timespec_duration(d));
           }
     #endif
     #endif // BOOST_THREAD_USES_CHRONO

--- a/include/boost/thread/pthread/timespec.hpp
+++ b/include/boost/thread/pthread/timespec.hpp
@@ -292,7 +292,8 @@ namespace boost
   template <class Duration>
   mono_timespec_timepoint::mono_timespec_timepoint(chrono::time_point<chrono::system_clock, Duration> const& abs_time)
   {
-    Duration since_now = abs_time - chrono::system_clock::now();
+    typedef typename common_type<Duration, typename chrono::system_clock::duration>::type CD;
+    CD since_now = abs_time - chrono::system_clock::now();
     value = (mono_timespec_clock::now() + timespec_duration(since_now)).get();
   }
   template <class Duration>

--- a/include/boost/thread/v2/thread.hpp
+++ b/include/boost/thread/v2/thread.hpp
@@ -27,25 +27,7 @@ namespace boost
 // namespace because they do not provide an interruption point.
 #if defined BOOST_THREAD_SLEEP_FOR_IS_STEADY
 
-    template <class Rep, class Period>
-    void sleep_for(const chrono::duration<Rep, Period>& d)
-    {
-      using namespace chrono;
-      if (d > duration<Rep, Period>::zero())
-      {
-          duration<long double> Max = nanoseconds::max BOOST_PREVENT_MACRO_SUBSTITUTION ();
-          nanoseconds ns;
-          if (d < Max)
-          {
-            ns = ceil<nanoseconds>(d);
-          }
-          else
-          {
-              ns = nanoseconds:: max BOOST_PREVENT_MACRO_SUBSTITUTION ();
-          }
-          sleep_for(ns);
-      }
-    }
+    // sleep_for(const chrono::duration<Rep, Period>& d) is defined in pthread/thread_data.hpp
 
     template <class Duration>
     inline BOOST_SYMBOL_VISIBLE
@@ -98,7 +80,7 @@ namespace boost
       while (d > Duration::zero())
       {
         Duration d100 = (std::min)(d, Duration(milliseconds(100)));
-        sleep_until(thread_detail::internal_clock_t::now() + ceil<nanoseconds>(d100));
+        sleep_until(thread_detail::internal_clock_t::now() + d100);
         d = t - Clock::now();
       }
     }
@@ -127,7 +109,7 @@ namespace boost
       while (d > Duration::zero())
       {
         Duration d100 = (std::min)(d, Duration(milliseconds(100)));
-        sleep_until(thread_detail::internal_clock_t::now() + ceil<nanoseconds>(d100));
+        sleep_until(thread_detail::internal_clock_t::now() + d100);
         d = t - Clock::now();
       }
     }

--- a/include/boost/thread/v2/thread.hpp
+++ b/include/boost/thread/v2/thread.hpp
@@ -41,10 +41,11 @@ namespace boost
     void sleep_until(const chrono::time_point<Clock, Duration>& t)
     {
       using namespace chrono;
-      Duration d = t - Clock::now();
-      while (d > Duration::zero())
+      typedef typename common_type<Duration, typename Clock::duration>::type CD;
+      CD d = t - Clock::now();
+      while (d > CD::zero())
       {
-        Duration d100 = (std::min)(d, Duration(milliseconds(100)));
+        CD d100 = (std::min)(d, CD(milliseconds(100)));
         sleep_for(d100);
         d = t - Clock::now();
       }
@@ -76,10 +77,11 @@ namespace boost
     void sleep_until(const chrono::time_point<Clock, Duration>& t)
     {
       using namespace chrono;
-      Duration d = t - Clock::now();
-      while (d > Duration::zero())
+      typedef typename common_type<Duration, typename Clock::duration>::type CD;
+      CD d = t - Clock::now();
+      while (d > CD::zero())
       {
-        Duration d100 = (std::min)(d, Duration(milliseconds(100)));
+        CD d100 = (std::min)(d, CD(milliseconds(100)));
         sleep_until(thread_detail::internal_clock_t::now() + d100);
         d = t - Clock::now();
       }
@@ -105,10 +107,11 @@ namespace boost
     void sleep_until(const chrono::time_point<Clock, Duration>& t)
     {
       using namespace chrono;
-      Duration d = t - Clock::now();
-      while (d > Duration::zero())
+      typedef typename common_type<Duration, typename Clock::duration>::type CD;
+      CD d = t - Clock::now();
+      while (d > CD::zero())
       {
-        Duration d100 = (std::min)(d, Duration(milliseconds(100)));
+        CD d100 = (std::min)(d, CD(milliseconds(100)));
         sleep_until(thread_detail::internal_clock_t::now() + d100);
         d = t - Clock::now();
       }


### PR DESCRIPTION
* Fixed an issue where the results of chrono arithmetic operations weren't being assigned to a common type that's guaranteed to compile.
* Eliminated unnecessary conversions to chrono::nanoseconds.

As expected, none of the test results changed with these updates.