### PR TITLE
fix or silence (msvc) compiler warnings about constant conditional ex…

### DIFF
--- a/example/ba_externallly_locked.cpp
+++ b/example/ba_externallly_locked.cpp
@@ -12,6 +12,10 @@
 #include <boost/thread/lock_types.hpp>
 #include <iostream>
 
+#ifdef BOOST_MSVC
+# pragma warning(disable: 4355) // 'this' : used in base member initializer list
+#endif
+
 using namespace boost;
 
 class BankAccount

--- a/example/future_fallback_to.cpp
+++ b/example/future_fallback_to.cpp
@@ -21,6 +21,10 @@
 
 #if defined BOOST_THREAD_PROVIDES_FUTURE_CONTINUATION
 
+#ifdef BOOST_MSVC
+#pragma warning(disable: 4127) // conditional expression is constant
+#endif
+
 int p1_ex()
 {
   BOOST_THREAD_LOG << "P1" << BOOST_THREAD_END_LOG;

--- a/example/future_then.cpp
+++ b/example/future_then.cpp
@@ -20,6 +20,10 @@
 #include <iostream>
 #if defined BOOST_THREAD_PROVIDES_FUTURE_CONTINUATION
 
+#ifdef BOOST_MSVC
+#pragma warning(disable: 4127) // conditional expression is constant
+#endif
+
 int p1()
 {
   BOOST_THREAD_LOG << "P1" << BOOST_THREAD_END_LOG;

--- a/example/future_unwrap.cpp
+++ b/example/future_unwrap.cpp
@@ -20,6 +20,10 @@
 
 #if defined BOOST_THREAD_PROVIDES_FUTURE_UNWRAP
 
+#ifdef BOOST_MSVC
+#pragma warning(disable: 4127) // conditional expression is constant
+#endif
+
 int p1()
 {
   BOOST_THREAD_LOG << "P1" << BOOST_THREAD_END_LOG;

--- a/example/future_when_all.cpp
+++ b/example/future_when_all.cpp
@@ -21,6 +21,10 @@
 #include <string>
 #if defined BOOST_THREAD_PROVIDES_FUTURE_WHEN_ALL_WHEN_ANY
 
+#ifdef BOOST_MSVC
+#pragma warning(disable: 4127) // conditional expression is constant
+#endif
+
 int p1()
 {
   BOOST_THREAD_LOG

--- a/example/lambda_future.cpp
+++ b/example/lambda_future.cpp
@@ -22,6 +22,9 @@
 #if    defined BOOST_THREAD_PROVIDES_FUTURE_CONTINUATION \
   && ! defined BOOST_NO_CXX11_LAMBDAS && ! (defined BOOST_MSVC && _MSC_VER < 1700)
 
+#ifdef BOOST_MSVC
+#pragma warning(disable: 4127) // conditional expression is constant
+#endif
 
 int main()
 {

--- a/example/thread_pool.cpp
+++ b/example/thread_pool.cpp
@@ -18,6 +18,10 @@
 #include <boost/assert.hpp>
 #include <string>
 
+#ifdef BOOST_MSVC
+#pragma warning(disable: 4127) // conditional expression is constant
+#endif
+
 void p1()
 {
   BOOST_THREAD_LOG

--- a/example/user_scheduler.cpp
+++ b/example/user_scheduler.cpp
@@ -17,6 +17,10 @@
 #include <boost/thread/thread_only.hpp>
 #include <string>
 
+#ifdef BOOST_MSVC
+#pragma warning(disable: 4127) // conditional expression is constant
+#endif
+
 void p1()
 {
   BOOST_THREAD_LOG

--- a/include/boost/thread/detail/config.hpp
+++ b/include/boost/thread/detail/config.hpp
@@ -387,7 +387,7 @@
 
 // provided for backwards compatibility, since this
 // macro was used for several releases by mistake.
-#if defined(BOOST_THREAD_DYN_DLL) && ! defined BOOST_THREAD_DYN_LINK
+#if defined(BOOST_THREAD_DYN_DLL) && ! defined(BOOST_THREAD_DYN_LINK)
 # define BOOST_THREAD_DYN_LINK
 #endif
 

--- a/include/boost/thread/executors/scheduler.hpp
+++ b/include/boost/thread/executors/scheduler.hpp
@@ -16,6 +16,11 @@
 
 #include <boost/config/abi_prefix.hpp>
 
+#if defined(BOOST_MSVC)
+# pragma warning(push)
+# pragma warning(disable: 4355) // 'this' : used in base member initializer list
+#endif
+
 namespace boost
 {
   namespace executors
@@ -266,6 +271,10 @@ namespace boost
   using executors::at_executor;
   using executors::scheduler;
 }
+
+#if defined(BOOST_MSVC)
+# pragma warning(pop)
+#endif
 
 #include <boost/config/abi_suffix.hpp>
 

--- a/include/boost/thread/executors/scheduling_adaptor.hpp
+++ b/include/boost/thread/executors/scheduling_adaptor.hpp
@@ -10,6 +10,11 @@
 
 #include <boost/thread/executors/detail/scheduled_executor_base.hpp>
 
+#if defined(BOOST_MSVC)
+# pragma warning(push)
+# pragma warning(disable: 4355) // 'this' : used in base member initializer list
+#endif
+
 namespace boost
 {
 namespace executors
@@ -49,4 +54,9 @@ namespace executors
   using executors::scheduling_adaptor;
 
 } //end boost
+
+#if defined(BOOST_MSVC)
+# pragma warning(pop)
+#endif
+
 #endif

--- a/include/boost/thread/executors/serial_executor.hpp
+++ b/include/boost/thread/executors/serial_executor.hpp
@@ -20,6 +20,11 @@
 
 #include <boost/config/abi_prefix.hpp>
 
+#if defined(BOOST_MSVC)
+# pragma warning(push)
+# pragma warning(disable: 4355) // 'this' : used in base member initializer list
+#endif
+
 namespace boost
 {
 namespace executors
@@ -210,6 +215,10 @@ namespace executors
 }
 using executors::serial_executor;
 }
+
+#if defined(BOOST_MSVC)
+# pragma warning(pop)
+#endif
 
 #include <boost/config/abi_suffix.hpp>
 

--- a/include/boost/thread/once.hpp
+++ b/include/boost/thread/once.hpp
@@ -10,6 +10,12 @@
 //  http://www.boost.org/LICENSE_1_0.txt)
 
 #include <boost/thread/detail/config.hpp>
+
+#ifdef BOOST_MSVC
+# pragma warning(push)
+# pragma warning(disable: 4702) // unreachable code
+#endif
+
 #include <boost/thread/detail/platform.hpp>
 #if defined(BOOST_THREAD_PLATFORM_WIN32)
 #include <boost/thread/win32/once.hpp>
@@ -40,5 +46,9 @@ inline void call_once(Function func,once_flag& flag)
 }
 
 #include <boost/config/abi_suffix.hpp>
+
+#ifdef BOOST_MSVC
+# pragma warning(pop)
+#endif
 
 #endif

--- a/test/sync/conditions/condition_variable/wait_until_pred_pass.cpp
+++ b/test/sync/conditions/condition_variable/wait_until_pred_pass.cpp
@@ -74,6 +74,7 @@ void f()
     Clock::time_point t0 = Clock::now();
     Clock::time_point t = t0 + Clock::duration(250);
     bool r = cv.wait_until(lk, t, Pred(test2));
+    (void)r;
     Clock::time_point t1 = Clock::now();
     if (runs == 0)
     {

--- a/test/sync/futures/future/get_or_pass.cpp
+++ b/test/sync/futures/future/get_or_pass.cpp
@@ -22,6 +22,10 @@
 
 #if defined BOOST_THREAD_USES_CHRONO
 
+#ifdef BOOST_MSVC
+#pragma warning(disable: 4127) // conditional expression is constant
+#endif
+
 namespace boost
 {
 template <typename T>

--- a/test/sync/futures/future/get_pass.cpp
+++ b/test/sync/futures/future/get_pass.cpp
@@ -32,6 +32,10 @@
 
 #if defined BOOST_THREAD_USES_CHRONO
 
+#ifdef BOOST_MSVC
+#pragma warning(disable: 4127) // conditional expression is constant
+#endif
+
 namespace boost
 {
 template <typename T>

--- a/test/sync/futures/future/then_deferred_pass.cpp
+++ b/test/sync/futures/future/then_deferred_pass.cpp
@@ -21,6 +21,9 @@
 
 #if defined BOOST_THREAD_PROVIDES_FUTURE_CONTINUATION
 
+#ifdef BOOST_MSVC
+#pragma warning(disable: 4127) // conditional expression is constant
+#endif
 
 int p1()
 {

--- a/test/sync/futures/future/then_executor_pass.cpp
+++ b/test/sync/futures/future/then_executor_pass.cpp
@@ -24,6 +24,9 @@
 
 #if defined BOOST_THREAD_PROVIDES_FUTURE_CONTINUATION
 
+#ifdef BOOST_MSVC
+#pragma warning(disable: 4127) // conditional expression is constant
+#endif
 
 int p1()
 {

--- a/test/sync/futures/future/then_pass.cpp
+++ b/test/sync/futures/future/then_pass.cpp
@@ -20,6 +20,9 @@
 
 #if defined BOOST_THREAD_PROVIDES_FUTURE_CONTINUATION
 
+#ifdef BOOST_MSVC
+#pragma warning(disable: 4127) // conditional expression is constant
+#endif
 
 int p1()
 {

--- a/test/sync/futures/future/wait_for_pass.cpp
+++ b/test/sync/futures/future/wait_for_pass.cpp
@@ -32,6 +32,10 @@
 
 #if defined BOOST_THREAD_USES_CHRONO
 
+#ifdef BOOST_MSVC
+#pragma warning(disable: 4127) // conditional expression is constant
+#endif
+
 typedef boost::chrono::milliseconds ms;
 
 namespace boost

--- a/test/sync/futures/future/wait_pass.cpp
+++ b/test/sync/futures/future/wait_pass.cpp
@@ -32,6 +32,10 @@
 
 #if defined BOOST_THREAD_USES_CHRONO
 
+#ifdef BOOST_MSVC
+#pragma warning(disable: 4127) // conditional expression is constant
+#endif
+
 typedef boost::chrono::milliseconds ms;
 
 namespace boost

--- a/test/sync/futures/future/wait_until_pass.cpp
+++ b/test/sync/futures/future/wait_until_pass.cpp
@@ -33,6 +33,10 @@
 
 #if defined BOOST_THREAD_USES_CHRONO
 
+#ifdef BOOST_MSVC
+#pragma warning(disable: 4127) // conditional expression is constant
+#endif
+
 typedef boost::chrono::milliseconds ms;
 
 namespace boost

--- a/test/sync/futures/promise/set_value_const_pass.cpp
+++ b/test/sync/futures/promise/set_value_const_pass.cpp
@@ -24,6 +24,10 @@
 #include <boost/detail/lightweight_test.hpp>
 #include <boost/static_assert.hpp>
 
+#ifdef BOOST_MSVC
+# pragma warning(disable: 4702) // unreachable code
+#endif
+
 struct A
 {
   A()

--- a/test/sync/futures/shared_future/then_executor_pass.cpp
+++ b/test/sync/futures/shared_future/then_executor_pass.cpp
@@ -23,6 +23,10 @@
 
 #if defined BOOST_THREAD_PROVIDES_FUTURE_CONTINUATION
 
+#ifdef BOOST_MSVC
+#pragma warning(disable: 4127) // conditional expression is constant
+#endif
+
 int p1()
 {
   BOOST_THREAD_LOG << "p1 < " << BOOST_THREAD_END_LOG;

--- a/test/sync/futures/shared_future/then_pass.cpp
+++ b/test/sync/futures/shared_future/then_pass.cpp
@@ -20,6 +20,10 @@
 
 #if defined BOOST_THREAD_PROVIDES_FUTURE_CONTINUATION
 
+#ifdef BOOST_MSVC
+#pragma warning(disable: 4127) // conditional expression is constant
+#endif
+
 int p1()
 {
   BOOST_THREAD_LOG << "p1 < " << BOOST_THREAD_END_LOG;

--- a/test/sync/futures/shared_future/wait_for_pass.cpp
+++ b/test/sync/futures/shared_future/wait_for_pass.cpp
@@ -32,6 +32,10 @@
 
 #if defined BOOST_THREAD_USES_CHRONO
 
+#ifdef BOOST_MSVC
+#pragma warning(disable: 4127) // conditional expression is constant
+#endif
+
 typedef boost::chrono::milliseconds ms;
 
 namespace boost

--- a/test/sync/futures/shared_future/wait_pass.cpp
+++ b/test/sync/futures/shared_future/wait_pass.cpp
@@ -32,6 +32,10 @@
 
 #if defined BOOST_THREAD_USES_CHRONO
 
+#ifdef BOOST_MSVC
+#pragma warning(disable: 4127) // conditional expression is constant
+#endif
+
 typedef boost::chrono::milliseconds ms;
 
 namespace boost

--- a/test/sync/futures/shared_future/wait_until_pass.cpp
+++ b/test/sync/futures/shared_future/wait_until_pass.cpp
@@ -33,6 +33,10 @@
 
 #if defined BOOST_THREAD_USES_CHRONO
 
+#ifdef BOOST_MSVC
+#pragma warning(disable: 4127) // conditional expression is constant
+#endif
+
 typedef boost::chrono::milliseconds ms;
 
 namespace boost

--- a/test/sync/futures/when_all/iterators_pass.cpp
+++ b/test/sync/futures/when_all/iterators_pass.cpp
@@ -31,6 +31,10 @@
 #include <boost/detail/lightweight_test.hpp>
 #include <stdexcept>
 
+#ifdef BOOST_MSVC
+#pragma warning(disable: 4127) // conditional expression is constant
+#endif
+
 int p1()
 {
   return 123;

--- a/test/sync/futures/when_all/one_pass.cpp
+++ b/test/sync/futures/when_all/one_pass.cpp
@@ -30,6 +30,10 @@
 #include <boost/detail/lightweight_test.hpp>
 #include <stdexcept>
 
+#ifdef BOOST_MSVC
+#pragma warning(disable: 4127) // conditional expression is constant
+#endif
+
 int p1()
 {
   return 123;

--- a/test/sync/futures/when_all/variadic_pass.cpp
+++ b/test/sync/futures/when_all/variadic_pass.cpp
@@ -30,6 +30,10 @@
 #include <boost/detail/lightweight_test.hpp>
 #include <stdexcept>
 
+#ifdef BOOST_MSVC
+#pragma warning(disable: 4127) // conditional expression is constant
+#endif
+
 int p1()
 {
   boost::this_thread::sleep_for(boost::chrono::milliseconds(100));

--- a/test/sync/futures/when_any/iterators_pass.cpp
+++ b/test/sync/futures/when_any/iterators_pass.cpp
@@ -31,6 +31,10 @@
 #include <boost/detail/lightweight_test.hpp>
 #include <stdexcept>
 
+#ifdef BOOST_MSVC
+#pragma warning(disable: 4127) // conditional expression is constant
+#endif
+
 int p1()
 {
   return 123;

--- a/test/sync/futures/when_any/one_pass.cpp
+++ b/test/sync/futures/when_any/one_pass.cpp
@@ -28,6 +28,10 @@
 #include <boost/thread/future.hpp>
 #include <boost/detail/lightweight_test.hpp>
 
+#ifdef BOOST_MSVC
+#pragma warning(disable: 4127) // conditional expression is constant
+#endif
+
 int p1()
 {
   return 123;

--- a/test/sync/futures/when_any/variadic_pass.cpp
+++ b/test/sync/futures/when_any/variadic_pass.cpp
@@ -29,6 +29,10 @@
 #include <boost/detail/lightweight_test.hpp>
 #include <stdexcept>
 
+#ifdef BOOST_MSVC
+#pragma warning(disable: 4127) // conditional expression is constant
+#endif
+
 int p1()
 {
   return 123;

--- a/test/sync/mutual_exclusion/sync_pq/pq_multi_thread_pass.cpp
+++ b/test/sync/mutual_exclusion/sync_pq/pq_multi_thread_pass.cpp
@@ -21,6 +21,10 @@
 
 #include <boost/core/lightweight_test.hpp>
 
+#ifdef BOOST_MSVC
+#pragma warning(disable: 4127) // conditional expression is constant
+#endif
+
 typedef boost::concurrent::sync_priority_queue<int> sync_pq;
 
 int call_pull(sync_pq* q, boost::barrier* go)

--- a/test/test_5542_1.cpp
+++ b/test/test_5542_1.cpp
@@ -31,7 +31,7 @@ public:
 
     void processQueue(unsigned N)
     {
-        float ms = N * 1e3;
+        unsigned ms = N * 1000;
         boost::posix_time::milliseconds workTime(ms);
 
 //        std::cout << "Worker: started, will work for "

--- a/test/test_futures.cpp
+++ b/test/test_futures.cpp
@@ -19,6 +19,10 @@
 
 #include <boost/test/unit_test.hpp>
 
+#ifdef BOOST_MSVC
+# pragma warning(disable: 4267) // conversion from ... to ..., possible loss of data
+#endif
+
 #ifndef BOOST_NO_CXX11_RVALUE_REFERENCES
     template<typename T>
     typename boost::remove_reference<T>::type&& cast_to_rval(T&& t)


### PR DESCRIPTION
…pressions, unused parameters, narrowing, unreachable code, use of 'this' in base member initializations, and some other minor stuff

Signed-off-by: Daniela Engert <dani@ngrt.de>