### PR TITLE
Fix final time jump issues

### DIFF
--- a/include/boost/thread/win32/basic_recursive_mutex.hpp
+++ b/include/boost/thread/win32/basic_recursive_mutex.hpp
@@ -65,25 +65,26 @@ namespace boost
                 return try_recursive_lock(current_thread_id) || try_timed_lock(current_thread_id,target);
             }
             template<typename Duration>
-            bool timed_lock(Duration const& timeout)
+            bool timed_lock(Duration const& target)
             {
-                return timed_lock(get_system_time()+timeout);
+                long const current_thread_id=boost::detail::winapi::GetCurrentThreadId();
+                return try_recursive_lock(current_thread_id) || try_timed_lock(current_thread_id,target);
             }
 #endif
 
 #ifdef BOOST_THREAD_USES_CHRONO
-        template <class Rep, class Period>
-        bool try_lock_for(const chrono::duration<Rep, Period>& rel_time)
-        {
+            template <class Rep, class Period>
+            bool try_lock_for(const chrono::duration<Rep, Period>& rel_time)
+            {
                 long const current_thread_id=boost::detail::winapi::GetCurrentThreadId();
                 return try_recursive_lock(current_thread_id) || try_timed_lock_for(current_thread_id,rel_time);
-        }
-        template <class Clock, class Duration>
-        bool try_lock_until(const chrono::time_point<Clock, Duration>& t)
-        {
+            }
+            template <class Clock, class Duration>
+            bool try_lock_until(const chrono::time_point<Clock, Duration>& t)
+            {
                 long const current_thread_id=boost::detail::winapi::GetCurrentThreadId();
                 return try_recursive_lock(current_thread_id) || try_timed_lock_until(current_thread_id,t);
-        }
+            }
 #endif
             void unlock()
             {
@@ -118,6 +119,17 @@ namespace boost
 
 #if defined BOOST_THREAD_USES_DATETIME
             bool try_timed_lock(long current_thread_id,::boost::system_time const& target)
+            {
+                if(mutex.timed_lock(target))
+                {
+                    BOOST_INTERLOCKED_EXCHANGE(&locking_thread_id,current_thread_id);
+                    recursion_count=1;
+                    return true;
+                }
+                return false;
+            }
+            template<typename Duration>
+            bool try_timed_lock(long current_thread_id,Duration const& target)
             {
                 if(mutex.timed_lock(target))
                 {

--- a/include/boost/thread/win32/basic_timed_mutex.hpp
+++ b/include/boost/thread/win32/basic_timed_mutex.hpp
@@ -22,6 +22,8 @@
 #include <boost/chrono/system_clocks.hpp>
 #include <boost/chrono/ceil.hpp>
 #endif
+#include <boost/thread/detail/platform_time.hpp>
+
 #include <boost/config/abi_prefix.hpp>
 
 namespace boost
@@ -59,7 +61,7 @@ namespace boost
                 }
             }
 
-
+            // Take the lock flag if it's available
             bool try_lock() BOOST_NOEXCEPT
             {
                 return !win32::interlocked_bit_test_and_set(&active_count,lock_flag_bit);
@@ -76,21 +78,21 @@ namespace boost
 
                 if(old_count&lock_flag_value)
                 {
-                    bool lock_acquired=false;
                     void* const sem=get_event();
 
                     do
                     {
-                        unsigned const retval(winapi::WaitForSingleObjectEx(sem, ::boost::detail::win32::infinite,0));
-                        BOOST_VERIFY(0 == retval || ::boost::detail::win32::wait_abandoned == retval);
-//                        BOOST_VERIFY(winapi::WaitForSingleObject(
-//                                         sem,::boost::detail::win32::infinite)==0);
-                        clear_waiting_and_try_lock(old_count);
-                        lock_acquired=!(old_count&lock_flag_value);
+                        if(winapi::WaitForSingleObjectEx(sem,::boost::detail::win32::infinite,0)==0)
+                        {
+                            clear_waiting_and_try_lock(old_count);
+                        }
                     }
-                    while(!lock_acquired);
+                    while(old_count&lock_flag_value);
                 }
             }
+
+            // Loop until the number of waiters has been incremented or we've taken the lock flag
+            // The loop is necessary since this function may be called by multiple threads simultaneously
             void mark_waiting_and_try_lock(long& old_count)
             {
                 for(;;)
@@ -102,12 +104,19 @@ namespace boost
                     {
                         if(was_locked)
                             old_count=new_count;
+                        // else we've taken the lock flag
+                            // don't update old_count so that the calling function can see that
+                            // the old lock flag was 0 and know that we've taken the lock flag
                         break;
                     }
                     old_count=current;
                 }
             }
 
+            // Loop until someone else has taken the lock flag and cleared the event set flag or
+            // until we've taken the lock flag and cleared the event set flag and decremented the
+            // number of waiters
+            // The loop is necessary since this function may be called by multiple threads simultaneously
             void clear_waiting_and_try_lock(long& old_count)
             {
                 old_count&=~lock_flag_value;
@@ -118,117 +127,126 @@ namespace boost
                     long const current=BOOST_INTERLOCKED_COMPARE_EXCHANGE(&active_count,new_count,old_count);
                     if(current==old_count)
                     {
+                        // if someone else has taken the lock flag
+                            // no need to update old_count since old_count == new_count (ignoring
+                            // event_set_flag_value which the calling function doesn't care about)
+                        // else we've taken the lock flag
+                            // don't update old_count so that the calling function can see that
+                            // the old lock flag was 0 and know that we've taken the lock flag
                         break;
                     }
                     old_count=current;
                 }
             }
 
+        private:
+            inline unsigned long getMs(detail::platform_duration const& d)
+            {
+                return static_cast<unsigned long>(d.getMs());
+            }
 
-#if defined BOOST_THREAD_USES_DATETIME
-            bool timed_lock(::boost::system_time const& wait_until)
+            template <typename Duration>
+            inline unsigned long getMs(Duration const& d)
+            {
+                return static_cast<unsigned long>(chrono::ceil<chrono::milliseconds>(d).count());
+            }
+
+            template <typename Clock, typename Timepoint, typename Duration>
+            bool do_lock_until(Timepoint const& t, Duration const& max)
             {
                 if(try_lock())
                 {
                     return true;
                 }
+
                 long old_count=active_count;
                 mark_waiting_and_try_lock(old_count);
 
                 if(old_count&lock_flag_value)
                 {
-                    bool lock_acquired=false;
                     void* const sem=get_event();
 
+                    // If the clock is the system clock, it may jump while this function
+                    // is waiting. To compensate for this and time out near the correct
+                    // time, we call WaitForSingleObjectEx() in a loop with a short
+                    // timeout and recheck the time remaining each time through the loop.
                     do
                     {
-                        if(winapi::WaitForSingleObjectEx(sem,::boost::detail::get_milliseconds_until(wait_until),0)!=0)
+                        Duration d(t - Clock::now());
+                        if(d <= Duration::zero()) // timeout occurred
                         {
                             BOOST_INTERLOCKED_DECREMENT(&active_count);
                             return false;
                         }
-                        clear_waiting_and_try_lock(old_count);
-                        lock_acquired=!(old_count&lock_flag_value);
+                        if(max != Duration::zero())
+                        {
+                            d = (std::min)(d, max);
+                        }
+                        if(winapi::WaitForSingleObjectEx(sem,getMs(d),0)==0)
+                        {
+                            clear_waiting_and_try_lock(old_count);
+                        }
                     }
-                    while(!lock_acquired);
+                    while(old_count&lock_flag_value);
                 }
                 return true;
+            }
+        public:
+
+#if defined BOOST_THREAD_USES_DATETIME
+            bool timed_lock(::boost::system_time const& wait_until)
+            {
+                const detail::real_platform_timepoint t(wait_until);
+                return do_lock_until<detail::real_platform_clock>(t, detail::platform_milliseconds(100));
             }
 
             template<typename Duration>
             bool timed_lock(Duration const& timeout)
             {
-                return timed_lock(get_system_time()+timeout);
+                const detail::mono_platform_timepoint t(detail::mono_platform_clock::now() + detail::platform_duration(timeout));
+                // The reference clock is steady and so no need to poll periodically, thus 0 ms max (i.e. no max)
+                return do_lock_until<detail::mono_platform_clock>(t, detail::platform_duration::zero());
             }
 
             bool timed_lock(boost::xtime const& timeout)
             {
-                return timed_lock(system_time(timeout));
+                const boost::system_time wait_until(timeout);
+                const detail::real_platform_timepoint t(wait_until);
+                return do_lock_until<detail::real_platform_clock>(t, detail::platform_milliseconds(100));
             }
 #endif
 #ifdef BOOST_THREAD_USES_CHRONO
             template <class Rep, class Period>
             bool try_lock_for(const chrono::duration<Rep, Period>& rel_time)
             {
-              return try_lock_until(chrono::steady_clock::now() + rel_time);
+                const chrono::steady_clock::time_point t(chrono::steady_clock::now() + rel_time);
+                typedef typename chrono::duration<Rep, Period> Duration;
+                typedef typename common_type<Duration, typename chrono::steady_clock::duration>::type common_duration;
+                // The reference clock is steady and so no need to poll periodically, thus 0 ms max (i.e. no max)
+                return do_lock_until<chrono::steady_clock>(t, common_duration::zero());
+            }
+            template <class Duration>
+            bool try_lock_until(const chrono::time_point<chrono::steady_clock, Duration>& t)
+            {
+                typedef typename common_type<Duration, typename chrono::steady_clock::duration>::type common_duration;
+                // The reference clock is steady and so no need to poll periodically, thus 0 ms max (i.e. no max)
+                return do_lock_until<chrono::steady_clock>(t, common_duration::zero());
             }
             template <class Clock, class Duration>
             bool try_lock_until(const chrono::time_point<Clock, Duration>& t)
             {
-              using namespace chrono;
-              system_clock::time_point     s_now = system_clock::now();
-              typename Clock::time_point  c_now = Clock::now();
-              return try_lock_until(s_now + ceil<system_clock::duration>(t - c_now));
-            }
-            template <class Duration>
-            bool try_lock_until(const chrono::time_point<chrono::system_clock, Duration>& t)
-            {
-              using namespace chrono;
-              typedef time_point<chrono::system_clock, chrono::system_clock::duration> sys_tmpt;
-              return try_lock_until(sys_tmpt(chrono::ceil<chrono::system_clock::duration>(t.time_since_epoch())));
-            }
-            bool try_lock_until(const chrono::time_point<chrono::system_clock, chrono::system_clock::duration>& tp)
-            {
-              if(try_lock())
-              {
-                  return true;
-              }
-              long old_count=active_count;
-              mark_waiting_and_try_lock(old_count);
-
-              if(old_count&lock_flag_value)
-              {
-                  bool lock_acquired=false;
-                  void* const sem=get_event();
-
-                  do
-                  {
-                      chrono::time_point<chrono::system_clock, chrono::system_clock::duration> now = chrono::system_clock::now();
-                      if (tp<=now) {
-                        BOOST_INTERLOCKED_DECREMENT(&active_count);
-                        return false;
-                      }
-                      chrono::milliseconds rel_time= chrono::ceil<chrono::milliseconds>(tp-now);
-
-                      if(winapi::WaitForSingleObjectEx(sem,static_cast<unsigned long>(rel_time.count()),0)!=0)
-                      {
-                          BOOST_INTERLOCKED_DECREMENT(&active_count);
-                          return false;
-                      }
-                      clear_waiting_and_try_lock(old_count);
-                      lock_acquired=!(old_count&lock_flag_value);
-                  }
-                  while(!lock_acquired);
-              }
-              return true;
+                typedef typename common_type<Duration, typename Clock::duration>::type common_duration;
+                return do_lock_until<Clock>(t, common_duration(chrono::milliseconds(100)));
             }
 #endif
 
             void unlock()
             {
-                long const offset=lock_flag_value;
+                // Clear the lock flag using atomic addition (works since long is always 32 bits on Windows)
                 long const old_count=BOOST_INTERLOCKED_EXCHANGE_ADD(&active_count,lock_flag_value);
-                if(!(old_count&event_set_flag_value) && (old_count>offset))
+                // If someone is waiting to take the lock, set the event set flag and, if
+                // the event set flag hadn't already been set, send an event.
+                if(!(old_count&event_set_flag_value) && (old_count>lock_flag_value))
                 {
                     if(!win32::interlocked_bit_test_and_set(&active_count,event_set_flag_bit))
                     {
@@ -238,6 +256,8 @@ namespace boost
             }
 
         private:
+            // Create an event in a thread-safe way
+            // The first thread to create the event wins and all other thread will use that event
             void* get_event()
             {
                 void* current_event=::boost::detail::interlocked_read_acquire(&event);

--- a/include/boost/thread/win32/condition_variable.hpp
+++ b/include/boost/thread/win32/condition_variable.hpp
@@ -272,7 +272,7 @@ namespace boost
               // do it here to avoid throwing on the destructor
               entry.remove_waiter_and_reset();
               locker.lock();
-              return woken;
+              return true;
             }
 
             void notify_one() BOOST_NOEXCEPT

--- a/include/boost/thread/win32/shared_mutex.hpp
+++ b/include/boost/thread/win32/shared_mutex.hpp
@@ -19,6 +19,7 @@
 #include <boost/chrono/ceil.hpp>
 #endif
 #include <boost/thread/detail/delete.hpp>
+#include <boost/thread/detail/platform_time.hpp>
 
 #include <boost/config/abi_prefix.hpp>
 
@@ -29,7 +30,7 @@ namespace boost
     private:
         struct state_data
         {
-            unsigned shared_count:11,
+            unsigned long shared_count:11,
                 shared_waiting:11,
                 exclusive:1,
                 upgrade:1,
@@ -38,19 +39,16 @@ namespace boost
 
             friend bool operator==(state_data const& lhs,state_data const& rhs)
             {
-                return *reinterpret_cast<unsigned const*>(&lhs)==*reinterpret_cast<unsigned const*>(&rhs);
+                return *reinterpret_cast<unsigned long const*>(&lhs)==*reinterpret_cast<unsigned long const*>(&rhs);
             }
         };
 
-
-        template<typename T>
-        T interlocked_compare_exchange(T* target,T new_value,T comparand)
+        inline state_data interlocked_compare_exchange(state_data* target, state_data new_value, state_data comparand)
         {
-            BOOST_STATIC_ASSERT(sizeof(T)==sizeof(long));
             long const res=BOOST_INTERLOCKED_COMPARE_EXCHANGE(reinterpret_cast<long*>(target),
                                                               *reinterpret_cast<long*>(&new_value),
                                                               *reinterpret_cast<long*>(&comparand));
-            return *reinterpret_cast<T const*>(&res);
+            return *reinterpret_cast<state_data const*>(&res);
         }
 
         enum
@@ -139,21 +137,60 @@ namespace boost
 
         void lock_shared()
         {
+            for(;;)
+            {
+                state_data old_state=state;
+                for(;;)
+                {
+                    state_data new_state=old_state;
+                    if(new_state.exclusive || new_state.exclusive_waiting_blocked)
+                    {
+                        ++new_state.shared_waiting;
+                        if(!new_state.shared_waiting)
+                        {
+                            boost::throw_exception(boost::lock_error());
+                        }
+                    }
+                    else
+                    {
+                        ++new_state.shared_count;
+                        if(!new_state.shared_count)
+                        {
+                            boost::throw_exception(boost::lock_error());
+                        }
+                    }
 
-#if defined BOOST_THREAD_USES_DATETIME
-            BOOST_VERIFY(timed_lock_shared(::boost::detail::get_system_time_sentinel()));
-#else
-            BOOST_VERIFY(try_lock_shared_until(chrono::steady_clock::now()));
-#endif
+                    state_data const current_state=interlocked_compare_exchange(&state,new_state,old_state);
+                    if(current_state==old_state)
+                    {
+                        break;
+                    }
+                    old_state=current_state;
+                }
+
+                if(!(old_state.exclusive| old_state.exclusive_waiting_blocked))
+                {
+                    return;
+                }
+
+                BOOST_VERIFY(detail::winapi::WaitForSingleObjectEx(semaphores[unlock_sem],::boost::detail::win32::infinite,0)==0);
+            }
         }
 
-#if defined BOOST_THREAD_USES_DATETIME
-        template<typename TimeDuration>
-        bool timed_lock_shared(TimeDuration const & relative_time)
+    private:
+        inline unsigned long getMs(detail::platform_duration const& d)
         {
-            return timed_lock_shared(get_system_time()+relative_time);
+            return static_cast<unsigned long>(d.getMs());
         }
-        bool timed_lock_shared(boost::system_time const& wait_until)
+
+        template <typename Duration>
+        inline unsigned long getMs(Duration const& d)
+        {
+            return static_cast<unsigned long>(chrono::ceil<chrono::milliseconds>(d).count());
+        }
+
+        template <typename Clock, typename Timepoint, typename Duration>
+        bool do_lock_shared_until(Timepoint const& t, Duration const& max)
         {
             for(;;)
             {
@@ -191,7 +228,30 @@ namespace boost
                     return true;
                 }
 
-                unsigned long const res=detail::winapi::WaitForSingleObjectEx(semaphores[unlock_sem],::boost::detail::get_milliseconds_until(wait_until), 0);
+                // If the clock is the system clock, it may jump while this function
+                // is waiting. To compensate for this and time out near the correct
+                // time, we call WaitForSingleObjectEx() in a loop with a short
+                // timeout and recheck the time remaining each time through the loop.
+                unsigned long res=0;
+                for(;;)
+                {
+                    Duration d(t - Clock::now());
+                    if(d <= Duration::zero()) // timeout occurred
+                    {
+                        res=detail::win32::timeout;
+                        break;
+                    }
+                    if(max != Duration::zero())
+                    {
+                        d = (std::min)(d, max);
+                    }
+                    res=detail::winapi::WaitForSingleObjectEx(semaphores[unlock_sem],getMs(d),0);
+                    if(res!=detail::win32::timeout) // semaphore released
+                    {
+                        break;
+                    }
+                }
+
                 if(res==detail::win32::timeout)
                 {
                     for(;;)
@@ -231,114 +291,45 @@ namespace boost
                 BOOST_ASSERT(res==0);
             }
         }
+    public:
+
+#if defined BOOST_THREAD_USES_DATETIME
+        template<typename TimeDuration>
+        bool timed_lock_shared(TimeDuration const & relative_time)
+        {
+            const detail::mono_platform_timepoint t(detail::mono_platform_clock::now() + detail::platform_duration(relative_time));
+            // The reference clock is steady and so no need to poll periodically, thus 0 ms max (i.e. no max)
+            return do_lock_shared_until<detail::mono_platform_clock>(t, detail::platform_duration::zero());
+        }
+        bool timed_lock_shared(boost::system_time const& wait_until)
+        {
+            const detail::real_platform_timepoint t(wait_until);
+            return do_lock_shared_until<detail::real_platform_clock>(t, detail::platform_milliseconds(100));
+        }
 #endif
 
 #ifdef BOOST_THREAD_USES_CHRONO
         template <class Rep, class Period>
         bool try_lock_shared_for(const chrono::duration<Rep, Period>& rel_time)
         {
-          return try_lock_shared_until(chrono::steady_clock::now() + rel_time);
+            const chrono::steady_clock::time_point t(chrono::steady_clock::now() + rel_time);
+            typedef typename chrono::duration<Rep, Period> Duration;
+            typedef typename common_type<Duration, typename chrono::steady_clock::duration>::type common_duration;
+            // The reference clock is steady and so no need to poll periodically, thus 0 ms max (i.e. no max)
+            return do_lock_shared_until<chrono::steady_clock>(t, common_duration::zero());
+        }
+        template <class Duration>
+        bool try_lock_shared_until(const chrono::time_point<chrono::steady_clock, Duration>& t)
+        {
+            typedef typename common_type<Duration, typename chrono::steady_clock::duration>::type common_duration;
+            // The reference clock is steady and so no need to poll periodically, thus 0 ms max (i.e. no max)
+            return do_lock_shared_until<chrono::steady_clock>(t, common_duration::zero());
         }
         template <class Clock, class Duration>
         bool try_lock_shared_until(const chrono::time_point<Clock, Duration>& t)
         {
-          using namespace chrono;
-          system_clock::time_point     s_now = system_clock::now();
-          typename Clock::time_point  c_now = Clock::now();
-          return try_lock_shared_until(s_now + ceil<system_clock::duration>(t - c_now));
-        }
-        template <class Duration>
-        bool try_lock_shared_until(const chrono::time_point<chrono::system_clock, Duration>& t)
-        {
-          using namespace chrono;
-          typedef time_point<chrono::system_clock, chrono::system_clock::duration> sys_tmpt;
-          return try_lock_shared_until(sys_tmpt(chrono::ceil<chrono::system_clock::duration>(t.time_since_epoch())));
-        }
-        bool try_lock_shared_until(const chrono::time_point<chrono::system_clock, chrono::system_clock::duration>& tp)
-        {
-          for(;;)
-          {
-            state_data old_state=state;
-            for(;;)
-            {
-              state_data new_state=old_state;
-              if(new_state.exclusive || new_state.exclusive_waiting_blocked)
-              {
-                  ++new_state.shared_waiting;
-                  if(!new_state.shared_waiting)
-                  {
-                      boost::throw_exception(boost::lock_error());
-                  }
-              }
-              else
-              {
-                  ++new_state.shared_count;
-                  if(!new_state.shared_count)
-                  {
-                      boost::throw_exception(boost::lock_error());
-                  }
-              }
-
-              state_data const current_state=interlocked_compare_exchange(&state,new_state,old_state);
-              if(current_state==old_state)
-              {
-                  break;
-              }
-              old_state=current_state;
-            }
-
-            if(!(old_state.exclusive| old_state.exclusive_waiting_blocked))
-            {
-              return true;
-            }
-
-            chrono::system_clock::time_point n = chrono::system_clock::now();
-            unsigned long res;
-            if (tp>n) {
-              chrono::milliseconds rel_time= chrono::ceil<chrono::milliseconds>(tp-n);
-              res=detail::winapi::WaitForSingleObjectEx(semaphores[unlock_sem],
-                static_cast<unsigned long>(rel_time.count()), 0);
-            } else {
-              res=detail::win32::timeout;
-            }
-            if(res==detail::win32::timeout)
-            {
-              for(;;)
-              {
-                state_data new_state=old_state;
-                if(new_state.exclusive || new_state.exclusive_waiting_blocked)
-                {
-                  if(new_state.shared_waiting)
-                  {
-                      --new_state.shared_waiting;
-                  }
-                }
-                else
-                {
-                  ++new_state.shared_count;
-                  if(!new_state.shared_count)
-                  {
-                      return false;
-                  }
-                }
-
-                state_data const current_state=interlocked_compare_exchange(&state,new_state,old_state);
-                if(current_state==old_state)
-                {
-                    break;
-                }
-                old_state=current_state;
-              }
-
-              if(!(old_state.exclusive| old_state.exclusive_waiting_blocked))
-              {
-                return true;
-              }
-              return false;
-            }
-
-            BOOST_ASSERT(res==0);
-          }
+            typedef typename common_type<Duration, typename Clock::duration>::type common_duration;
+            return do_lock_shared_until<Clock>(t, common_duration(chrono::milliseconds(100)));
         }
 #endif
 
@@ -388,24 +379,6 @@ namespace boost
             }
         }
 
-        void lock()
-        {
-
-#if defined BOOST_THREAD_USES_DATETIME
-            BOOST_VERIFY(timed_lock(::boost::detail::get_system_time_sentinel()));
-#else
-            BOOST_VERIFY(try_lock_until(chrono::steady_clock::now()));
-#endif
-        }
-
-#if defined BOOST_THREAD_USES_DATETIME
-        template<typename TimeDuration>
-        bool timed_lock(TimeDuration const & relative_time)
-        {
-            return timed_lock(get_system_time()+relative_time);
-        }
-#endif
-
         bool try_lock()
         {
             state_data old_state=state;
@@ -431,14 +404,58 @@ namespace boost
             return true;
         }
 
-
-#if defined BOOST_THREAD_USES_DATETIME
-        bool timed_lock(boost::system_time const& wait_until)
+        void lock()
         {
             for(;;)
             {
                 state_data old_state=state;
+                for(;;)
+                {
+                    state_data new_state=old_state;
+                    if(new_state.shared_count || new_state.exclusive)
+                    {
+                        ++new_state.exclusive_waiting;
+                        if(!new_state.exclusive_waiting)
+                        {
+                            boost::throw_exception(boost::lock_error());
+                        }
 
+                        new_state.exclusive_waiting_blocked=true;
+                    }
+                    else
+                    {
+                        new_state.exclusive=true;
+                    }
+
+                    state_data const current_state=interlocked_compare_exchange(&state,new_state,old_state);
+                    if(current_state==old_state)
+                    {
+                        break;
+                    }
+                    old_state=current_state;
+                }
+
+                if(!old_state.shared_count && !old_state.exclusive)
+                {
+                    return;
+                }
+
+                #ifndef UNDER_CE
+                const bool wait_all = true;
+                #else
+                const bool wait_all = false;
+                #endif
+                BOOST_VERIFY(detail::winapi::WaitForMultipleObjectsEx(2,semaphores,wait_all,::boost::detail::win32::infinite,0)<2);
+            }
+        }
+
+    private:
+        template <typename Clock, typename Timepoint, typename Duration>
+        bool do_lock_until(Timepoint const& t, Duration const& max)
+        {
+            for(;;)
+            {
+                state_data old_state=state;
                 for(;;)
                 {
                     state_data new_state=old_state;
@@ -469,12 +486,35 @@ namespace boost
                 {
                     return true;
                 }
-                #ifndef UNDER_CE
-                const bool wait_all = true;
-                #else
-                const bool wait_all = false;
-                #endif
-                unsigned long const wait_res=detail::winapi::WaitForMultipleObjectsEx(2,semaphores,wait_all,::boost::detail::get_milliseconds_until(wait_until), 0);
+
+                // If the clock is the system clock, it may jump while this function
+                // is waiting. To compensate for this and time out near the correct
+                // time, we call WaitForMultipleObjectsEx() in a loop with a short
+                // timeout and recheck the time remaining each time through the loop.
+                unsigned long wait_res=0;
+                for(;;)
+                {
+                    Duration d(t - Clock::now());
+                    if(d <= Duration::zero()) // timeout occurred
+                    {
+                        wait_res=detail::win32::timeout;
+                        break;
+                    }
+                    if(max != Duration::zero())
+                    {
+                        d = (std::min)(d, max);
+                    }
+                    #ifndef UNDER_CE
+                    wait_res=detail::winapi::WaitForMultipleObjectsEx(2,semaphores,true,getMs(d),0);
+                    #else
+                    wait_res=detail::winapi::WaitForMultipleObjectsEx(2,semaphores,false,getMs(d),0);
+                    #endif
+                    if(wait_res!=detail::win32::timeout) // semaphore released
+                    {
+                        break;
+                    }
+                }
+
                 if(wait_res==detail::win32::timeout)
                 {
                     for(;;)
@@ -515,123 +555,48 @@ namespace boost
                     }
                     return false;
                 }
+
                 BOOST_ASSERT(wait_res<2);
             }
+        }
+    public:
+
+#if defined BOOST_THREAD_USES_DATETIME
+        bool timed_lock(boost::system_time const& wait_until)
+        {
+            const detail::real_platform_timepoint t(wait_until);
+            return do_lock_until<detail::real_platform_clock>(t, detail::platform_milliseconds(100));
+        }
+        template<typename TimeDuration>
+        bool timed_lock(TimeDuration const & relative_time)
+        {
+            const detail::mono_platform_timepoint t(detail::mono_platform_clock::now() + detail::platform_duration(relative_time));
+            // The reference clock is steady and so no need to poll periodically, thus 0 ms max (i.e. no max)
+            return do_lock_until<detail::mono_platform_clock>(t, detail::platform_duration::zero());
         }
 #endif
 #ifdef BOOST_THREAD_USES_CHRONO
         template <class Rep, class Period>
         bool try_lock_for(const chrono::duration<Rep, Period>& rel_time)
         {
-          return try_lock_until(chrono::steady_clock::now() + rel_time);
+            const chrono::steady_clock::time_point t(chrono::steady_clock::now() + rel_time);
+            typedef typename chrono::duration<Rep, Period> Duration;
+            typedef typename common_type<Duration, typename chrono::steady_clock::duration>::type common_duration;
+            // The reference clock is steady and so no need to poll periodically, thus 0 ms max (i.e. no max)
+            return do_lock_until<chrono::steady_clock>(t, common_duration::zero());
+        }
+        template <class Duration>
+        bool try_lock_until(const chrono::time_point<chrono::steady_clock, Duration>& t)
+        {
+            typedef typename common_type<Duration, typename chrono::steady_clock::duration>::type common_duration;
+            // The reference clock is steady and so no need to poll periodically, thus 0 ms max (i.e. no max)
+            return do_lock_until<chrono::steady_clock>(t, common_duration::zero());
         }
         template <class Clock, class Duration>
         bool try_lock_until(const chrono::time_point<Clock, Duration>& t)
         {
-          using namespace chrono;
-          system_clock::time_point     s_now = system_clock::now();
-          typename Clock::time_point  c_now = Clock::now();
-          return try_lock_until(s_now + ceil<system_clock::duration>(t - c_now));
-        }
-        template <class Duration>
-        bool try_lock_until(const chrono::time_point<chrono::system_clock, Duration>& t)
-        {
-          using namespace chrono;
-          typedef time_point<chrono::system_clock, chrono::system_clock::duration> sys_tmpt;
-          return try_lock_until(sys_tmpt(chrono::ceil<chrono::system_clock::duration>(t.time_since_epoch())));
-        }
-        bool try_lock_until(const chrono::time_point<chrono::system_clock, chrono::system_clock::duration>& tp)
-        {
-          for(;;)
-          {
-            state_data old_state=state;
-
-            for(;;)
-            {
-              state_data new_state=old_state;
-              if(new_state.shared_count || new_state.exclusive)
-              {
-                ++new_state.exclusive_waiting;
-                if(!new_state.exclusive_waiting)
-                {
-                    boost::throw_exception(boost::lock_error());
-                }
-
-                new_state.exclusive_waiting_blocked=true;
-              }
-              else
-              {
-                new_state.exclusive=true;
-              }
-
-              state_data const current_state=interlocked_compare_exchange(&state,new_state,old_state);
-              if(current_state==old_state)
-              {
-                break;
-              }
-              old_state=current_state;
-            }
-
-            if(!old_state.shared_count && !old_state.exclusive)
-            {
-                return true;
-            }
-            #ifndef UNDER_CE
-            const bool wait_all = true;
-            #else
-            const bool wait_all = false;
-            #endif
-
-            chrono::system_clock::time_point n = chrono::system_clock::now();
-            unsigned long wait_res;
-            if (tp>n) {
-              chrono::milliseconds rel_time= chrono::ceil<chrono::milliseconds>(tp-chrono::system_clock::now());
-              wait_res=detail::winapi::WaitForMultipleObjectsEx(2,semaphores,wait_all,
-                  static_cast<unsigned long>(rel_time.count()), 0);
-            } else {
-              wait_res=detail::win32::timeout;
-            }
-            if(wait_res==detail::win32::timeout)
-            {
-              for(;;)
-              {
-                bool must_notify = false;
-                state_data new_state=old_state;
-                if(new_state.shared_count || new_state.exclusive)
-                {
-                  if(new_state.exclusive_waiting)
-                  {
-                    if(!--new_state.exclusive_waiting)
-                    {
-                      new_state.exclusive_waiting_blocked=false;
-                      must_notify = true;
-                    }
-                  }
-                }
-                else
-                {
-                  new_state.exclusive=true;
-                }
-
-                state_data const current_state=interlocked_compare_exchange(&state,new_state,old_state);
-                if (must_notify)
-                {
-                  BOOST_VERIFY(detail::winapi::ReleaseSemaphore(semaphores[unlock_sem],1,0)!=0);
-                }
-                if(current_state==old_state)
-                {
-                  break;
-                }
-                old_state=current_state;
-              }
-              if(!old_state.shared_count && !old_state.exclusive)
-              {
-                return true;
-              }
-              return false;
-            }
-            BOOST_ASSERT(wait_res<2);
-          }
+            typedef typename common_type<Duration, typename Clock::duration>::type common_duration;
+            return do_lock_until<Clock>(t, common_duration(chrono::milliseconds(100)));
         }
 #endif
 
@@ -698,7 +663,7 @@ namespace boost
                     return;
                 }
 
-                BOOST_VERIFY(!detail::winapi::WaitForSingleObjectEx(semaphores[unlock_sem],detail::winapi::infinite, 0));
+                BOOST_VERIFY(detail::winapi::WaitForSingleObjectEx(semaphores[unlock_sem],detail::winapi::infinite,0)==0);
             }
         }
 
@@ -790,7 +755,7 @@ namespace boost
                 {
                     if(!last_reader)
                     {
-                        BOOST_VERIFY(!detail::winapi::WaitForSingleObjectEx(upgrade_sem,detail::win32::infinite, 0));
+                        BOOST_VERIFY(detail::winapi::WaitForSingleObjectEx(upgrade_sem,detail::win32::infinite,0)==0);
                     }
                     break;
                 }
@@ -823,27 +788,6 @@ namespace boost
             }
             release_waiters(old_state);
         }
-//        bool try_unlock_upgrade_and_lock()
-//        {
-//          return false;
-//        }
-//#ifdef BOOST_THREAD_USES_CHRONO
-//        template <class Rep, class Period>
-//        bool
-//        try_unlock_upgrade_and_lock_for(
-//                                const chrono::duration<Rep, Period>& rel_time)
-//        {
-//          return try_unlock_upgrade_and_lock_until(
-//                                 chrono::steady_clock::now() + rel_time);
-//        }
-//        template <class Clock, class Duration>
-//        bool
-//        try_unlock_upgrade_and_lock_until(
-//                          const chrono::time_point<Clock, Duration>& abs_time)
-//        {
-//          return false;
-//        }
-//#endif
 
         void unlock_and_lock_shared()
         {

--- a/test/sync/mutual_exclusion/locks/upgrade_lock/cons/adopt_lock_pass.cpp
+++ b/test/sync/mutual_exclusion/locks/upgrade_lock/cons/adopt_lock_pass.cpp
@@ -27,7 +27,7 @@
 int main()
 {
   boost::shared_mutex m;
-  m.lock();
+  m.lock_upgrade();
   boost::upgrade_lock<boost::shared_mutex> lk(m, boost::adopt_lock);
   BOOST_TEST(lk.mutex() == &m);
   BOOST_TEST(lk.owns_lock() == true);


### PR DESCRIPTION
The following implementations have been fixed:

- include/boost/thread/win32/basic_timed_mutex.hpp
- include/boost/thread/win32/basic_recursive_mutex.hpp
- include/boost/thread/win32/shared_mutex.hpp
- include/boost/thread/v2/shared_mutex.hpp