### PR TITLE
Fixed try_join_* and timed_join functions that were failing time jump tests

### DIFF
--- a/include/boost/thread/detail/thread.hpp
+++ b/include/boost/thread/detail/thread.hpp
@@ -480,7 +480,7 @@ namespace boost
         template <class Rep, class Period>
         bool try_join_for(const chrono::duration<Rep, Period>& rel_time)
         {
-          return try_join_until(thread_detail::internal_clock_t::now() + rel_time);
+          return try_join_until(chrono::steady_clock::now() + rel_time);
         }
 #endif
 
@@ -488,14 +488,16 @@ namespace boost
         bool try_join_until(const chrono::time_point<Clock, Duration>& t)
         {
           using namespace chrono;
-          bool joined= false;
-          do {
-            thread_detail::internal_clock_t::time_point     s_now = thread_detail::internal_clock_t::now();
-            typedef typename common_type<Duration, typename Clock::duration>::type CD;
-            CD d = t - Clock::now();
-            if (d <= CD::zero()) return false; // in case the Clock::time_point t is already reached
-            joined = try_join_until(s_now + d);
-          } while (! joined);
+          typedef typename common_type<Duration, typename Clock::duration>::type CD;
+          CD d = t - Clock::now();
+          if ( d < CD::zero() ) return false; // d == zero() is valid
+          d = (std::min)(d, CD(milliseconds(100)));
+          while ( ! try_join_until(thread_detail::internal_clock_t::now() + d) )
+          {
+            d = t - Clock::now();
+            if ( d <= CD::zero() ) return false;
+            d = (std::min)(d, CD(milliseconds(100)));
+          }
           return true;
         }
 #endif
@@ -511,10 +513,9 @@ namespace boost
 
 #ifdef BOOST_THREAD_USES_CHRONO
         template <class Duration>
-        bool try_join_until(const chrono::time_point<thread_detail::internal_clock_t, Duration>& t)
+        bool try_join_until(const chrono::time_point<chrono::steady_clock, Duration>& t)
         {
-          chrono::milliseconds rel_time= chrono::ceil<chrono::milliseconds>(t-thread_detail::internal_clock_t::now());
-          return do_try_join_for(rel_time.count());
+          return try_join_for(t - chrono::steady_clock::now());
         }
 #endif
 
@@ -527,16 +528,27 @@ namespace boost
 #if defined BOOST_THREAD_USES_DATETIME
         bool timed_join(const system_time& abs_time)
         {
-          const detail::internal_timespec_timepoint ts = abs_time;
+          const detail::real_timespec_timepoint ts(abs_time);
+#if defined BOOST_THREAD_HAS_CONDATTR_SET_CLOCK_MONOTONIC
+          detail::timespec_duration d = ts - detail::real_timespec_clock::now();
+          d = (std::min)(d, detail::timespec_milliseconds(100));
+          while ( ! do_try_join_until(detail::internal_timespec_clock::now() + d) )
+          {
+            d = ts - detail::real_timespec_clock::now();
+            if ( d <= detail::timespec_duration::zero() ) return false;
+            d = (std::min)(d, detail::timespec_milliseconds(100));
+          }
+          return true;
+#else
           return do_try_join_until(ts);
+#endif
         }
 #endif
 #ifdef BOOST_THREAD_USES_CHRONO
         template <class Duration>
         bool try_join_until(const chrono::time_point<thread_detail::internal_clock_t, Duration>& t)
         {
-          const boost::detail::internal_timespec_timepoint ts = t;
-          return do_try_join_until(ts);
+          return do_try_join_until(boost::detail::internal_timespec_timepoint(t));
         }
 #endif // defined(BOOST_THREAD_PLATFORM_WIN32)
 
@@ -548,10 +560,23 @@ namespace boost
         inline bool timed_join(TimeDuration const& rel_time)
         {
 #if defined(BOOST_THREAD_PLATFORM_WIN32)
-            return do_try_join_for(rel_time.total_milliseconds());
+          return do_try_join_for(rel_time.total_milliseconds());
 #else
-            const boost::detail::internal_timespec_timepoint ts = boost::detail::internal_timespec_clock::now() + boost::detail::timespec_duration(rel_time);
-            return do_try_join_until(ts);
+          detail::timespec_duration d(rel_time);
+          if ( d < detail::timespec_duration::zero() ) return false; // d == zero() is valid
+#if defined(CLOCK_MONOTONIC) && !defined BOOST_THREAD_HAS_CONDATTR_SET_CLOCK_MONOTONIC
+          const detail::mono_timespec_timepoint& ts = detail::mono_timespec_clock::now() + d;
+          d = (std::min)(d, detail::timespec_milliseconds(100));
+          while ( ! do_try_join_until(detail::internal_timespec_clock::now() + d) )
+          {
+            d = ts - detail::mono_timespec_clock::now();
+            if ( d <= detail::timespec_duration::zero() ) return false;
+            d = (std::min)(d, detail::timespec_milliseconds(100));
+          }
+          return true;
+#else
+          return do_try_join_until(detail::internal_timespec_clock::now() + d);
+#endif
 #endif
         }
 #endif

--- a/include/boost/thread/detail/thread.hpp
+++ b/include/boost/thread/detail/thread.hpp
@@ -506,10 +506,20 @@ namespace boost
         bool do_try_join_for_noexcept(uintmax_t milli, bool& res);
         inline bool do_try_join_for(uintmax_t milli);
     public:
-        bool timed_join(const system_time& abs_time);
-        //{
-        //  return do_try_join_for(get_milliseconds_until(wait_until));
-        //}
+#if defined BOOST_THREAD_USES_DATETIME
+        bool timed_join(const system_time& abs_time)
+        {
+          posix_time::time_duration d = abs_time - get_system_time();
+          d = (std::min)(d, posix_time::time_duration(posix_time::milliseconds(100)));
+          while ( ! do_try_join_for(d.total_milliseconds()) )
+          {
+            d = abs_time - get_system_time();
+            if ( d <= posix_time::milliseconds(0) ) return false;
+            d = (std::min)(d, posix_time::time_duration(posix_time::milliseconds(100)));
+          }
+          return true;
+        }
+#endif
 
 #ifdef BOOST_THREAD_USES_CHRONO
         template <class Duration>

--- a/include/boost/thread/future.hpp
+++ b/include/boost/thread/future.hpp
@@ -1398,7 +1398,7 @@ namespace boost
         future_status
         wait_for(const chrono::duration<Rep, Period>& rel_time) const
         {
-          return wait_until(thread_detail::internal_clock_t::now() + rel_time);
+          return wait_until(chrono::steady_clock::now() + rel_time);
 
         }
         template <class Clock, class Duration>

--- a/include/boost/thread/pthread/shared_mutex.hpp
+++ b/include/boost/thread/pthread/shared_mutex.hpp
@@ -236,7 +236,7 @@ namespace boost
         template <class Rep, class Period>
         bool try_lock_shared_for(const chrono::duration<Rep, Period>& rel_time)
         {
-          return try_lock_shared_until(thread_detail::internal_clock_t::now() + rel_time);
+          return try_lock_shared_until(chrono::steady_clock::now() + rel_time);
         }
         template <class Clock, class Duration>
         bool try_lock_shared_until(const chrono::time_point<Clock, Duration>& abs_time)
@@ -336,7 +336,7 @@ namespace boost
         template <class Rep, class Period>
         bool try_lock_for(const chrono::duration<Rep, Period>& rel_time)
         {
-          return try_lock_until(thread_detail::internal_clock_t::now() + rel_time);
+          return try_lock_until(chrono::steady_clock::now() + rel_time);
         }
         template <class Clock, class Duration>
         bool try_lock_until(const chrono::time_point<Clock, Duration>& abs_time)
@@ -440,7 +440,7 @@ namespace boost
         template <class Rep, class Period>
         bool try_lock_upgrade_for(const chrono::duration<Rep, Period>& rel_time)
         {
-          return try_lock_upgrade_until(thread_detail::internal_clock_t::now() + rel_time);
+          return try_lock_upgrade_until(chrono::steady_clock::now() + rel_time);
         }
         template <class Clock, class Duration>
         bool try_lock_upgrade_until(const chrono::time_point<Clock, Duration>& abs_time)
@@ -548,8 +548,7 @@ namespace boost
         try_unlock_upgrade_and_lock_for(
                                 const chrono::duration<Rep, Period>& rel_time)
         {
-          return try_unlock_upgrade_and_lock_until(
-              thread_detail::internal_clock_t::now() + rel_time);
+          return try_unlock_upgrade_and_lock_until(chrono::steady_clock::now() + rel_time);
         }
         template <class Clock, class Duration>
         bool
@@ -613,8 +612,7 @@ namespace boost
             try_unlock_shared_and_lock_for(
                                 const chrono::duration<Rep, Period>& rel_time)
         {
-          return try_unlock_shared_and_lock_until(
-              thread_detail::internal_clock_t::now() + rel_time);
+          return try_unlock_shared_and_lock_until(chrono::steady_clock::now() + rel_time);
         }
         template <class Clock, class Duration>
             bool
@@ -677,8 +675,7 @@ namespace boost
             try_unlock_shared_and_lock_upgrade_for(
                                 const chrono::duration<Rep, Period>& rel_time)
         {
-          return try_unlock_shared_and_lock_upgrade_until(
-              thread_detail::internal_clock_t::now() + rel_time);
+          return try_unlock_shared_and_lock_upgrade_until(chrono::steady_clock::now() + rel_time);
         }
         template <class Clock, class Duration>
             bool

--- a/include/boost/thread/pthread/timespec.hpp
+++ b/include/boost/thread/pthread/timespec.hpp
@@ -216,11 +216,11 @@ namespace boost
     explicit mono_timespec_timepoint(boost::intmax_t const& ns) : value(ns_to_timespec(ns)) {}
 
 #if defined BOOST_THREAD_USES_DATETIME
+    // fixme: delete this function once it's no longer being used because it's
+    // not a valid way to convert from system time to steady time
     inline mono_timespec_timepoint(boost::system_time const& abs_time);
 #endif
 #if defined BOOST_THREAD_USES_CHRONO
-    template <class Duration>
-    inline mono_timespec_timepoint(chrono::time_point<chrono::system_clock, Duration> const& abs_time);
     template <class Duration>
     inline mono_timespec_timepoint(chrono::time_point<chrono::steady_clock, Duration> const& abs_time);
 #endif
@@ -273,6 +273,8 @@ namespace boost
 
   struct mono_timespec_clock
   {
+    // fixme: add support for mono_timespec_clock::now() on MAC OS X using code from
+    // https://github.com/boostorg/chrono/blob/develop/include/boost/chrono/detail/inlined/mac/chrono.hpp
     static inline mono_timespec_timepoint now()
     {
       timespec ts;
@@ -287,6 +289,8 @@ namespace boost
   };
 
 #if defined BOOST_THREAD_USES_DATETIME
+  // fixme: delete this function once it's no longer being used because it's
+  // not a valid way to convert from system time to steady time
   mono_timespec_timepoint::mono_timespec_timepoint(boost::system_time const& abs_time)
   {
     boost::posix_time::time_duration const since_now = abs_time - boost::get_system_time();
@@ -294,13 +298,6 @@ namespace boost
   }
 #endif
 #if defined BOOST_THREAD_USES_CHRONO
-  template <class Duration>
-  mono_timespec_timepoint::mono_timespec_timepoint(chrono::time_point<chrono::system_clock, Duration> const& abs_time)
-  {
-    typedef typename common_type<Duration, typename chrono::system_clock::duration>::type CD;
-    CD since_now = abs_time - chrono::system_clock::now();
-    value = (mono_timespec_clock::now() + timespec_duration(since_now)).get();
-  }
   template <class Duration>
   mono_timespec_timepoint::mono_timespec_timepoint(chrono::time_point<chrono::steady_clock, Duration> const& abs_time)
   {

--- a/include/boost/thread/v2/shared_mutex.hpp
+++ b/include/boost/thread/v2/shared_mutex.hpp
@@ -197,7 +197,7 @@ namespace boost {
       template <class Rep, class Period>
       bool try_lock_for(const boost::chrono::duration<Rep, Period>& rel_time)
       {
-        return try_lock_until(thread_detail::internal_clock_t::now() + rel_time);
+        return try_lock_until(chrono::steady_clock::now() + rel_time);
       }
       template <class Clock, class Duration>
       bool
@@ -214,8 +214,7 @@ namespace boost {
       bool
       try_lock_shared_for(const boost::chrono::duration<Rep, Period>& rel_time)
       {
-        return try_lock_shared_until(thread_detail::internal_clock_t::now() +
-            rel_time);
+        return try_lock_shared_until(chrono::steady_clock::now() + rel_time);
       }
       template <class Clock, class Duration>
       bool
@@ -401,7 +400,7 @@ namespace boost {
       template <class Rep, class Period>
       bool try_lock_for(const boost::chrono::duration<Rep, Period>& rel_time)
       {
-        return try_lock_until(thread_detail::internal_clock_t::now() + rel_time);
+        return try_lock_until(chrono::steady_clock::now() + rel_time);
       }
       template <class Clock, class Duration>
       bool
@@ -417,8 +416,7 @@ namespace boost {
       bool
       try_lock_shared_for(const boost::chrono::duration<Rep, Period>& rel_time)
       {
-        return try_lock_shared_until(thread_detail::internal_clock_t::now() +
-            rel_time);
+        return try_lock_shared_until(chrono::steady_clock::now() + rel_time);
       }
       template <class Clock, class Duration>
       bool
@@ -435,8 +433,7 @@ namespace boost {
       try_lock_upgrade_for(
           const boost::chrono::duration<Rep, Period>& rel_time)
       {
-        return try_lock_upgrade_until(thread_detail::internal_clock_t::now() +
-            rel_time);
+        return try_lock_upgrade_until(chrono::steady_clock::now() + rel_time);
       }
       template <class Clock, class Duration>
       bool
@@ -452,8 +449,7 @@ namespace boost {
       try_unlock_shared_and_lock_for(
           const boost::chrono::duration<Rep, Period>& rel_time)
       {
-        return try_unlock_shared_and_lock_until(
-            thread_detail::internal_clock_t::now() + rel_time);
+        return try_unlock_shared_and_lock_until(chrono::steady_clock::now() + rel_time);
       }
       template <class Clock, class Duration>
       bool
@@ -469,8 +465,7 @@ namespace boost {
       try_unlock_shared_and_lock_upgrade_for(
           const boost::chrono::duration<Rep, Period>& rel_time)
       {
-        return try_unlock_shared_and_lock_upgrade_until(
-            thread_detail::internal_clock_t::now() + rel_time);
+        return try_unlock_shared_and_lock_upgrade_until(chrono::steady_clock::now() + rel_time);
       }
       template <class Clock, class Duration>
       bool
@@ -487,8 +482,7 @@ namespace boost {
       try_unlock_upgrade_and_lock_for(
           const boost::chrono::duration<Rep, Period>& rel_time)
       {
-        return try_unlock_upgrade_and_lock_until(
-            thread_detail::internal_clock_t::now() + rel_time);
+        return try_unlock_upgrade_and_lock_until(chrono::steady_clock::now() + rel_time);
       }
       template <class Clock, class Duration>
       bool

--- a/src/win32/thread.cpp
+++ b/src/win32/thread.cpp
@@ -459,12 +459,6 @@ namespace boost
         }
     }
 
-#if defined BOOST_THREAD_USES_DATETIME
-    bool thread::timed_join(boost::system_time const& wait_until)
-    {
-      return do_try_join_for(boost::detail::get_milliseconds_until(wait_until));
-    }
-#endif
     bool thread::do_try_join_for_noexcept(uintmax_t milli, bool& res)
     {
       detail::thread_data_ptr local_thread_info=(get_thread_info)();


### PR DESCRIPTION
Here are the test results with this PR. try_join_*() and timed_join() now work correctly on both Linux and Windows.

[linux_results_austin_no_monotonic.txt](https://github.com/boostorg/thread/files/1322217/linux_results_austin_no_monotonic.txt)
[linux_results_austin_yes_monotonic.txt](https://github.com/boostorg/thread/files/1322218/linux_results_austin_yes_monotonic.txt)
[windows_results_austin_no_monotonic.txt](https://github.com/boostorg/thread/files/1322216/windows_results_austin_no_monotonic.txt)