### PR TITLE
future.hpp: Fixed name shadowing

### DIFF
--- a/include/boost/thread/future.hpp
+++ b/include/boost/thread/future.hpp
@@ -159,7 +159,7 @@ namespace boost
             boost::function<void()> callback;
             // This declaration should be only included conditionally, but is included to maintain the same layout.
             continuations_type continuations;
-            executor_ptr_type ex;
+            executor_ptr_type ex_;
 
             // This declaration should be only included conditionally, but is included to maintain the same layout.
             virtual void launch_continuation()
@@ -173,18 +173,18 @@ namespace boost
                 is_constructed(false),
                 policy_(launch::none),
                 continuations(),
-                ex()
+                ex_()
             {}
 
-            shared_state_base(exceptional_ptr const& ex_):
-                exception(ex_.ptr_),
+            shared_state_base(exceptional_ptr const& ex):
+                exception(ex.ptr_),
                 done(true),
                 is_valid_(true),
                 is_deferred_(false),
                 is_constructed(false),
                 policy_(launch::none),
                 continuations(),
-                ex()
+                ex_()
             {}
 
 
@@ -193,23 +193,23 @@ namespace boost
             }
             executor_ptr_type get_executor()
             {
-              return ex;
+              return ex_;
             }
 
             void set_executor_policy(executor_ptr_type aex)
             {
               set_executor();
-              ex = aex;
+              ex_ = aex;
             }
             void set_executor_policy(executor_ptr_type aex, boost::lock_guard<boost::mutex>&)
             {
               set_executor();
-              ex = aex;
+              ex_ = aex;
             }
             void set_executor_policy(executor_ptr_type aex, boost::unique_lock<boost::mutex>&)
             {
               set_executor();
-              ex = aex;
+              ex_ = aex;
             }
 
             bool valid(boost::unique_lock<boost::mutex>&) { return is_valid_; }


### PR DESCRIPTION
```
gcc.compile.c++ ../../../../bin.v2/libs/thread/build/gcc-gnu-6/release/cxxstd-03-iso/threadapi-pthread/threading-multi/pthread/thread.o
In file included from ../../../../libs/thread/src/pthread/thread.cpp:19:0:
../../../../boost/thread/future.hpp: In constructor ‘boost::detail::shared_state<T>::shared_state(const boost::exceptional_ptr&)’:
../../../../boost/thread/future.hpp:545:52: error: declaration of ‘ex’ shadows a member of ‘boost::detail::shared_state<T>’ [-Werror=shadow]
             shared_state(exceptional_ptr const& ex):
                                                    ^
In file included from ../../../../libs/thread/src/pthread/thread.cpp:19:0:
../../../../boost/thread/future.hpp:162:31: note: shadowed declaration is here
             executor_ptr_type ex;
                               ^~
In file included from ../../../../libs/thread/src/pthread/thread.cpp:19:0:
../../../../boost/thread/future.hpp: In constructor ‘boost::detail::shared_state<T&>::shared_state(const boost::exceptional_ptr&)’:
../../../../boost/thread/future.hpp:731:52: error: declaration of ‘ex’ shadows a member of ‘boost::detail::shared_state<T&>’ [-Werror=shadow]
             shared_state(exceptional_ptr const& ex):
                                                    ^
In file included from ../../../../libs/thread/src/pthread/thread.cpp:19:0:
../../../../boost/thread/future.hpp:162:31: note: shadowed declaration is here
             executor_ptr_type ex;
                               ^~
In file included from ../../../../libs/thread/src/pthread/thread.cpp:19:0:
../../../../boost/thread/future.hpp: In constructor ‘boost::detail::shared_state<void>::shared_state(const boost::exceptional_ptr&)’:
../../../../boost/thread/future.hpp:810:52: error: declaration of ‘ex’ shadows a member of ‘boost::detail::shared_state<void>’ [-Werror=shadow]
             shared_state(exceptional_ptr const& ex):
                                                    ^
In file included from ../../../../libs/thread/src/pthread/thread.cpp:19:0:
../../../../boost/thread/future.hpp:162:31: note: shadowed declaration is here
             executor_ptr_type ex;
                               ^~
```