### PR TITLE
Inheriting std::iterator is deprecated in c++17

### DIFF
--- a/test/test_generic_locks.cpp
+++ b/test/test_generic_locks.cpp
@@ -12,6 +12,8 @@
 #include <boost/thread/thread_only.hpp>
 #include <boost/thread/locks.hpp>
 #include <boost/thread/condition_variable.hpp>
+#include <iterator>
+#include <cstddef>
 
 BOOST_AUTO_TEST_CASE(test_lock_two_uncontended)
 {
@@ -300,13 +302,17 @@ BOOST_AUTO_TEST_CASE(test_lock_five_in_range)
     }
 }
 
-class dummy_iterator:
-    public std::iterator<std::forward_iterator_tag,
-                         dummy_mutex>
+class dummy_iterator
 {
 private:
     dummy_mutex* p;
 public:
+    typedef std::forward_iterator_tag iterator_category;
+    typedef dummy_mutex value_type;
+    typedef std::ptrdiff_t difference_type;
+    typedef dummy_mutex* pointer;
+    typedef dummy_mutex& reference;
+
     explicit dummy_iterator(dummy_mutex* p_):
         p(p_)
     {}


### PR DESCRIPTION
Therefore get rid of that and replace inheritance by lifting std::iterator's members into the derived class.

Signed-off-by: Daniela Engert <dani@ngrt.de>