### PR TITLE
Fix shared_mutex and future time jump tests

### DIFF
--- a/include/boost/thread/future.hpp
+++ b/include/boost/thread/future.hpp
@@ -191,6 +191,12 @@ namespace boost
             virtual ~shared_state_base()
             {
             }
+
+            inline bool is_done()
+            {
+                return done;
+            }
+
             executor_ptr_type get_executor()
             {
               return ex;
@@ -348,10 +354,7 @@ namespace boost
                 is_deferred_=false;
                 execute(lk);
               }
-              while(!done)
-              {
-                  waiters.wait(lk);
-              }
+              waiters.wait(lk, boost::bind(&shared_state_base::is_done, boost::ref(*this)));
               if(rethrow && exception)
               {
                   boost::rethrow_exception(exception);
@@ -370,6 +373,17 @@ namespace boost
             }
 
 #if defined BOOST_THREAD_USES_DATETIME
+            template<typename Duration>
+            bool timed_wait(Duration const& rel_time)
+            {
+                boost::unique_lock<boost::mutex> lock(this->mutex);
+                if (is_deferred_)
+                    return false;
+
+                do_callback(lock);
+                return waiters.timed_wait(lock, rel_time, boost::bind(&shared_state_base::is_done, boost::ref(*this)));
+            }
+
             bool timed_wait_until(boost::system_time const& target_time)
             {
                 boost::unique_lock<boost::mutex> lock(this->mutex);
@@ -377,15 +391,7 @@ namespace boost
                     return false;
 
                 do_callback(lock);
-                while(!done)
-                {
-                    bool const success=waiters.timed_wait(lock,target_time);
-                    if(!success && !done)
-                    {
-                        return false;
-                    }
-                }
-                return true;
+                return waiters.timed_wait(lock, target_time, boost::bind(&shared_state_base::is_done, boost::ref(*this)));
             }
 #endif
 #ifdef BOOST_THREAD_USES_CHRONO
@@ -398,13 +404,9 @@ namespace boost
               if (is_deferred_)
                   return future_status::deferred;
               do_callback(lock);
-              while(!done)
+              if(!waiters.wait_until(lock, abs_time, boost::bind(&shared_state_base::is_done, boost::ref(*this))))
               {
-                  cv_status const st=waiters.wait_until(lock,abs_time);
-                  if(st==cv_status::timeout && !done)
-                  {
-                    return future_status::timeout;
-                  }
+                  return future_status::timeout;
               }
               return future_status::ready;
             }
@@ -899,10 +901,7 @@ namespace boost
             join();
 #elif defined BOOST_THREAD_ASYNC_FUTURE_WAITS
             unique_lock<boost::mutex> lk(this->mutex);
-            while(!this->done)
-            {
-              this->waiters.wait(lk);
-            }
+            this->waiters.wait(lk, boost::bind(&shared_state_base::is_done, boost::ref(*this)));
 #endif
           }
 
@@ -1452,7 +1451,11 @@ namespace boost
         template<typename Duration>
         bool timed_wait(Duration const& rel_time) const
         {
-            return timed_wait_until(boost::get_system_time()+rel_time);
+            if(!future_)
+            {
+                boost::throw_exception(future_uninitialized());
+            }
+            return future_->timed_wait(rel_time);
         }
 
         bool timed_wait_until(boost::system_time const& abs_time) const

--- a/include/boost/thread/pthread/mutex.hpp
+++ b/include/boost/thread/pthread/mutex.hpp
@@ -309,11 +309,11 @@ namespace boost
             while(is_locked)
             {
                 int const cond_res=pthread_cond_timedwait(&cond,&m,&timeout.getTs());
-                if(cond_res==ETIMEDOUT)
+                if(is_locked)
                 {
                     return false;
                 }
-                BOOST_ASSERT(!cond_res);
+                BOOST_ASSERT(!cond_res || cond_res==ETIMEDOUT);
             }
             is_locked=true;
             return true;

--- a/include/boost/thread/pthread/recursive_mutex.hpp
+++ b/include/boost/thread/pthread/recursive_mutex.hpp
@@ -350,11 +350,11 @@ namespace boost
             while(is_locked)
             {
                 int const cond_res=pthread_cond_timedwait(&cond,&m,&timeout.getTs());
-                if(cond_res==ETIMEDOUT)
+                if(is_locked)
                 {
                     return false;
                 }
-                BOOST_ASSERT(!cond_res);
+                BOOST_ASSERT(!cond_res || cond_res==ETIMEDOUT);
             }
             is_locked=true;
             ++count;

--- a/include/boost/thread/pthread/shared_mutex.hpp
+++ b/include/boost/thread/pthread/shared_mutex.hpp
@@ -9,6 +9,7 @@
 //  http://www.boost.org/LICENSE_1_0.txt)
 
 #include <boost/assert.hpp>
+#include <boost/bind.hpp>
 #include <boost/static_assert.hpp>
 #include <boost/thread/mutex.hpp>
 #include <boost/thread/condition_variable.hpp>
@@ -78,11 +79,6 @@ namespace boost
                 return ! (shared_count || exclusive);
             }
 
-            void exclusive_blocked (bool blocked)
-            {
-                exclusive_waiting_blocked = blocked;
-            }
-
             void lock ()
             {
                 exclusive = true;
@@ -99,35 +95,25 @@ namespace boost
                 return ! (exclusive || exclusive_waiting_blocked);
             }
 
-            bool more_shared () const
+            bool no_shared () const
             {
-                return shared_count > 0 ;
+                return shared_count==0;
             }
-            unsigned get_shared_count () const
+
+            bool one_shared () const
             {
-                return shared_count ;
+                return shared_count==1;
             }
-            unsigned  lock_shared ()
+
+            void lock_shared ()
             {
-                return ++shared_count;
+                ++shared_count;
             }
 
 
             void unlock_shared ()
             {
                 --shared_count;
-            }
-
-            bool unlock_shared_downgrades()
-            {
-                  if (upgrade) {
-                      upgrade=false;
-                      exclusive=true;
-                      return true;
-                  } else {
-                      exclusive_waiting_blocked=false;
-                      return false;
-                  }
             }
 
             void lock_upgrade ()
@@ -185,10 +171,7 @@ namespace boost
             boost::this_thread::disable_interruption do_not_disturb;
 #endif
             boost::unique_lock<boost::mutex> lk(state_change);
-            while(!state.can_lock_shared())
-            {
-                shared_cond.wait(lk);
-            }
+            shared_cond.wait(lk, boost::bind(&state_data::can_lock_shared, boost::ref(state)));
             state.lock_shared();
         }
 
@@ -211,13 +194,9 @@ namespace boost
             boost::this_thread::disable_interruption do_not_disturb;
 #endif
             boost::unique_lock<boost::mutex> lk(state_change);
-
-            while(!state.can_lock_shared())
+            if(!shared_cond.timed_wait(lk, timeout, boost::bind(&state_data::can_lock_shared, boost::ref(state))))
             {
-                if(!shared_cond.timed_wait(lk,timeout))
-                {
-                    return false;
-                }
+                return false;
             }
             state.lock_shared();
             return true;
@@ -226,7 +205,16 @@ namespace boost
         template<typename TimeDuration>
         bool timed_lock_shared(TimeDuration const & relative_time)
         {
-            return timed_lock_shared(get_system_time()+relative_time);
+#if defined BOOST_THREAD_PROVIDES_INTERRUPTIONS
+            boost::this_thread::disable_interruption do_not_disturb;
+#endif
+            boost::unique_lock<boost::mutex> lk(state_change);
+            if(!shared_cond.timed_wait(lk, relative_time, boost::bind(&state_data::can_lock_shared, boost::ref(state))))
+            {
+                return false;
+            }
+            state.lock_shared();
+            return true;
         }
 #endif
 #ifdef BOOST_THREAD_USES_CHRONO
@@ -242,14 +230,9 @@ namespace boost
           boost::this_thread::disable_interruption do_not_disturb;
 #endif
           boost::unique_lock<boost::mutex> lk(state_change);
-
-          while(!state.can_lock_shared())
-          //while(state.exclusive || state.exclusive_waiting_blocked)
+          if(!shared_cond.wait_until(lk, abs_time, boost::bind(&state_data::can_lock_shared, boost::ref(state))))
           {
-              if(cv_status::timeout==shared_cond.wait_until(lk,abs_time))
-              {
-                  return false;
-              }
+              return false;
           }
           state.lock_shared();
           return true;
@@ -260,11 +243,11 @@ namespace boost
             boost::unique_lock<boost::mutex> lk(state_change);
             state.assert_lock_shared();
             state.unlock_shared();
-            if (! state.more_shared())
+            if (state.no_shared())
             {
                 if (state.upgrade)
                 {
-                    // As there is a thread doing a unlock_upgrade_and_lock that is waiting for ! state.more_shared()
+                    // As there is a thread doing a unlock_upgrade_and_lock that is waiting for state.no_shared()
                     // avoid other threads to lock, lock_upgrade or lock_shared, so only this thread is notified.
                     state.upgrade=false;
                     state.exclusive=true;
@@ -286,12 +269,8 @@ namespace boost
             boost::this_thread::disable_interruption do_not_disturb;
 #endif
             boost::unique_lock<boost::mutex> lk(state_change);
-
-            while (state.shared_count || state.exclusive)
-            {
-                state.exclusive_waiting_blocked=true;
-                exclusive_cond.wait(lk);
-            }
+            state.exclusive_waiting_blocked=true;
+            exclusive_cond.wait(lk, boost::bind(&state_data::can_lock, boost::ref(state)));
             state.exclusive=true;
         }
 
@@ -302,20 +281,12 @@ namespace boost
             boost::this_thread::disable_interruption do_not_disturb;
 #endif
             boost::unique_lock<boost::mutex> lk(state_change);
-
-            while(state.shared_count || state.exclusive)
+            state.exclusive_waiting_blocked=true;
+            if(!exclusive_cond.timed_wait(lk, timeout, boost::bind(&state_data::can_lock, boost::ref(state))))
             {
-                state.exclusive_waiting_blocked=true;
-                if(!exclusive_cond.timed_wait(lk,timeout))
-                {
-                    if(state.shared_count || state.exclusive)
-                    {
-                        state.exclusive_waiting_blocked=false;
-                        release_waiters();
-                        return false;
-                    }
-                    break;
-                }
+                state.exclusive_waiting_blocked=false;
+                release_waiters();
+                return false;
             }
             state.exclusive=true;
             return true;
@@ -324,7 +295,19 @@ namespace boost
         template<typename TimeDuration>
         bool timed_lock(TimeDuration const & relative_time)
         {
-            return timed_lock(get_system_time()+relative_time);
+#if defined BOOST_THREAD_PROVIDES_INTERRUPTIONS
+            boost::this_thread::disable_interruption do_not_disturb;
+#endif
+            boost::unique_lock<boost::mutex> lk(state_change);
+            state.exclusive_waiting_blocked=true;
+            if(!exclusive_cond.timed_wait(lk, relative_time, boost::bind(&state_data::can_lock, boost::ref(state))))
+            {
+                state.exclusive_waiting_blocked=false;
+                release_waiters();
+                return false;
+            }
+            state.exclusive=true;
+            return true;
         }
 #endif
 #ifdef BOOST_THREAD_USES_CHRONO
@@ -340,20 +323,12 @@ namespace boost
           boost::this_thread::disable_interruption do_not_disturb;
 #endif
           boost::unique_lock<boost::mutex> lk(state_change);
-
-          while(state.shared_count || state.exclusive)
+          state.exclusive_waiting_blocked=true;
+          if(!exclusive_cond.wait_until(lk, abs_time, boost::bind(&state_data::can_lock, boost::ref(state))))
           {
-              state.exclusive_waiting_blocked=true;
-              if(cv_status::timeout == exclusive_cond.wait_until(lk,abs_time))
-              {
-                  if(state.shared_count || state.exclusive)
-                  {
-                      state.exclusive_waiting_blocked=false;
-                      release_waiters();
-                      return false;
-                  }
-                  break;
-              }
+              state.exclusive_waiting_blocked=false;
+              release_waiters();
+              return false;
           }
           state.exclusive=true;
           return true;
@@ -363,17 +338,12 @@ namespace boost
         bool try_lock()
         {
             boost::unique_lock<boost::mutex> lk(state_change);
-
-            if(state.shared_count || state.exclusive)
+            if(!state.can_lock())
             {
                 return false;
             }
-            else
-            {
-                state.exclusive=true;
-                return true;
-            }
-
+            state.exclusive=true;
+            return true;
         }
 
         void unlock()
@@ -392,10 +362,7 @@ namespace boost
             boost::this_thread::disable_interruption do_not_disturb;
 #endif
             boost::unique_lock<boost::mutex> lk(state_change);
-            while(state.exclusive || state.exclusive_waiting_blocked || state.upgrade)
-            {
-                shared_cond.wait(lk);
-            }
+            shared_cond.wait(lk, boost::bind(&state_data::can_lock_upgrade, boost::ref(state)));
             state.lock_shared();
             state.upgrade=true;
         }
@@ -407,16 +374,9 @@ namespace boost
             boost::this_thread::disable_interruption do_not_disturb;
 #endif
             boost::unique_lock<boost::mutex> lk(state_change);
-            while(state.exclusive || state.exclusive_waiting_blocked || state.upgrade)
+            if(!shared_cond.timed_wait(lk, timeout, boost::bind(&state_data::can_lock_upgrade, boost::ref(state))))
             {
-                if(!shared_cond.timed_wait(lk,timeout))
-                {
-                    if(state.exclusive || state.exclusive_waiting_blocked || state.upgrade)
-                    {
-                        return false;
-                    }
-                    break;
-                }
+                return false;
             }
             state.lock_shared();
             state.upgrade=true;
@@ -426,7 +386,17 @@ namespace boost
         template<typename TimeDuration>
         bool timed_lock_upgrade(TimeDuration const & relative_time)
         {
-            return timed_lock_upgrade(get_system_time()+relative_time);
+#if defined BOOST_THREAD_PROVIDES_INTERRUPTIONS
+            boost::this_thread::disable_interruption do_not_disturb;
+#endif
+            boost::unique_lock<boost::mutex> lk(state_change);
+            if(!shared_cond.timed_wait(lk, relative_time, boost::bind(&state_data::can_lock_upgrade, boost::ref(state))))
+            {
+                return false;
+            }
+            state.lock_shared();
+            state.upgrade=true;
+            return true;
         }
 #endif
 #ifdef BOOST_THREAD_USES_CHRONO
@@ -442,16 +412,9 @@ namespace boost
           boost::this_thread::disable_interruption do_not_disturb;
 #endif
           boost::unique_lock<boost::mutex> lk(state_change);
-          while(state.exclusive || state.exclusive_waiting_blocked || state.upgrade)
+          if(!shared_cond.wait_until(lk, abs_time, boost::bind(&state_data::can_lock_upgrade, boost::ref(state))))
           {
-              if(cv_status::timeout == shared_cond.wait_until(lk,abs_time))
-              {
-                  if(state.exclusive || state.exclusive_waiting_blocked || state.upgrade)
-                  {
-                      return false;
-                  }
-                  break;
-              }
+              return false;
           }
           state.lock_shared();
           state.upgrade=true;
@@ -461,17 +424,14 @@ namespace boost
         bool try_lock_upgrade()
         {
             boost::unique_lock<boost::mutex> lk(state_change);
-            if(state.exclusive || state.exclusive_waiting_blocked || state.upgrade)
+            if(!state.can_lock_upgrade())
             {
                 return false;
             }
-            else
-            {
-                state.lock_shared();
-                state.upgrade=true;
-                state.assert_lock_upgraded();
-                return true;
-            }
+            state.lock_shared();
+            state.upgrade=true;
+            state.assert_lock_upgraded();
+            return true;
         }
 
         void unlock_upgrade()
@@ -479,7 +439,7 @@ namespace boost
             boost::unique_lock<boost::mutex> lk(state_change);
             //state.upgrade=false;
             state.unlock_upgrade();
-            if(! state.more_shared() )
+            if(state.no_shared())
             {
                 state.exclusive_waiting_blocked=false;
                 release_waiters();
@@ -497,10 +457,7 @@ namespace boost
             boost::unique_lock<boost::mutex> lk(state_change);
             state.assert_lock_upgraded();
             state.unlock_shared();
-            while (state.more_shared())
-            {
-                upgrade_cond.wait(lk);
-            }
+            upgrade_cond.wait(lk, boost::bind(&state_data::no_shared, boost::ref(state)));
             state.upgrade=false;
             state.exclusive=true;
             state.assert_locked();
@@ -554,16 +511,9 @@ namespace boost
 #endif
           boost::unique_lock<boost::mutex> lk(state_change);
           state.assert_lock_upgraded();
-          if (state.shared_count != 1)
+          if(!shared_cond.wait_until(lk, abs_time, boost::bind(&state_data::one_shared, boost::ref(state))))
           {
-              for (;;)
-              {
-                cv_status status = shared_cond.wait_until(lk,abs_time);
-                if (state.shared_count == 1)
-                  break;
-                if(status == cv_status::timeout)
-                  return false;
-              }
+              return false;
           }
           state.upgrade=false;
           state.exclusive=true;
@@ -619,16 +569,9 @@ namespace boost
 #endif
           boost::unique_lock<boost::mutex> lk(state_change);
           state.assert_lock_shared();
-          if (state.shared_count != 1)
+          if(!shared_cond.wait_until(lk, abs_time, boost::bind(&state_data::one_shared, boost::ref(state))))
           {
-              for (;;)
-              {
-                cv_status status = shared_cond.wait_until(lk,abs_time);
-                if (state.shared_count == 1)
-                  break;
-                if(status == cv_status::timeout)
-                  return false;
-              }
+              return false;
           }
           state.upgrade=false;
           state.exclusive=true;
@@ -654,10 +597,7 @@ namespace boost
         {
           boost::unique_lock<boost::mutex> lk(state_change);
           state.assert_lock_shared();
-          if(    !state.exclusive
-              && !state.exclusive_waiting_blocked
-              && !state.upgrade
-              )
+          if(state.can_lock_upgrade())
           {
             state.upgrade=true;
             return true;
@@ -683,22 +623,9 @@ namespace boost
 #endif
           boost::unique_lock<boost::mutex> lk(state_change);
           state.assert_lock_shared();
-          if(    state.exclusive
-              || state.exclusive_waiting_blocked
-              || state.upgrade
-              )
+          if(!exclusive_cond.wait_until(lk, abs_time, boost::bind(&state_data::can_lock_upgrade, boost::ref(state))))
           {
-              for (;;)
-              {
-                cv_status status = exclusive_cond.wait_until(lk,abs_time);
-                if(    ! state.exclusive
-                    && ! state.exclusive_waiting_blocked
-                    && ! state.upgrade
-                    )
-                  break;
-                if(status == cv_status::timeout)
-                  return false;
-              }
+              return false;
           }
           state.upgrade=true;
           return true;


### PR DESCRIPTION
This PR is composed of two commits.

The first commit simply reverts `pthread/shared_mutex.hpp` and `future.hpp` back to the versions in `develop`, which reverts all of the changes we've made to these two files to date.

The second commit re-fixes the time jump issues by using the predicate versions of the wait functions, which is a simpler solution than the one we were using before and which works even with the changes we made to avoid losing notifications.