### PR TITLE
Remove racy checks

### DIFF
--- a/test/sync/futures/when_any/iterators_pass.cpp
+++ b/test/sync/futures/when_any/iterators_pass.cpp
@@ -205,7 +205,6 @@ int main()
     BOOST_TEST(all.valid());
     BOOST_TEST(! all.is_ready());
     pt1();
-    BOOST_TEST(! all.is_ready());
     pt2();
     boost::this_thread::sleep_for(boost::chrono::milliseconds(300));
     BOOST_TEST(all.is_ready());

--- a/test/sync/futures/when_any/variadic_pass.cpp
+++ b/test/sync/futures/when_any/variadic_pass.cpp
@@ -169,7 +169,6 @@ int main()
     BOOST_TEST(all.valid());
     BOOST_TEST(! all.is_ready());
     pt1();
-    BOOST_TEST(! all.is_ready());
     pt2();
     boost::this_thread::sleep_for(boost::chrono::milliseconds(300));
     BOOST_TEST(all.is_ready());


### PR DESCRIPTION
 These checks may or may not be true depending on how long it takes `pt1`/`p1` to finish executing. You can verify this by adding a sleep before the check in which case "is_ready()" is always true.

My guess is this may have come from copy/paste from the `when_all` tests. I did not go through all `when_any` tests extremely thoroughly, so there might be other cases as well.