### PR TITLE
Rewrite GetTickCount64 emulation implementation.

### DIFF
--- a/build/Jamfile.v2
+++ b/build/Jamfile.v2
@@ -284,6 +284,7 @@ alias thread_sources
       win32/thread.cpp
       win32/tss_dll.cpp
       win32/tss_pe.cpp
+      win32/thread_primitives.cpp
       future.cpp
     : ## requirements ##
       <threadapi>win32

--- a/include/boost/thread/detail/platform_time.hpp
+++ b/include/boost/thread/detail/platform_time.hpp
@@ -429,7 +429,7 @@ inline FP init_steady_clock(kern_return_t & err)
 #else
       // Use GetTickCount64() because it's more reliable on older
       // systems like Windows XP and Windows Server 2003.
-      win32::ticks_type msec = win32::GetTickCount64_()();
+      win32::ticks_type msec = win32::gettickcount64();
       return mono_platform_timepoint(msec * 1000000);
 #endif
 #elif defined(BOOST_THREAD_CHRONO_MAC_API)

--- a/src/win32/thread_primitives.cpp
+++ b/src/win32/thread_primitives.cpp
@@ -1,0 +1,79 @@
+//  thread_primitives.cpp
+//
+//  (C) Copyright 2018 Andrey Semashev
+//
+//  Distributed under the Boost Software License, Version 1.0. (See
+//  accompanying file LICENSE_1_0.txt or copy at
+//  http://www.boost.org/LICENSE_1_0.txt)
+
+#include <boost/winapi/config.hpp>
+#include <boost/winapi/dll.hpp>
+#include <boost/winapi/time.hpp>
+#include <boost/config.hpp>
+#include <boost/cstdint.hpp>
+#include <boost/memory_order.hpp>
+#include <boost/atomic/atomic.hpp>
+#include <boost/thread/win32/interlocked_read.hpp>
+#include <boost/thread/win32/thread_primitives.hpp>
+
+namespace boost {
+namespace detail {
+namespace win32 {
+
+#if BOOST_USE_WINAPI_VERSION >= BOOST_WINAPI_VERSION_WIN6
+
+// Directly use API from Vista and later
+BOOST_THREAD_DECL boost::detail::win32::detail::gettickcount64_t gettickcount64 = &::boost::winapi::GetTickCount64;
+
+#else // BOOST_USE_WINAPI_VERSION >= BOOST_WINAPI_VERSION_WIN6
+
+namespace {
+
+// Zero-initialized initially
+BOOST_ALIGNMENT(64) static boost::atomic< uint64_t > g_ticks;
+
+//! Artifical implementation of GetTickCount64
+ticks_type WINAPI get_tick_count64()
+{
+    uint64_t old_state = g_ticks.load(boost::memory_order_acquire);
+
+    uint32_t new_ticks = boost::winapi::GetTickCount();
+
+    uint32_t old_ticks = static_cast< uint32_t >(old_state & UINT64_C(0x00000000ffffffff));
+    uint64_t new_state = ((old_state & UINT64_C(0xffffffff00000000)) + (static_cast< uint64_t >(new_ticks < old_ticks) << 32)) | static_cast< uint64_t >(new_ticks);
+
+    g_ticks.store(new_state, boost::memory_order_release);
+
+    return new_state;
+}
+
+ticks_type WINAPI get_tick_count_init()
+{
+    boost::winapi::HMODULE_ hKernel32 = boost::winapi::GetModuleHandleW(L"kernel32.dll");
+    if (hKernel32)
+    {
+        boost::detail::win32::detail::gettickcount64_t p =
+            (boost::detail::win32::detail::gettickcount64_t)boost::winapi::get_proc_address(hKernel32, "GetTickCount64");
+        if (p)
+        {
+            // Use native API
+            boost::detail::interlocked_write_release(&gettickcount64, p);
+            return p();
+        }
+    }
+
+    // No native API available
+    boost::detail::interlocked_write_release(&gettickcount64, &get_tick_count64);
+    return get_tick_count64();
+}
+
+} // namespace
+
+BOOST_THREAD_DECL boost::detail::win32::detail::gettickcount64_t gettickcount64 = &get_tick_count_init;
+
+#endif // BOOST_USE_WINAPI_VERSION >= BOOST_WINAPI_VERSION_WIN6
+
+} // namespace win32
+} // namespace detail
+} // namespace boost
+

--- a/src/win32/thread_primitives.cpp
+++ b/src/win32/thread_primitives.cpp
@@ -9,6 +9,10 @@
 #include <boost/winapi/config.hpp>
 #include <boost/winapi/dll.hpp>
 #include <boost/winapi/time.hpp>
+#include <boost/winapi/event.hpp>
+#include <boost/winapi/handles.hpp>
+#include <boost/winapi/thread_pool.hpp>
+#include <cstdlib>
 #include <boost/config.hpp>
 #include <boost/cstdint.hpp>
 #include <boost/memory_order.hpp>
@@ -29,22 +33,59 @@ BOOST_THREAD_DECL boost::detail::win32::detail::gettickcount64_t gettickcount64 
 
 namespace {
 
+enum init_state
+{
+    uninitialized = 0,
+    in_progress,
+    initialized
+};
+
+struct get_tick_count64_state
+{
+    boost::atomic< uint64_t > ticks;
+    boost::atomic< init_state > init;
+    boost::winapi::HANDLE_ wait_event;
+    boost::winapi::HANDLE_ wait_handle;
+};
+
 // Zero-initialized initially
-BOOST_ALIGNMENT(64) static boost::atomic< uint64_t > g_ticks;
+BOOST_ALIGNMENT(64) static get_tick_count64_state g_state;
 
 //! Artifical implementation of GetTickCount64
 ticks_type WINAPI get_tick_count64()
 {
-    uint64_t old_state = g_ticks.load(boost::memory_order_acquire);
+    uint64_t old_state = g_state.ticks.load(boost::memory_order_acquire);
 
     uint32_t new_ticks = boost::winapi::GetTickCount();
 
     uint32_t old_ticks = static_cast< uint32_t >(old_state & UINT64_C(0x00000000ffffffff));
     uint64_t new_state = ((old_state & UINT64_C(0xffffffff00000000)) + (static_cast< uint64_t >(new_ticks < old_ticks) << 32)) | static_cast< uint64_t >(new_ticks);
 
-    g_ticks.store(new_state, boost::memory_order_release);
+    g_state.ticks.store(new_state, boost::memory_order_release);
 
     return new_state;
+}
+
+//! The function is called periodically in the system thread pool to make sure g_state.ticks is timely updated
+void NTAPI refresh_get_tick_count64(boost::winapi::PVOID_, boost::winapi::BOOLEAN_)
+{
+    get_tick_count64();
+}
+
+//! Cleanup function to stop get_tick_count64 refreshes
+void cleanup_get_tick_count64()
+{
+    if (g_state.wait_handle)
+    {
+        boost::winapi::UnregisterWait(g_state.wait_handle);
+        g_state.wait_handle = NULL;
+    }
+
+    if (g_state.wait_event)
+    {
+        boost::winapi::CloseHandle(g_state.wait_event);
+        g_state.wait_event = NULL;
+    }
 }
 
 ticks_type WINAPI get_tick_count_init()
@@ -57,13 +98,34 @@ ticks_type WINAPI get_tick_count_init()
         if (p)
         {
             // Use native API
-            boost::detail::interlocked_write_release(&gettickcount64, p);
+            boost::detail::interlocked_write_release((void**)&gettickcount64, (void*)p);
             return p();
         }
     }
 
-    // No native API available
-    boost::detail::interlocked_write_release(&gettickcount64, &get_tick_count64);
+    // No native API available. Use emulation with periodic refreshes to make sure the GetTickCount wrap arounds are properly counted.
+    init_state old_init = uninitialized;
+    if (g_state.init.compare_exchange_strong(old_init, in_progress, boost::memory_order_acq_rel, boost::memory_order_relaxed))
+    {
+        if (!g_state.wait_event)
+            g_state.wait_event = boost::winapi::create_anonymous_event(NULL, false, false);
+        if (g_state.wait_event)
+        {
+            boost::winapi::BOOL_ res = boost::winapi::RegisterWaitForSingleObject(&g_state.wait_handle, g_state.wait_event, &refresh_get_tick_count64, NULL, 0x7fffffff, boost::winapi::WT_EXECUTEINWAITTHREAD_);
+            if (res)
+            {
+                std::atexit(&cleanup_get_tick_count64);
+
+                boost::detail::interlocked_write_release((void**)&gettickcount64, (void*)&get_tick_count64);
+                g_state.init.store(initialized, boost::memory_order_release);
+                goto finish;
+            }
+        }
+
+        g_state.init.store(uninitialized, boost::memory_order_release);
+    }
+
+finish:
     return get_tick_count64();
 }
 
@@ -76,4 +138,3 @@ BOOST_THREAD_DECL boost::detail::win32::detail::gettickcount64_t gettickcount64 
 } // namespace win32
 } // namespace detail
 } // namespace boost
-


### PR DESCRIPTION
This is to resolve the possible license violation as the previous
implementation has been taken from StackOverflow and was not licensed
under the Boost Software License. The new implementation was adopted from
Boost.Log:

https://github.com/boostorg/log/blob/1cc577cbf5fae8f55c71c4493a7ef89027bd85dc/src/timestamp.cpp#L66-L86

The legal issue has been raised in:

https://lists.boost.org/Archives/boost/2018/02/241453.php

Fixes https://github.com/boostorg/thread/issues/209.