### PR TITLE
Auto-detection of <threadapi> based on <target-os>

### DIFF
--- a/build/Jamfile.v2
+++ b/build/Jamfile.v2
@@ -37,7 +37,7 @@ import feature ;
 import indirect ;
 import path ;
 import configure ; 
-import property-set ;
+import threadapi ;
 
 project boost/thread
     : source-location ../src
@@ -130,9 +130,9 @@ project boost/thread
         <target-os>windows:<define>WIN32_LEAN_AND_MEAN
         <target-os>windows:<define>BOOST_USE_WINDOWS_H
         
-        <conditional>@detect_threadapi
+        <conditional>@threadapi.detect
 
-    # : default-build <threading>multi      
+    # : default-build <threading>multi
     : usage-requirements  # pass these requirement to dependents (i.e. users)
       #<link>static:<define>BOOST_THREAD_STATIC_LINK=1
       #<link>shared:<define>BOOST_THREAD_DYN_LINK=1
@@ -144,23 +144,8 @@ project boost/thread
       <library>/boost/system//boost_system
     ;
 
-local rule default_threadapi ( property-set )
-{
-    local api = pthread ;
-    if [ $(property-set).get <target-os> ] = windows { api = win32 ; }
-    return $(api) ;
-}
+feature.feature threadapi : pthread win32 : optional propagated ;
 
-feature.feature threadapi : native pthread win32 : propagated ;
-
-rule detect_threadapi ( properties * )
-{
-    local property-set = [ property-set.create $(properties) ] ;
-    local api = [ $(property-set).get <threadapi> ] ;
-    if $(api) = native { api = [ default_threadapi $(property-set) ] ; }
-    return <threadapi>$(api) ;
-}
-    
 exe has_atomic_flag_lockfree : ../build/has_atomic_flag_lockfree_test.cpp ; 
 
 rule tag ( name : type ? : property-set )
@@ -172,7 +157,7 @@ rule tag ( name : type ? : property-set )
         local api = [ $(property-set).get <threadapi> ] ;
 
         # non native api gets additional tag
-        if $(api) != [ default_threadapi $(property-set) ] {
+        if $(api) != [ threadapi.get-default $(property-set) ] {
             result = $(result)_$(api) ;
         }
     }

--- a/build/Jamfile.v2
+++ b/build/Jamfile.v2
@@ -17,7 +17,7 @@
 # PTW32_INCLUDE and PTW32_LIB respectively. You can specify these
 # paths in site-config.jam, user-config.jam or in the environment.
 # A new feature is provided to request a specific API:
-# <threadapi>win32 and <threadapi)pthread.
+# <threadapi>win32 and <threadapi>pthread.
 #
 # The naming of the resulting libraries is mostly the same for the
 # variant native to the build platform, i.e.
@@ -33,7 +33,6 @@
 #########################################################################
 
 import os ;
-import feature ;
 import indirect ;
 import path ;
 import configure ; 
@@ -143,8 +142,6 @@ project boost/thread
       #<define>BOOST_THREAD_DONT_PROVIDE_INTERRUPTIONS
       <library>/boost/system//boost_system
     ;
-
-feature.feature threadapi : pthread win32 : optional propagated ;
 
 exe has_atomic_flag_lockfree : ../build/has_atomic_flag_lockfree_test.cpp ; 
 

--- a/build/Jamfile.v2
+++ b/build/Jamfile.v2
@@ -142,6 +142,8 @@ project boost/thread
       #<define>BOOST_SYSTEM_NO_DEPRECATED
       #<define>BOOST_THREAD_DONT_PROVIDE_INTERRUPTIONS
       <library>/boost/system//boost_system
+
+      <conditional>@detect_threadapi
     ;
 
 local rule default_threadapi ( property-set )

--- a/build/Jamfile.v2
+++ b/build/Jamfile.v2
@@ -142,8 +142,6 @@ project boost/thread
       #<define>BOOST_SYSTEM_NO_DEPRECATED
       #<define>BOOST_THREAD_DONT_PROVIDE_INTERRUPTIONS
       <library>/boost/system//boost_system
-
-      <conditional>@detect_threadapi
     ;
 
 local rule default_threadapi ( property-set )

--- a/build/Jamfile.v2
+++ b/build/Jamfile.v2
@@ -37,6 +37,7 @@ import feature ;
 import indirect ;
 import path ;
 import configure ; 
+import property-set ;
 
 project boost/thread
     : source-location ../src
@@ -128,8 +129,10 @@ project boost/thread
 
         <target-os>windows:<define>WIN32_LEAN_AND_MEAN
         <target-os>windows:<define>BOOST_USE_WINDOWS_H
+        
+        <conditional>@detect_threadapi
 
-    # : default-build <threading>multi
+    # : default-build <threading>multi      
     : usage-requirements  # pass these requirement to dependents (i.e. users)
       #<link>static:<define>BOOST_THREAD_STATIC_LINK=1
       #<link>shared:<define>BOOST_THREAD_DYN_LINK=1
@@ -141,16 +144,23 @@ project boost/thread
       <library>/boost/system//boost_system
     ;
 
-local rule default_threadapi ( )
+local rule default_threadapi ( property-set )
 {
     local api = pthread ;
-    if [ os.name ] = "NT" { api = win32 ; }
+    if [ $(property-set).get <target-os> ] = windows { api = win32 ; }
     return $(api) ;
 }
 
-feature.feature threadapi : pthread win32 : propagated ;
-feature.set-default threadapi : [ default_threadapi ] ;
+feature.feature threadapi : native pthread win32 : propagated ;
 
+rule detect_threadapi ( properties * )
+{
+    local property-set = [ property-set.create $(properties) ] ;
+    local api = [ $(property-set).get <threadapi> ] ;
+    if $(api) = native { api = [ default_threadapi $(property-set) ] ; }
+    return <threadapi>$(api) ;
+}
+    
 exe has_atomic_flag_lockfree : ../build/has_atomic_flag_lockfree_test.cpp ; 
 
 rule tag ( name : type ? : property-set )
@@ -162,7 +172,7 @@ rule tag ( name : type ? : property-set )
         local api = [ $(property-set).get <threadapi> ] ;
 
         # non native api gets additional tag
-        if $(api) != [ default_threadapi ] {
+        if $(api) != [ default_threadapi $(property-set) ] {
             result = $(result)_$(api) ;
         }
     }

--- a/build/threadapi.jam
+++ b/build/threadapi.jam
@@ -1,4 +1,7 @@
 import property-set ;
+import feature : feature ;
+
+feature threadapi : win32 pthread : optional propagated ;
 
 rule get-default ( property-set )
 {

--- a/build/threadapi.jam
+++ b/build/threadapi.jam
@@ -1,0 +1,16 @@
+import property-set ;
+
+rule get-default ( property-set )
+{
+	local api = pthread ;
+	if [ $(property-set).get <target-os> ] = windows { api = win32 ; }
+	return $(api) ;
+}
+
+rule detect ( properties * )
+{
+	local ps = [ property-set.create $(properties) ] ;
+	local api = [ $(ps).get <threadapi> ] ;
+	if ! $(api) { api = [ get-default $(ps) ] ; }
+	return <threadapi>$(api) ;
+}

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -18,7 +18,7 @@
 
 # bring in rules for testing
 import testing ;
-import property-set ;
+import threadapi ;
 
 project
     : requirements
@@ -107,23 +107,8 @@ project
         <toolset>msvc:<cxxflags>/wd4512
         <toolset>msvc:<cxxflags>/wd6246
 
-        <conditional>@detect_threadapi
+        <conditional>@threadapi.detect
     ;
-
-local rule default_threadapi ( property-set )
-{
-    local api = pthread ;
-    if [ $(property-set).get <target-os> ] = windows { api = win32 ; }
-    return $(api) ;
-}
-
-rule detect_threadapi ( properties * )
-{
-    local property-set = [ property-set.create $(properties) ] ;
-    local api = [ $(property-set).get <threadapi> ] ;
-    if $(api) = native { api = [ default_threadapi $(property-set) ] ; }
-    return <threadapi>$(api) ;
-}
 
 rule thread-run ( sources )
 {

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -18,6 +18,7 @@
 
 # bring in rules for testing
 import testing ;
+import property-set ;
 
 project
     : requirements
@@ -105,7 +106,24 @@ project
         <toolset>msvc:<cxxflags>/wd4100
         <toolset>msvc:<cxxflags>/wd4512
         <toolset>msvc:<cxxflags>/wd6246
+
+        <conditional>@detect_threadapi
     ;
+
+local rule default_threadapi ( property-set )
+{
+    local api = pthread ;
+    if [ $(property-set).get <target-os> ] = windows { api = win32 ; }
+    return $(api) ;
+}
+
+rule detect_threadapi ( properties * )
+{
+    local property-set = [ property-set.create $(properties) ] ;
+    local api = [ $(property-set).get <threadapi> ] ;
+    if $(api) = native { api = [ default_threadapi $(property-set) ] ; }
+    return <threadapi>$(api) ;
+}
 
 rule thread-run ( sources )
 {


### PR DESCRIPTION
Currently Boost.Thread selects the default `<threadapi>` value based on host system name. How to make it dependent of `<target-os>` was discussed in tickets [#3393](https://svn.boost.org/trac10/ticket/3393) and [#7706](https://svn.boost.org/trac10/ticket/7706). My solution is somewhat similar to [this proposal](https://svn.boost.org/trac10/attachment/ticket/3393/threadapi2.diff) but also allows `<threadapi>` to be specified in build request and improves the `<tag>` feature behavior:

* `<threadapi>` has an additional value `native` which is the default.
  If build request doesn't specify other value, it is replaced
  either with "pthread" or "win32" depending on `<target-os>`.
* `<tag>` modifies name of generated library only if resulting `<threadapi>`
  value differs from one that would have been chosen to replace `native`
  according to `<target-os>.`