### PR TITLE
Add clang thread-safety annotations to boost::mutex (pthread-only)

### DIFF
--- a/include/boost/thread/detail/config.hpp
+++ b/include/boost/thread/detail/config.hpp
@@ -11,6 +11,7 @@
 #include <boost/config.hpp>
 #include <boost/detail/workaround.hpp>
 #include <boost/thread/detail/platform.hpp>
+#include <boost/thread/detail/thread_safety.hpp>
 
 //#define BOOST_THREAD_DONT_PROVIDE_INTERRUPTIONS
 // ATTRIBUTE_MAY_ALIAS

--- a/include/boost/thread/detail/thread_safety.hpp
+++ b/include/boost/thread/detail/thread_safety.hpp
@@ -1,0 +1,138 @@
+#ifndef BOOST_THREAD_DETAIL_THREAD_SAFETY_HPP
+#define BOOST_THREAD_DETAIL_THREAD_SAFETY_HPP
+
+// See https://clang.llvm.org/docs/ThreadSafetyAnalysis.html
+
+// Enable thread safety attributes only with clang.
+// The attributes can be safely erased when compiling with other compilers.
+#if defined(__clang__) && (!defined(SWIG))
+#define THREAD_ANNOTATION_ATTRIBUTE__(x)   __attribute__((x))
+#else
+#define THREAD_ANNOTATION_ATTRIBUTE__(x)   // no-op
+#endif
+
+#define CAPABILITY(x) \
+  THREAD_ANNOTATION_ATTRIBUTE__(capability(x))
+
+#define SCOPED_CAPABILITY \
+  THREAD_ANNOTATION_ATTRIBUTE__(scoped_lockable)
+
+#define GUARDED_BY(x) \
+  THREAD_ANNOTATION_ATTRIBUTE__(guarded_by(x))
+
+#define PT_GUARDED_BY(x) \
+  THREAD_ANNOTATION_ATTRIBUTE__(pt_guarded_by(x))
+
+#define ACQUIRED_BEFORE(...) \
+  THREAD_ANNOTATION_ATTRIBUTE__(acquired_before(__VA_ARGS__))
+
+#define ACQUIRED_AFTER(...) \
+  THREAD_ANNOTATION_ATTRIBUTE__(acquired_after(__VA_ARGS__))
+
+#define REQUIRES(...) \
+  THREAD_ANNOTATION_ATTRIBUTE__(requires_capability(__VA_ARGS__))
+
+#define REQUIRES_SHARED(...) \
+  THREAD_ANNOTATION_ATTRIBUTE__(requires_shared_capability(__VA_ARGS__))
+
+#define ACQUIRE(...) \
+  THREAD_ANNOTATION_ATTRIBUTE__(acquire_capability(__VA_ARGS__))
+
+#define ACQUIRE_SHARED(...) \
+  THREAD_ANNOTATION_ATTRIBUTE__(acquire_shared_capability(__VA_ARGS__))
+
+#define RELEASE(...) \
+  THREAD_ANNOTATION_ATTRIBUTE__(release_capability(__VA_ARGS__))
+
+#define RELEASE_SHARED(...) \
+  THREAD_ANNOTATION_ATTRIBUTE__(release_shared_capability(__VA_ARGS__))
+
+#define TRY_ACQUIRE(...) \
+  THREAD_ANNOTATION_ATTRIBUTE__(try_acquire_capability(__VA_ARGS__))
+
+#define TRY_ACQUIRE_SHARED(...) \
+  THREAD_ANNOTATION_ATTRIBUTE__(try_acquire_shared_capability(__VA_ARGS__))
+
+#define EXCLUDES(...) \
+  THREAD_ANNOTATION_ATTRIBUTE__(locks_excluded(__VA_ARGS__))
+
+#define ASSERT_CAPABILITY(x) \
+  THREAD_ANNOTATION_ATTRIBUTE__(assert_capability(x))
+
+#define ASSERT_SHARED_CAPABILITY(x) \
+  THREAD_ANNOTATION_ATTRIBUTE__(assert_shared_capability(x))
+
+#define RETURN_CAPABILITY(x) \
+  THREAD_ANNOTATION_ATTRIBUTE__(lock_returned(x))
+
+#define NO_THREAD_SAFETY_ANALYSIS \
+  THREAD_ANNOTATION_ATTRIBUTE__(no_thread_safety_analysis)
+
+#ifdef USE_LOCK_STYLE_THREAD_SAFETY_ATTRIBUTES
+// The original version of thread safety analysis the following attribute
+// definitions.  These use a lock-based terminology.  They are still in use
+// by existing thread safety code, and will continue to be supported.
+
+// Deprecated.
+#define PT_GUARDED_VAR \
+  THREAD_ANNOTATION_ATTRIBUTE__(pt_guarded_var)
+
+// Deprecated.
+#define GUARDED_VAR \
+  THREAD_ANNOTATION_ATTRIBUTE__(guarded_var)
+
+// Replaced by REQUIRES
+#define EXCLUSIVE_LOCKS_REQUIRED(...) \
+  THREAD_ANNOTATION_ATTRIBUTE__(exclusive_locks_required(__VA_ARGS__))
+
+// Replaced by REQUIRES_SHARED
+#define SHARED_LOCKS_REQUIRED(...) \
+  THREAD_ANNOTATION_ATTRIBUTE__(shared_locks_required(__VA_ARGS__))
+
+// Replaced by CAPABILITY
+#define LOCKABLE \
+  THREAD_ANNOTATION_ATTRIBUTE__(lockable)
+
+// Replaced by SCOPED_CAPABILITY
+#define SCOPED_LOCKABLE \
+  THREAD_ANNOTATION_ATTRIBUTE__(scoped_lockable)
+
+// Replaced by ACQUIRE
+#define EXCLUSIVE_LOCK_FUNCTION(...) \
+  THREAD_ANNOTATION_ATTRIBUTE__(exclusive_lock_function(__VA_ARGS__))
+
+// Replaced by ACQUIRE_SHARED
+#define SHARED_LOCK_FUNCTION(...) \
+  THREAD_ANNOTATION_ATTRIBUTE__(shared_lock_function(__VA_ARGS__))
+
+// Replaced by RELEASE and RELEASE_SHARED
+#define UNLOCK_FUNCTION(...) \
+  THREAD_ANNOTATION_ATTRIBUTE__(unlock_function(__VA_ARGS__))
+
+// Replaced by TRY_ACQUIRE
+#define EXCLUSIVE_TRYLOCK_FUNCTION(...) \
+  THREAD_ANNOTATION_ATTRIBUTE__(exclusive_trylock_function(__VA_ARGS__))
+
+// Replaced by TRY_ACQUIRE_SHARED
+#define SHARED_TRYLOCK_FUNCTION(...) \
+  THREAD_ANNOTATION_ATTRIBUTE__(shared_trylock_function(__VA_ARGS__))
+
+// Replaced by ASSERT_CAPABILITY
+#define ASSERT_EXCLUSIVE_LOCK(...) \
+  THREAD_ANNOTATION_ATTRIBUTE__(assert_exclusive_lock(__VA_ARGS__))
+
+// Replaced by ASSERT_SHARED_CAPABILITY
+#define ASSERT_SHARED_LOCK(...) \
+  THREAD_ANNOTATION_ATTRIBUTE__(assert_shared_lock(__VA_ARGS__))
+
+// Replaced by EXCLUDE_CAPABILITY.
+#define LOCKS_EXCLUDED(...) \
+  THREAD_ANNOTATION_ATTRIBUTE__(locks_excluded(__VA_ARGS__))
+
+// Replaced by RETURN_CAPABILITY
+#define LOCK_RETURNED(x) \
+  THREAD_ANNOTATION_ATTRIBUTE__(lock_returned(x))
+
+#endif  // USE_LOCK_STYLE_THREAD_SAFETY_ATTRIBUTES
+
+#endif  // BOOST_THREAD_DETAIL_THREAD_SAFETY_HPP

--- a/include/boost/thread/detail/thread_safety.hpp
+++ b/include/boost/thread/detail/thread_safety.hpp
@@ -6,67 +6,67 @@
 // Enable thread safety attributes only with clang.
 // The attributes can be safely erased when compiling with other compilers.
 #if defined(__clang__) && (!defined(SWIG))
-#define THREAD_ANNOTATION_ATTRIBUTE__(x)   __attribute__((x))
+#define BOOST_THREAD_ANNOTATION_ATTRIBUTE__(x)   __attribute__((x))
 #else
-#define THREAD_ANNOTATION_ATTRIBUTE__(x)   // no-op
+#define BOOST_THREAD_ANNOTATION_ATTRIBUTE__(x)   // no-op
 #endif
 
-#define CAPABILITY(x) \
-  THREAD_ANNOTATION_ATTRIBUTE__(capability(x))
+#define BOOST_THREAD_CAPABILITY(x) \
+  BOOST_THREAD_ANNOTATION_ATTRIBUTE__(capability(x))
 
-#define SCOPED_CAPABILITY \
-  THREAD_ANNOTATION_ATTRIBUTE__(scoped_lockable)
+#define BOOST_THREAD_SCOPED_CAPABILITY \
+  BOOST_THREAD_ANNOTATION_ATTRIBUTE__(scoped_lockable)
 
-#define GUARDED_BY(x) \
-  THREAD_ANNOTATION_ATTRIBUTE__(guarded_by(x))
+#define BOOST_THREAD_GUARDED_BY(x) \
+  BOOST_THREAD_ANNOTATION_ATTRIBUTE__(guarded_by(x))
 
-#define PT_GUARDED_BY(x) \
-  THREAD_ANNOTATION_ATTRIBUTE__(pt_guarded_by(x))
+#define BOOST_THREAD_PT_GUARDED_BY(x) \
+  BOOST_THREAD_ANNOTATION_ATTRIBUTE__(pt_guarded_by(x))
 
-#define ACQUIRED_BEFORE(...) \
-  THREAD_ANNOTATION_ATTRIBUTE__(acquired_before(__VA_ARGS__))
+#define BOOST_THREAD_ACQUIRED_BEFORE(...) \
+  BOOST_THREAD_ANNOTATION_ATTRIBUTE__(acquired_before(__VA_ARGS__))
 
-#define ACQUIRED_AFTER(...) \
-  THREAD_ANNOTATION_ATTRIBUTE__(acquired_after(__VA_ARGS__))
+#define BOOST_THREAD_ACQUIRED_AFTER(...) \
+  BOOST_THREAD_ANNOTATION_ATTRIBUTE__(acquired_after(__VA_ARGS__))
 
-#define REQUIRES(...) \
-  THREAD_ANNOTATION_ATTRIBUTE__(requires_capability(__VA_ARGS__))
+#define BOOST_THREAD_REQUIRES(...) \
+  BOOST_THREAD_ANNOTATION_ATTRIBUTE__(requires_capability(__VA_ARGS__))
 
-#define REQUIRES_SHARED(...) \
-  THREAD_ANNOTATION_ATTRIBUTE__(requires_shared_capability(__VA_ARGS__))
+#define BOOST_THREAD_REQUIRES_SHARED(...) \
+  BOOST_THREAD_ANNOTATION_ATTRIBUTE__(requires_shared_capability(__VA_ARGS__))
 
-#define ACQUIRE(...) \
-  THREAD_ANNOTATION_ATTRIBUTE__(acquire_capability(__VA_ARGS__))
+#define BOOST_THREAD_ACQUIRE(...) \
+  BOOST_THREAD_ANNOTATION_ATTRIBUTE__(acquire_capability(__VA_ARGS__))
 
-#define ACQUIRE_SHARED(...) \
-  THREAD_ANNOTATION_ATTRIBUTE__(acquire_shared_capability(__VA_ARGS__))
+#define BOOST_THREAD_ACQUIRE_SHARED(...) \
+  BOOST_THREAD_ANNOTATION_ATTRIBUTE__(acquire_shared_capability(__VA_ARGS__))
 
-#define RELEASE(...) \
-  THREAD_ANNOTATION_ATTRIBUTE__(release_capability(__VA_ARGS__))
+#define BOOST_THREAD_RELEASE(...) \
+  BOOST_THREAD_ANNOTATION_ATTRIBUTE__(release_capability(__VA_ARGS__))
 
-#define RELEASE_SHARED(...) \
-  THREAD_ANNOTATION_ATTRIBUTE__(release_shared_capability(__VA_ARGS__))
+#define BOOST_THREAD_RELEASE_SHARED(...) \
+  BOOST_THREAD_ANNOTATION_ATTRIBUTE__(release_shared_capability(__VA_ARGS__))
 
-#define TRY_ACQUIRE(...) \
-  THREAD_ANNOTATION_ATTRIBUTE__(try_acquire_capability(__VA_ARGS__))
+#define BOOST_THREAD_TRY_ACQUIRE(...) \
+  BOOST_THREAD_ANNOTATION_ATTRIBUTE__(try_acquire_capability(__VA_ARGS__))
 
-#define TRY_ACQUIRE_SHARED(...) \
-  THREAD_ANNOTATION_ATTRIBUTE__(try_acquire_shared_capability(__VA_ARGS__))
+#define BOOST_THREAD_TRY_ACQUIRE_SHARED(...) \
+  BOOST_THREAD_ANNOTATION_ATTRIBUTE__(try_acquire_shared_capability(__VA_ARGS__))
 
-#define EXCLUDES(...) \
-  THREAD_ANNOTATION_ATTRIBUTE__(locks_excluded(__VA_ARGS__))
+#define BOOST_THREAD_EXCLUDES(...) \
+  BOOST_THREAD_ANNOTATION_ATTRIBUTE__(locks_excluded(__VA_ARGS__))
 
-#define ASSERT_CAPABILITY(x) \
-  THREAD_ANNOTATION_ATTRIBUTE__(assert_capability(x))
+#define BOOST_THREAD_ASSERT_CAPABILITY(x) \
+  BOOST_THREAD_ANNOTATION_ATTRIBUTE__(assert_capability(x))
 
-#define ASSERT_SHARED_CAPABILITY(x) \
-  THREAD_ANNOTATION_ATTRIBUTE__(assert_shared_capability(x))
+#define BOOST_THREAD_ASSERT_SHARED_CAPABILITY(x) \
+  BOOST_THREAD_ANNOTATION_ATTRIBUTE__(assert_shared_capability(x))
 
-#define RETURN_CAPABILITY(x) \
-  THREAD_ANNOTATION_ATTRIBUTE__(lock_returned(x))
+#define BOOST_THREAD_RETURN_CAPABILITY(x) \
+  BOOST_THREAD_ANNOTATION_ATTRIBUTE__(lock_returned(x))
 
-#define NO_THREAD_SAFETY_ANALYSIS \
-  THREAD_ANNOTATION_ATTRIBUTE__(no_thread_safety_analysis)
+#define BOOST_THREAD_NO_THREAD_SAFETY_ANALYSIS \
+  BOOST_THREAD_ANNOTATION_ATTRIBUTE__(no_thread_safety_analysis)
 
 #ifdef USE_LOCK_STYLE_THREAD_SAFETY_ATTRIBUTES
 // The original version of thread safety analysis the following attribute
@@ -74,64 +74,64 @@
 // by existing thread safety code, and will continue to be supported.
 
 // Deprecated.
-#define PT_GUARDED_VAR \
-  THREAD_ANNOTATION_ATTRIBUTE__(pt_guarded_var)
+#define BOOST_THREAD_PT_GUARDED_VAR \
+  BOOST_THREAD_ANNOTATION_ATTRIBUTE__(pt_guarded_var)
 
 // Deprecated.
-#define GUARDED_VAR \
-  THREAD_ANNOTATION_ATTRIBUTE__(guarded_var)
+#define BOOST_THREAD_GUARDED_VAR \
+  BOOST_THREAD_ANNOTATION_ATTRIBUTE__(guarded_var)
 
 // Replaced by REQUIRES
-#define EXCLUSIVE_LOCKS_REQUIRED(...) \
-  THREAD_ANNOTATION_ATTRIBUTE__(exclusive_locks_required(__VA_ARGS__))
+#define BOOST_THREAD_EXCLUSIVE_LOCKS_REQUIRED(...) \
+  BOOST_THREAD_ANNOTATION_ATTRIBUTE__(exclusive_locks_required(__VA_ARGS__))
 
 // Replaced by REQUIRES_SHARED
-#define SHARED_LOCKS_REQUIRED(...) \
-  THREAD_ANNOTATION_ATTRIBUTE__(shared_locks_required(__VA_ARGS__))
+#define BOOST_THREAD_SHARED_LOCKS_REQUIRED(...) \
+  BOOST_THREAD_ANNOTATION_ATTRIBUTE__(shared_locks_required(__VA_ARGS__))
 
 // Replaced by CAPABILITY
-#define LOCKABLE \
-  THREAD_ANNOTATION_ATTRIBUTE__(lockable)
+#define BOOST_THREAD_LOCKABLE \
+  BOOST_THREAD_ANNOTATION_ATTRIBUTE__(lockable)
 
 // Replaced by SCOPED_CAPABILITY
-#define SCOPED_LOCKABLE \
-  THREAD_ANNOTATION_ATTRIBUTE__(scoped_lockable)
+#define BOOST_THREAD_SCOPED_LOCKABLE \
+  BOOST_THREAD_ANNOTATION_ATTRIBUTE__(scoped_lockable)
 
 // Replaced by ACQUIRE
-#define EXCLUSIVE_LOCK_FUNCTION(...) \
-  THREAD_ANNOTATION_ATTRIBUTE__(exclusive_lock_function(__VA_ARGS__))
+#define BOOST_THREAD_EXCLUSIVE_LOCK_FUNCTION(...) \
+  BOOST_THREAD_ANNOTATION_ATTRIBUTE__(exclusive_lock_function(__VA_ARGS__))
 
 // Replaced by ACQUIRE_SHARED
-#define SHARED_LOCK_FUNCTION(...) \
-  THREAD_ANNOTATION_ATTRIBUTE__(shared_lock_function(__VA_ARGS__))
+#define BOOST_THREAD_SHARED_LOCK_FUNCTION(...) \
+  BOOST_THREAD_ANNOTATION_ATTRIBUTE__(shared_lock_function(__VA_ARGS__))
 
 // Replaced by RELEASE and RELEASE_SHARED
-#define UNLOCK_FUNCTION(...) \
-  THREAD_ANNOTATION_ATTRIBUTE__(unlock_function(__VA_ARGS__))
+#define BOOST_THREAD_UNLOCK_FUNCTION(...) \
+  BOOST_THREAD_ANNOTATION_ATTRIBUTE__(unlock_function(__VA_ARGS__))
 
 // Replaced by TRY_ACQUIRE
-#define EXCLUSIVE_TRYLOCK_FUNCTION(...) \
-  THREAD_ANNOTATION_ATTRIBUTE__(exclusive_trylock_function(__VA_ARGS__))
+#define BOOST_THREAD_EXCLUSIVE_TRYLOCK_FUNCTION(...) \
+  BOOST_THREAD_ANNOTATION_ATTRIBUTE__(exclusive_trylock_function(__VA_ARGS__))
 
 // Replaced by TRY_ACQUIRE_SHARED
-#define SHARED_TRYLOCK_FUNCTION(...) \
-  THREAD_ANNOTATION_ATTRIBUTE__(shared_trylock_function(__VA_ARGS__))
+#define BOOST_THREAD_SHARED_TRYLOCK_FUNCTION(...) \
+  BOOST_THREAD_ANNOTATION_ATTRIBUTE__(shared_trylock_function(__VA_ARGS__))
 
 // Replaced by ASSERT_CAPABILITY
-#define ASSERT_EXCLUSIVE_LOCK(...) \
-  THREAD_ANNOTATION_ATTRIBUTE__(assert_exclusive_lock(__VA_ARGS__))
+#define BOOST_THREAD_ASSERT_EXCLUSIVE_LOCK(...) \
+  BOOST_THREAD_ANNOTATION_ATTRIBUTE__(assert_exclusive_lock(__VA_ARGS__))
 
 // Replaced by ASSERT_SHARED_CAPABILITY
-#define ASSERT_SHARED_LOCK(...) \
-  THREAD_ANNOTATION_ATTRIBUTE__(assert_shared_lock(__VA_ARGS__))
+#define BOOST_THREAD_ASSERT_SHARED_LOCK(...) \
+  BOOST_THREAD_ANNOTATION_ATTRIBUTE__(assert_shared_lock(__VA_ARGS__))
 
 // Replaced by EXCLUDE_CAPABILITY.
-#define LOCKS_EXCLUDED(...) \
-  THREAD_ANNOTATION_ATTRIBUTE__(locks_excluded(__VA_ARGS__))
+#define BOOST_THREAD_LOCKS_EXCLUDED(...) \
+  BOOST_THREAD_ANNOTATION_ATTRIBUTE__(locks_excluded(__VA_ARGS__))
 
 // Replaced by RETURN_CAPABILITY
-#define LOCK_RETURNED(x) \
-  THREAD_ANNOTATION_ATTRIBUTE__(lock_returned(x))
+#define BOOST_THREAD_LOCK_RETURNED(x) \
+  BOOST_THREAD_ANNOTATION_ATTRIBUTE__(lock_returned(x))
 
 #endif  // USE_LOCK_STYLE_THREAD_SAFETY_ATTRIBUTES
 

--- a/include/boost/thread/lock_guard.hpp
+++ b/include/boost/thread/lock_guard.hpp
@@ -23,7 +23,7 @@ namespace boost
 {
 
   template <typename Mutex>
-  class lock_guard
+  class BOOST_THREAD_SCOPED_CAPABILITY lock_guard
   {
   private:
     Mutex& m;
@@ -32,13 +32,13 @@ namespace boost
     typedef Mutex mutex_type;
     BOOST_THREAD_NO_COPYABLE( lock_guard )
 
-    explicit lock_guard(Mutex& m_) :
+    explicit lock_guard(Mutex& m_) BOOST_THREAD_ACQUIRE(m_) :
       m(m_)
     {
       m.lock();
     }
 
-    lock_guard(Mutex& m_, adopt_lock_t) :
+    lock_guard(Mutex& m_, adopt_lock_t) BOOST_THREAD_REQUIRES(m_) :
       m(m_)
     {
 #if ! defined BOOST_THREAD_PROVIDES_NESTED_LOCKS
@@ -62,7 +62,7 @@ namespace boost
     }
 
 #endif
-    ~lock_guard()
+    ~lock_guard() BOOST_THREAD_RELEASE()
     {
       m.unlock();
     }

--- a/include/boost/thread/pthread/mutex.hpp
+++ b/include/boost/thread/pthread/mutex.hpp
@@ -85,7 +85,7 @@ namespace boost
 #endif
 
   }
-    class mutex
+    class CAPABILITY("mutex") mutex
     {
     private:
         pthread_mutex_t m;
@@ -107,7 +107,7 @@ namespace boost
           BOOST_ASSERT(!res);
         }
 
-        void lock()
+        void lock() ACQUIRE()
         {
             int res = posix::pthread_mutex_lock(&m);
             if (res)
@@ -116,7 +116,7 @@ namespace boost
             }
         }
 
-        void unlock()
+        void unlock() RELEASE()
         {
             int res = posix::pthread_mutex_unlock(&m);
             (void)res;
@@ -127,7 +127,7 @@ namespace boost
 //            }
         }
 
-        bool try_lock()
+        bool try_lock() TRY_ACQUIRE(true)
         {
             int res;
             do

--- a/include/boost/thread/pthread/mutex.hpp
+++ b/include/boost/thread/pthread/mutex.hpp
@@ -85,7 +85,7 @@ namespace boost
 #endif
 
   }
-    class CAPABILITY("mutex") mutex
+    class BOOST_THREAD_CAPABILITY("mutex") mutex
     {
     private:
         pthread_mutex_t m;
@@ -107,7 +107,7 @@ namespace boost
           BOOST_ASSERT(!res);
         }
 
-        void lock() ACQUIRE()
+        void lock() BOOST_THREAD_ACQUIRE()
         {
             int res = posix::pthread_mutex_lock(&m);
             if (res)
@@ -116,7 +116,7 @@ namespace boost
             }
         }
 
-        void unlock() RELEASE()
+        void unlock() BOOST_THREAD_RELEASE()
         {
             int res = posix::pthread_mutex_unlock(&m);
             (void)res;
@@ -127,7 +127,7 @@ namespace boost
 //            }
         }
 
-        bool try_lock() TRY_ACQUIRE(true)
+        bool try_lock() BOOST_THREAD_TRY_ACQUIRE(true)
         {
             int res;
             do

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -208,28 +208,34 @@ rule thread-compile-fail ( sources : reqs * : name )
     ;
 }
 
+rule clang-thread-safety ( properties * )
+{
+    if <toolset>clang in $(properties)
+    {
+        return <cxxflags>-Werror=thread-safety ;
+    }
+    else
+    {
+        return <build>no ;
+    }
+}
+
 rule thread-safety-compile ( sources : reqs * : name )
 {
-    if <toolset>clang in $(reqs)
-    {
-        return
-        [ compile $(sources)
-            : $(reqs) <cxxflags>-Werror=thread-safety
-            : $(name) ]
-        ;
-    }
+    return
+    [ compile $(sources)
+        : $(reqs) <conditional>@clang-thread-safety
+        : $(name) ]
+    ;
 }
 
 rule thread-safety-compile-fail ( sources : reqs * : name )
 {
-    if <toolset>clang in $(reqs)
-    {
-        return
-        [ compile-fail $(sources)
-            : $(reqs) <cxxflags>-Werror=thread-safety
-            : $(name) ]
-        ;
-    }
+    return
+    [ compile-fail $(sources)
+        : $(reqs) <conditional>@clang-thread-safety
+        : $(name) ]
+    ;
 }
 
 rule thread-compile ( sources : reqs * : name )

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -645,12 +645,12 @@ rule thread-compile ( sources : reqs * : name )
     :
           [ thread-compile-fail ./sync/mutual_exclusion/mutex/assign_fail.cpp : : mutex__assign_f ]
           [ thread-compile-fail ./sync/mutual_exclusion/mutex/copy_fail.cpp : : mutex__copy_f ]
-          [ thread-safety-compile ./sync/mutual_exclusion/mutex/lock_compile_pass.cpp : <toolset>clang : mutex__lock_compile_p ]
-          [ thread-safety-compile-fail ./sync/mutual_exclusion/mutex/lock_compile_fail.cpp : <toolset>clang : mutex__lock_compile_f ]
+          [ thread-safety-compile ./sync/mutual_exclusion/mutex/lock_compile_pass.cpp : : mutex__lock_compile_p ]
+          [ thread-safety-compile-fail ./sync/mutual_exclusion/mutex/lock_compile_fail.cpp : : mutex__lock_compile_f ]
           # https://bugs.llvm.org/show_bug.cgi?id=32954
           # http://clang-developers.42468.n3.nabble.com/thread-safety-warnings-specifically-try-acquire-capability-td4059337.html
-          #[ thread-safety-compile ./sync/mutual_exclusion/mutex/try_lock_compile_pass.cpp : <toolset>clang : mutex__try_lock_compile_p ]
-          [ thread-safety-compile-fail ./sync/mutual_exclusion/mutex/try_lock_compile_fail.cpp : <toolset>clang : mutex__try_lock_compile_f ]
+          #[ thread-safety-compile ./sync/mutual_exclusion/mutex/try_lock_compile_pass.cpp : : mutex__try_lock_compile_p ]
+          [ thread-safety-compile-fail ./sync/mutual_exclusion/mutex/try_lock_compile_fail.cpp : : mutex__try_lock_compile_f ]
           [ thread-run2-noit ./sync/mutual_exclusion/mutex/default_pass.cpp : mutex__default_p ]
           [ thread-run2-noit ./sync/mutual_exclusion/mutex/lock_pass.cpp : mutex__lock_p ]
           [ thread-run2-noit-pthread ./sync/mutual_exclusion/mutex/native_handle_pass.cpp : mutex__native_handle_p ]

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -208,6 +208,30 @@ rule thread-compile-fail ( sources : reqs * : name )
     ;
 }
 
+rule thread-safety-compile ( sources : reqs * : name )
+{
+    if <toolset>clang in $(reqs)
+    {
+        return
+        [ compile $(sources)
+            : $(reqs) <cxxflags>-Werror=thread-safety
+            : $(name) ]
+        ;
+    }
+}
+
+rule thread-safety-compile-fail ( sources : reqs * : name )
+{
+    if <toolset>clang in $(reqs)
+    {
+        return
+        [ compile-fail $(sources)
+            : $(reqs) <cxxflags>-Werror=thread-safety
+            : $(name) ]
+        ;
+    }
+}
+
 rule thread-compile ( sources : reqs * : name )
 {
     return
@@ -615,6 +639,12 @@ rule thread-compile ( sources : reqs * : name )
     :
           [ thread-compile-fail ./sync/mutual_exclusion/mutex/assign_fail.cpp : : mutex__assign_f ]
           [ thread-compile-fail ./sync/mutual_exclusion/mutex/copy_fail.cpp : : mutex__copy_f ]
+          [ thread-safety-compile ./sync/mutual_exclusion/mutex/lock_compile_pass.cpp : <toolset>clang : mutex__lock_compile_p ]
+          [ thread-safety-compile-fail ./sync/mutual_exclusion/mutex/lock_compile_fail.cpp : <toolset>clang : mutex__lock_compile_f ]
+          # https://bugs.llvm.org/show_bug.cgi?id=32954
+          # http://clang-developers.42468.n3.nabble.com/thread-safety-warnings-specifically-try-acquire-capability-td4059337.html
+          #[ thread-safety-compile ./sync/mutual_exclusion/mutex/try_lock_compile_pass.cpp : <toolset>clang : mutex__try_lock_compile_p ]
+          [ thread-safety-compile-fail ./sync/mutual_exclusion/mutex/try_lock_compile_fail.cpp : <toolset>clang : mutex__try_lock_compile_f ]
           [ thread-run2-noit ./sync/mutual_exclusion/mutex/default_pass.cpp : mutex__default_p ]
           [ thread-run2-noit ./sync/mutual_exclusion/mutex/lock_pass.cpp : mutex__lock_p ]
           [ thread-run2-noit-pthread ./sync/mutual_exclusion/mutex/native_handle_pass.cpp : mutex__native_handle_p ]

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -491,6 +491,10 @@ rule thread-compile ( sources : reqs * : name )
     :
           [ thread-compile-fail ./sync/mutual_exclusion/locks/lock_guard/copy_assign_fail.cpp : : lock_guard__cons__copy_assign_f ]
           [ thread-compile-fail ./sync/mutual_exclusion/locks/lock_guard/copy_ctor_fail.cpp : : lock_guard__cons__copy_ctor_f ]
+          [ thread-safety-compile ./sync/mutual_exclusion/locks/lock_guard/lock_guard_compile_pass.cpp : : lock_guard__lock_compile_p ]
+          [ thread-safety-compile-fail ./sync/mutual_exclusion/locks/lock_guard/lock_guard_compile_fail.cpp : : lock_guard__lock_compile_f ]
+          [ thread-safety-compile ./sync/mutual_exclusion/locks/lock_guard/lock_guard_adopt_lock_compile_pass.cpp : : lock_guard__adopt_lock_compile_p ]
+          [ thread-safety-compile-fail ./sync/mutual_exclusion/locks/lock_guard/lock_guard_adopt_lock_compile_fail.cpp : : lock_guard__adopt_lock_compile_f ]
           [ thread-run2-noit ./sync/mutual_exclusion/locks/lock_guard/adopt_lock_pass.cpp : lock_guard__cons__adopt_lock_p ]
           [ thread-run2-noit ./sync/mutual_exclusion/locks/lock_guard/default_pass.cpp : lock_guard__cons__default_p ]
           [ thread-run2-noit ./sync/mutual_exclusion/locks/lock_guard/types_pass.cpp : lock_guard__types_p ]

--- a/test/sync/mutual_exclusion/locks/lock_guard/lock_guard_adopt_lock_compile_fail.cpp
+++ b/test/sync/mutual_exclusion/locks/lock_guard/lock_guard_adopt_lock_compile_fail.cpp
@@ -1,0 +1,21 @@
+// Copyright (C) 2018 Tom Hughes
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+// <boost/thread/lock_guard.hpp>
+
+// template <class Mutex> class lock_guard;
+
+// lock_guard(Mutex& m_, adopt_lock_t)
+
+#include <boost/thread/lock_guard.hpp>
+#include <boost/thread/mutex.hpp>
+#include <boost/detail/lightweight_test.hpp>
+
+boost::mutex m;
+
+void fail()
+{
+  boost::lock_guard<boost::mutex> lk(m, boost::adopt_lock);
+}

--- a/test/sync/mutual_exclusion/locks/lock_guard/lock_guard_adopt_lock_compile_pass.cpp
+++ b/test/sync/mutual_exclusion/locks/lock_guard/lock_guard_adopt_lock_compile_pass.cpp
@@ -1,0 +1,22 @@
+// Copyright (C) 2018 Tom Hughes
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+// <boost/thread/lock_guard.hpp>
+
+// template <class Mutex> class lock_guard;
+
+// lock_guard(Mutex& m_, adopt_lock_t)
+
+#include <boost/thread/lock_guard.hpp>
+#include <boost/thread/mutex.hpp>
+#include <boost/detail/lightweight_test.hpp>
+
+boost::mutex m;
+
+void pass()
+{
+  m.lock();
+  boost::lock_guard<boost::mutex> lk(m, boost::adopt_lock);
+}

--- a/test/sync/mutual_exclusion/locks/lock_guard/lock_guard_compile_fail.cpp
+++ b/test/sync/mutual_exclusion/locks/lock_guard/lock_guard_compile_fail.cpp
@@ -1,0 +1,22 @@
+// Copyright (C) 2018 Tom Hughes
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+// <boost/thread/lock_guard.hpp>
+
+// template <class Mutex> class lock_guard;
+
+// lock_guard(Mutex& m_)
+
+#include <boost/thread/lock_guard.hpp>
+#include <boost/thread/mutex.hpp>
+#include <boost/detail/lightweight_test.hpp>
+
+boost::mutex m;
+
+void fail()
+{
+  boost::lock_guard<boost::mutex> lk0(m);
+  boost::lock_guard<boost::mutex> lk1(m);
+}

--- a/test/sync/mutual_exclusion/locks/lock_guard/lock_guard_compile_pass.cpp
+++ b/test/sync/mutual_exclusion/locks/lock_guard/lock_guard_compile_pass.cpp
@@ -1,0 +1,24 @@
+// Copyright (C) 2018 Tom Hughes
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+// <boost/thread/lock_guard.hpp>
+
+// template <class Mutex> class lock_guard;
+
+// lock_guard(Mutex& m_)
+
+#include <boost/thread/lock_guard.hpp>
+#include <boost/thread/mutex.hpp>
+#include <boost/detail/lightweight_test.hpp>
+
+boost::mutex m;
+
+void pass()
+{
+  {
+    boost::lock_guard<boost::mutex> lk0(m);
+  }
+  boost::lock_guard<boost::mutex> lk1(m);
+}

--- a/test/sync/mutual_exclusion/mutex/lock_compile_fail.cpp
+++ b/test/sync/mutual_exclusion/mutex/lock_compile_fail.cpp
@@ -1,0 +1,19 @@
+// Copyright (C) 2017 Tom Hughes
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+// <boost/thread/mutex.hpp>
+
+// class mutex;
+
+#include <boost/thread/mutex.hpp>
+#include <boost/detail/lightweight_test.hpp>
+
+void fail()
+{
+  boost::mutex m0;
+  m0.lock();
+  m0.lock();
+  m0.unlock();
+}

--- a/test/sync/mutual_exclusion/mutex/lock_compile_pass.cpp
+++ b/test/sync/mutual_exclusion/mutex/lock_compile_pass.cpp
@@ -1,0 +1,18 @@
+// Copyright (C) 2017 Tom Hughes
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+// <boost/thread/mutex.hpp>
+
+// class mutex;
+
+#include <boost/thread/mutex.hpp>
+#include <boost/detail/lightweight_test.hpp>
+
+void pass()
+{
+  boost::mutex m0;
+  m0.lock();
+  m0.unlock();
+}

--- a/test/sync/mutual_exclusion/mutex/try_lock_compile_fail.cpp
+++ b/test/sync/mutual_exclusion/mutex/try_lock_compile_fail.cpp
@@ -1,0 +1,19 @@
+// Copyright (C) 2017 Tom Hughes
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+// <boost/thread/mutex.hpp>
+
+// class mutex;
+
+#include <boost/thread/mutex.hpp>
+#include <boost/detail/lightweight_test.hpp>
+
+void fail()
+{
+  boost::mutex m0;
+  if (!m0.try_lock()) {
+    m0.unlock();
+  }
+}

--- a/test/sync/mutual_exclusion/mutex/try_lock_compile_pass.cpp
+++ b/test/sync/mutual_exclusion/mutex/try_lock_compile_pass.cpp
@@ -1,0 +1,19 @@
+// Copyright (C) 2017 Tom Hughes
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+// <boost/thread/mutex.hpp>
+
+// class mutex;
+
+#include <boost/thread/mutex.hpp>
+#include <boost/detail/lightweight_test.hpp>
+
+void pass()
+{
+  boost::mutex m0;
+  if (m0.try_lock()) {
+    m0.unlock();
+  }
+}


### PR DESCRIPTION
This is a first-pass attempt to get feedback for adding thread safety annotations (#101). There are more annotations that can be added to other classes, but I want to make sure that the approach and style are correct before doing more.

I think the first step is to add the annotations to the associated boost classes so that downstream projects can use them. A next and more advanced step would be to get the `boost::thread` library itself compiling with analysis enabled (`-Wthread-safety`).

Specifically, I'm not very familiar with boost build, so there may be better ways of doing what I'm trying to do, which is to conditionally compile tests only if the compiler is `clang`.

It's also unclear to me which builds on travis need to succeed in order for the PR to be accepted since several variants are currently failing: https://travis-ci.org/boostorg/thread