### PR TITLE
Timespec Improvements, Minor Cleanup

### DIFF
--- a/include/boost/thread/pthread/thread_data.hpp
+++ b/include/boost/thread/pthread/thread_data.hpp
@@ -278,14 +278,11 @@ namespace boost
             condition_variable cond;
 
 #if defined BOOST_THREAD_HAS_CONDATTR_SET_CLOCK_MONOTONIC
-            const timespec maxSleepTs = {0, 100000000}; // 100 milliseconds
-            const detail::timespec_duration maxSleep(maxSleepTs);
-
             detail::timespec_duration d = ts - detail::real_timespec_clock::now();
             while (d > detail::timespec_duration::zero())
             {
-                detail::timespec_duration d100 = (std::min)(d, maxSleep);
-                cond.do_wait_until(lock, detail::internal_timespec_clock::now() + d100);
+                d = (std::min)(d, detail::timespec_milliseconds(100));
+                cond.do_wait_until(lock, detail::internal_timespec_clock::now() + d);
                 d = ts - detail::real_timespec_clock::now();
             }
 #else
@@ -294,9 +291,9 @@ namespace boost
         }
 
         template<typename TimeDuration>
-        inline BOOST_SYMBOL_VISIBLE void sleep(TimeDuration const& rel_time)
+        void sleep(TimeDuration const& rel_time)
         {
-          boost::this_thread::hidden::sleep_for(detail::timespec_duration(rel_time));
+            boost::this_thread::hidden::sleep_for(detail::timespec_duration(rel_time));
         }
 #endif // BOOST_THREAD_USES_DATETIME
     } // this_thread

--- a/include/boost/thread/pthread/timespec.hpp
+++ b/include/boost/thread/pthread/timespec.hpp
@@ -36,7 +36,7 @@ namespace boost
   namespace detail
   {
 
-    inline timespec int_to_timespec(boost::intmax_t const& ns)
+    inline timespec ns_to_timespec(boost::intmax_t const& ns)
     {
       boost::intmax_t s = ns / 1000000000l;
       struct timespec ts;
@@ -44,7 +44,7 @@ namespace boost
       ts.tv_nsec = static_cast<long> (ns - s * 1000000000l);
       return ts;
     }
-    inline boost::intmax_t to_nanoseconds_int_max(timespec const& ts)
+    inline boost::intmax_t timespec_to_ns(timespec const& ts)
     {
       return static_cast<boost::intmax_t>(ts.tv_sec) * 1000000000l + ts.tv_nsec;
     }
@@ -53,6 +53,7 @@ namespace boost
     {
     public:
       explicit timespec_duration(timespec const& v) : value(v) {}
+      explicit timespec_duration(boost::intmax_t const& ns) : value(ns_to_timespec(ns)) {}
 
 #if defined BOOST_THREAD_USES_DATETIME
       timespec_duration(boost::posix_time::time_duration const& rel_time)
@@ -74,6 +75,7 @@ namespace boost
 
       timespec& get() { return value; }
       timespec const& get() const { return value; }
+      boost::intmax_t getNs() const { return timespec_to_ns(value); }
 
       static inline timespec_duration zero()
       {
@@ -88,33 +90,39 @@ namespace boost
 
     inline bool operator==(timespec_duration const& lhs, timespec_duration const& rhs)
     {
-      return to_nanoseconds_int_max(lhs.get()) == to_nanoseconds_int_max(rhs.get());
+      return lhs.getNs() == rhs.getNs();
     }
     inline bool operator!=(timespec_duration const& lhs, timespec_duration const& rhs)
     {
-      return to_nanoseconds_int_max(lhs.get()) != to_nanoseconds_int_max(rhs.get());
+      return lhs.getNs() != rhs.getNs();
     }
     inline bool operator<(timespec_duration const& lhs, timespec_duration const& rhs)
     {
-      return to_nanoseconds_int_max(lhs.get()) < to_nanoseconds_int_max(rhs.get());
+      return lhs.getNs() < rhs.getNs();
     }
     inline bool operator<=(timespec_duration const& lhs, timespec_duration const& rhs)
     {
-      return to_nanoseconds_int_max(lhs.get()) <= to_nanoseconds_int_max(rhs.get());
+      return lhs.getNs() <= rhs.getNs();
     }
     inline bool operator>(timespec_duration const& lhs, timespec_duration const& rhs)
     {
-      return to_nanoseconds_int_max(lhs.get()) > to_nanoseconds_int_max(rhs.get());
+      return lhs.getNs() > rhs.getNs();
     }
     inline bool operator>=(timespec_duration const& lhs, timespec_duration const& rhs)
     {
-      return to_nanoseconds_int_max(lhs.get()) >= to_nanoseconds_int_max(rhs.get());
+      return lhs.getNs() >= rhs.getNs();
+    }
+
+    inline timespec_duration timespec_milliseconds(long const& ms)
+    {
+      return timespec_duration(ms * 1000000l);
     }
 
     class real_timespec_timepoint
     {
     public:
       explicit real_timespec_timepoint(timespec const& v) : value(v) {}
+      explicit real_timespec_timepoint(boost::intmax_t const& ns) : value(ns_to_timespec(ns)) {}
 
 #if defined BOOST_THREAD_USES_DATETIME
       real_timespec_timepoint(boost::system_time const& abs_time)
@@ -133,54 +141,52 @@ namespace boost
 
       timespec& get() { return value; }
       timespec const& get() const { return value; }
+      boost::intmax_t getNs() const { return timespec_to_ns(value); }
+
     private:
       timespec value;
     };
 
     inline bool operator==(real_timespec_timepoint const& lhs, real_timespec_timepoint const& rhs)
     {
-      return to_nanoseconds_int_max(lhs.get()) == to_nanoseconds_int_max(rhs.get());
+      return lhs.getNs() == rhs.getNs();
     }
     inline bool operator!=(real_timespec_timepoint const& lhs, real_timespec_timepoint const& rhs)
     {
-      return to_nanoseconds_int_max(lhs.get()) != to_nanoseconds_int_max(rhs.get());
+      return lhs.getNs() != rhs.getNs();
     }
     inline bool operator<(real_timespec_timepoint const& lhs, real_timespec_timepoint const& rhs)
     {
-      return to_nanoseconds_int_max(lhs.get()) < to_nanoseconds_int_max(rhs.get());
+      return lhs.getNs() < rhs.getNs();
     }
     inline bool operator<=(real_timespec_timepoint const& lhs, real_timespec_timepoint const& rhs)
     {
-      return to_nanoseconds_int_max(lhs.get()) <= to_nanoseconds_int_max(rhs.get());
+      return lhs.getNs() <= rhs.getNs();
     }
     inline bool operator>(real_timespec_timepoint const& lhs, real_timespec_timepoint const& rhs)
     {
-      return to_nanoseconds_int_max(lhs.get()) > to_nanoseconds_int_max(rhs.get());
+      return lhs.getNs() > rhs.getNs();
     }
     inline bool operator>=(real_timespec_timepoint const& lhs, real_timespec_timepoint const& rhs)
     {
-      return to_nanoseconds_int_max(lhs.get()) >= to_nanoseconds_int_max(rhs.get());
+      return lhs.getNs() >= rhs.getNs();
     }
 
     inline real_timespec_timepoint operator+(real_timespec_timepoint const& lhs, timespec_duration const& rhs)
     {
-      // fixme: replace by to_timespec_duration
-      return real_timespec_timepoint(int_to_timespec(to_nanoseconds_int_max(lhs.get()) + to_nanoseconds_int_max(rhs.get())));
+      return real_timespec_timepoint(lhs.getNs() + rhs.getNs());
     }
     inline real_timespec_timepoint operator+(timespec_duration const& lhs, real_timespec_timepoint const& rhs)
     {
-      // fixme: replace by to_timespec_duration
-      return real_timespec_timepoint(int_to_timespec(to_nanoseconds_int_max(lhs.get()) + to_nanoseconds_int_max(rhs.get())));
+      return real_timespec_timepoint(lhs.getNs() + rhs.getNs());
     }
     inline timespec_duration operator-(real_timespec_timepoint const& lhs, real_timespec_timepoint const& rhs)
     {
-      // fixme: replace by to_timespec_duration
-      return timespec_duration(int_to_timespec(to_nanoseconds_int_max(lhs.get()) - to_nanoseconds_int_max(rhs.get())));
+      return timespec_duration(lhs.getNs() - rhs.getNs());
     }
 
     struct real_timespec_clock
     {
-      // fixme: Why not use ststem_clock::now()?
       static inline real_timespec_timepoint now()
       {
         timespec ts;
@@ -207,6 +213,7 @@ namespace boost
   {
   public:
     explicit mono_timespec_timepoint(timespec const& v) : value(v) {}
+    explicit mono_timespec_timepoint(boost::intmax_t const& ns) : value(ns_to_timespec(ns)) {}
 
 #if defined BOOST_THREAD_USES_DATETIME
     inline mono_timespec_timepoint(boost::system_time const& abs_time);
@@ -220,54 +227,52 @@ namespace boost
 
     timespec& get() { return value; }
     timespec const& get() const { return value; }
+    boost::intmax_t getNs() const { return timespec_to_ns(value); }
+
   private:
     timespec value;
   };
 
   inline bool operator==(mono_timespec_timepoint const& lhs, mono_timespec_timepoint const& rhs)
   {
-    return to_nanoseconds_int_max(lhs.get()) == to_nanoseconds_int_max(rhs.get());
+    return lhs.getNs() == rhs.getNs();
   }
   inline bool operator!=(mono_timespec_timepoint const& lhs, mono_timespec_timepoint const& rhs)
   {
-    return to_nanoseconds_int_max(lhs.get()) != to_nanoseconds_int_max(rhs.get());
+    return lhs.getNs() != rhs.getNs();
   }
   inline bool operator<(mono_timespec_timepoint const& lhs, mono_timespec_timepoint const& rhs)
   {
-    return to_nanoseconds_int_max(lhs.get()) < to_nanoseconds_int_max(rhs.get());
+    return lhs.getNs() < rhs.getNs();
   }
   inline bool operator<=(mono_timespec_timepoint const& lhs, mono_timespec_timepoint const& rhs)
   {
-    return to_nanoseconds_int_max(lhs.get()) <= to_nanoseconds_int_max(rhs.get());
+    return lhs.getNs() <= rhs.getNs();
   }
   inline bool operator>(mono_timespec_timepoint const& lhs, mono_timespec_timepoint const& rhs)
   {
-    return to_nanoseconds_int_max(lhs.get()) > to_nanoseconds_int_max(rhs.get());
+    return lhs.getNs() > rhs.getNs();
   }
   inline bool operator>=(mono_timespec_timepoint const& lhs, mono_timespec_timepoint const& rhs)
   {
-    return to_nanoseconds_int_max(lhs.get()) >= to_nanoseconds_int_max(rhs.get());
+    return lhs.getNs() >= rhs.getNs();
   }
 
   inline mono_timespec_timepoint operator+(mono_timespec_timepoint const& lhs, timespec_duration const& rhs)
   {
-    // fixme: replace by to_timespec_duration
-    return mono_timespec_timepoint(int_to_timespec(to_nanoseconds_int_max(lhs.get()) + to_nanoseconds_int_max(rhs.get())));
+    return mono_timespec_timepoint(lhs.getNs() + rhs.getNs());
   }
   inline mono_timespec_timepoint operator+(timespec_duration const& lhs, mono_timespec_timepoint const& rhs)
   {
-    // fixme: replace by to_timespec_duration
-    return mono_timespec_timepoint(int_to_timespec(to_nanoseconds_int_max(lhs.get()) + to_nanoseconds_int_max(rhs.get())));
+    return mono_timespec_timepoint(lhs.getNs() + rhs.getNs());
   }
   inline timespec_duration operator-(mono_timespec_timepoint const& lhs, mono_timespec_timepoint const& rhs)
   {
-    // fixme: replace by to_timespec_duration
-    return timespec_duration(int_to_timespec(to_nanoseconds_int_max(lhs.get()) - to_nanoseconds_int_max(rhs.get())));
+    return timespec_duration(lhs.getNs() - rhs.getNs());
   }
 
   struct mono_timespec_clock
   {
-    // fixme: Why not use steady_clock::now()?
     static inline mono_timespec_timepoint now()
     {
       timespec ts;

--- a/include/boost/thread/pthread/timespec.hpp
+++ b/include/boost/thread/pthread/timespec.hpp
@@ -113,7 +113,7 @@ namespace boost
       return lhs.getNs() >= rhs.getNs();
     }
 
-    inline timespec_duration timespec_milliseconds(long const& ms)
+    static inline timespec_duration timespec_milliseconds(long const& ms)
     {
       return timespec_duration(ms * 1000000l);
     }

--- a/include/boost/thread/v2/thread.hpp
+++ b/include/boost/thread/v2/thread.hpp
@@ -30,7 +30,6 @@ namespace boost
     // sleep_for(const chrono::duration<Rep, Period>& d) is defined in pthread/thread_data.hpp
 
     template <class Duration>
-    inline BOOST_SYMBOL_VISIBLE
     void sleep_until(const chrono::time_point<chrono::steady_clock, Duration>& t)
     {
       using namespace chrono;
@@ -45,8 +44,8 @@ namespace boost
       CD d = t - Clock::now();
       while (d > CD::zero())
       {
-        CD d100 = (std::min)(d, CD(milliseconds(100)));
-        sleep_for(d100);
+        d = (std::min)(d, CD(milliseconds(100)));
+        sleep_for(d);
         d = t - Clock::now();
       }
     }
@@ -81,8 +80,8 @@ namespace boost
       CD d = t - Clock::now();
       while (d > CD::zero())
       {
-        CD d100 = (std::min)(d, CD(milliseconds(100)));
-        sleep_until(thread_detail::internal_clock_t::now() + d100);
+        d = (std::min)(d, CD(milliseconds(100)));
+        sleep_until(thread_detail::internal_clock_t::now() + d);
         d = t - Clock::now();
       }
     }
@@ -111,8 +110,8 @@ namespace boost
       CD d = t - Clock::now();
       while (d > CD::zero())
       {
-        CD d100 = (std::min)(d, CD(milliseconds(100)));
-        sleep_until(thread_detail::internal_clock_t::now() + d100);
+        d = (std::min)(d, CD(milliseconds(100)));
+        sleep_until(thread_detail::internal_clock_t::now() + d);
         d = t - Clock::now();
       }
     }

--- a/src/pthread/thread.cpp
+++ b/src/pthread/thread.cpp
@@ -468,15 +468,12 @@ namespace boost
             condition_variable cond;
 
 #if defined(CLOCK_MONOTONIC) && !defined BOOST_THREAD_HAS_CONDATTR_SET_CLOCK_MONOTONIC
-            const timespec maxSleepTs = {0, 100000000}; // 100 milliseconds
-            const detail::timespec_duration maxSleep(maxSleepTs);
-
             const detail::mono_timespec_timepoint& ts2 = detail::mono_timespec_clock::now() + ts;
             detail::timespec_duration d = ts;
             while (d > detail::timespec_duration::zero())
             {
-                detail::timespec_duration d100 = (std::min)(d, maxSleep);
-                cond.do_wait_until(lock, detail::internal_timespec_clock::now() + d100);
+                d = (std::min)(d, detail::timespec_milliseconds(100));
+                cond.do_wait_until(lock, detail::internal_timespec_clock::now() + d);
                 d = ts2 - detail::mono_timespec_clock::now();
             }
 #else


### PR DESCRIPTION
* Added a constructor to timespec_duration, real_timespec_timepoint, and mono_timespec_timepoint that takes an intmax_t representing the number of nanoseconds in the timespec.
* Added a getNs() function to timespec_duration, real_timespec_timepoint, and mono_timespec_timepoint that returns an intmax_t representing the number of nanoseconds in the timespec.
* Added a timespec_milliseconds() function that takes an integer representing milliseconds and returns a timespec_duration.
* Removed some unnecessary BOOST_SYMBOL_VISIBLE declarations.
* Removed the unnecessary d100 variable declarations.