### PR TITLE
Account for sleep time in timing tests

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -45,7 +45,7 @@ build_steps: &build_steps
         command: |
           echo "using $TOOLSET : : $COMPILER : <cxxflags>-std=$CXXSTD <cxxflags>$DEFINES ;" > ~/user-config.jam
           cd ../boost-root
-          ./b2 -j10 libs/thread/test toolset=$TOOLSET
+          ./b2 -j8 libs/thread/test toolset=$TOOLSET
 
 mac_build: &mac_build
   macos:

--- a/circle.yml
+++ b/circle.yml
@@ -66,7 +66,6 @@ jobs:
       - TOOLSET: "gcc"
       - COMPILER: "g++"
       - CXXSTD: "c++11"
-      - DEFINES: "-DBOOST_THREAD_TEST_TIME_MS=100"
 
   linux-g++-7-c++98:
     <<: *linux_build
@@ -74,7 +73,6 @@ jobs:
       - TOOLSET: "gcc"
       - COMPILER: "g++-7"
       - CXXSTD: "c++98"
-      - DEFINES: "-DBOOST_THREAD_TEST_TIME_MS=100"
 
   linux-g++-7-c++11:
     <<: *linux_build
@@ -82,7 +80,6 @@ jobs:
       - TOOLSET: "gcc"
       - COMPILER: "g++-7"
       - CXXSTD: "c++11"
-      - DEFINES: "-DBOOST_THREAD_TEST_TIME_MS=100"
 
   linux-g++-7-c++14:
     <<: *linux_build
@@ -90,7 +87,6 @@ jobs:
       - TOOLSET: "gcc"
       - COMPILER: "g++-7"
       - CXXSTD: "c++14"
-      - DEFINES: "-DBOOST_THREAD_TEST_TIME_MS=100"
 
   linux-g++-7-c++1z:
     <<: *linux_build
@@ -98,7 +94,6 @@ jobs:
       - TOOLSET: "gcc"
       - COMPILER: "g++-7"
       - CXXSTD: "c++1z"
-      - DEFINES: "-DBOOST_THREAD_TEST_TIME_MS=100"
 
   linux-clang++-4.0-c++98:
     <<: *linux_build
@@ -106,7 +101,6 @@ jobs:
       - TOOLSET: "clang"
       - COMPILER: "clang++-4.0"
       - CXXSTD: "c++98"
-      - DEFINES: "-DBOOST_THREAD_TEST_TIME_MS=100"
 
   linux-clang++-4.0-c++11:
     <<: *linux_build
@@ -114,7 +108,6 @@ jobs:
       - TOOLSET: "clang"
       - COMPILER: "clang++-4.0"
       - CXXSTD: "c++11"
-      - DEFINES: "-DBOOST_THREAD_TEST_TIME_MS=100"
 
   linux-clang++-4.0-c++14:
     <<: *linux_build
@@ -122,7 +115,6 @@ jobs:
       - TOOLSET: "clang"
       - COMPILER: "clang++-4.0"
       - CXXSTD: "c++14"
-      - DEFINES: "-DBOOST_THREAD_TEST_TIME_MS=100"
 
   linux-clang++-4.0-c++1z:
     <<: *linux_build
@@ -130,7 +122,6 @@ jobs:
       - TOOLSET: "clang"
       - COMPILER: "clang++-4.0"
       - CXXSTD: "c++1z"
-      - DEFINES: "-DBOOST_THREAD_TEST_TIME_MS=100"
 
   mac-clang++-c++98:
     <<: *mac_build
@@ -138,7 +129,7 @@ jobs:
       - TOOLSET: "clang"
       - COMPILER: "clang++"
       - CXXSTD: "c++98"
-      - DEFINES: "-DBOOST_THREAD_TEST_TIME_MS=170"
+      - DEFINES: "-DBOOST_THREAD_TEST_TIME_MS=100"
 
   mac-clang++-c++11:
     <<: *mac_build
@@ -146,7 +137,7 @@ jobs:
       - TOOLSET: "clang"
       - COMPILER: "clang++"
       - CXXSTD: "c++11"
-      - DEFINES: "-DBOOST_THREAD_TEST_TIME_MS=170"
+      - DEFINES: "-DBOOST_THREAD_TEST_TIME_MS=100"
 
   mac-clang++-c++14:
     <<: *mac_build
@@ -154,7 +145,7 @@ jobs:
       - TOOLSET: "clang"
       - COMPILER: "clang++"
       - CXXSTD: "c++14"
-      - DEFINES: "-DBOOST_THREAD_TEST_TIME_MS=170"
+      - DEFINES: "-DBOOST_THREAD_TEST_TIME_MS=100"
 
   mac-clang++-c++1z:
     <<: *mac_build
@@ -162,7 +153,7 @@ jobs:
       - TOOLSET: "clang"
       - COMPILER: "clang++"
       - CXXSTD: "c++1z"
-      - DEFINES: "-DBOOST_THREAD_TEST_TIME_MS=170"
+      - DEFINES: "-DBOOST_THREAD_TEST_TIME_MS=100"
 
 workflows:
   version: 2

--- a/test/sync/conditions/condition_variable/wait_until_pass.cpp
+++ b/test/sync/conditions/condition_variable/wait_until_pass.cpp
@@ -67,12 +67,14 @@ void f()
     Clock::time_point t1 = Clock::now();
     if (runs == 0)
     {
-      assert(t1 - t0 < max_diff);
+      ns d = t1 - t0;
+      BOOST_THREAD_TEST_IT(d, ns(max_diff));
       assert(test2 != 0);
     }
     else
     {
-      assert(t1 - t0 - Clock::duration(250) < max_diff);
+      ns d = t1 - t0 - Clock::duration(250);
+      BOOST_THREAD_TEST_IT(d, ns(max_diff));
       assert(test2 == 0);
     }
     ++runs;

--- a/test/sync/mutual_exclusion/locks/lock_guard/adopt_lock_pass.cpp
+++ b/test/sync/mutual_exclusion/locks/lock_guard/adopt_lock_pass.cpp
@@ -30,6 +30,8 @@ typedef Clock::time_point time_point;
 typedef Clock::duration duration;
 typedef boost::chrono::milliseconds ms;
 typedef boost::chrono::nanoseconds ns;
+time_point t0;
+time_point t1;
 #endif
 boost::mutex m;
 
@@ -38,15 +40,12 @@ const ms max_diff(BOOST_THREAD_TEST_TIME_MS);
 void f()
 {
 #ifdef BOOST_THREAD_USES_CHRONO
-  time_point t0 = Clock::now();
-  time_point t1;
+  t0 = Clock::now();
   {
     m.lock();
     boost::lock_guard<boost::mutex> lg(m, boost::adopt_lock);
     t1 = Clock::now();
   }
-  ns d = t1 - t0 - ms(250);
-  BOOST_THREAD_TEST_IT(d, ns(max_diff));
 #else
   //time_point t0 = Clock::now();
   //time_point t1;
@@ -65,10 +64,21 @@ int main()
   m.lock();
   boost::thread t(f);
 #ifdef BOOST_THREAD_USES_CHRONO
+  time_point t2 = Clock::now();
   boost::this_thread::sleep_for(ms(250));
+  time_point t3 = Clock::now();
 #endif
   m.unlock();
   t.join();
+
+#if defined BOOST_THREAD_USES_CHRONO
+  ns sleep_time = t3 - t2;
+  ns d_ns = t1 - t0 - sleep_time;
+  ms d_ms = boost::chrono::duration_cast<boost::chrono::milliseconds>(d_ns);
+  // BOOST_TEST_GE(d_ms.count(), 0);
+  BOOST_THREAD_TEST_IT(d_ms, max_diff);
+  BOOST_THREAD_TEST_IT(d_ns, ns(max_diff));
+#endif
 
   return boost::report_errors();
 }

--- a/test/sync/mutual_exclusion/locks/lock_guard/default_pass.cpp
+++ b/test/sync/mutual_exclusion/locks/lock_guard/default_pass.cpp
@@ -30,6 +30,8 @@ typedef Clock::time_point time_point;
 typedef Clock::duration duration;
 typedef boost::chrono::milliseconds ms;
 typedef boost::chrono::nanoseconds ns;
+time_point t0;
+time_point t1;
 #endif
 
 boost::mutex m;
@@ -39,14 +41,11 @@ const ms max_diff(BOOST_THREAD_TEST_TIME_MS);
 void f()
 {
 #ifdef BOOST_THREAD_USES_CHRONO
-  time_point t0 = Clock::now();
-  time_point t1;
+  t0 = Clock::now();
   {
     boost::lock_guard<boost::mutex> lg(m);
     t1 = Clock::now();
   }
-  ns d = t1 - t0 - ms(250);
-  BOOST_THREAD_TEST_IT(d, ns(max_diff));
 #else
   //time_point t0 = Clock::now();
   //time_point t1;
@@ -64,10 +63,21 @@ int main()
   m.lock();
   boost::thread t(f);
 #ifdef BOOST_THREAD_USES_CHRONO
+  time_point t2 = Clock::now();
   boost::this_thread::sleep_for(ms(250));
+  time_point t3 = Clock::now();
 #endif
   m.unlock();
   t.join();
+
+#if defined BOOST_THREAD_USES_CHRONO
+  ns sleep_time = t3 - t2;
+  ns d_ns = t1 - t0 - sleep_time;
+  ms d_ms = boost::chrono::duration_cast<boost::chrono::milliseconds>(d_ns);
+  // BOOST_TEST_GE(d_ms.count(), 0);
+  BOOST_THREAD_TEST_IT(d_ms, max_diff);
+  BOOST_THREAD_TEST_IT(d_ns, ns(max_diff));
+#endif
 
   return boost::report_errors();
 }

--- a/test/sync/mutual_exclusion/locks/lock_guard/make_lock_guard_adopt_lock_pass.cpp
+++ b/test/sync/mutual_exclusion/locks/lock_guard/make_lock_guard_adopt_lock_pass.cpp
@@ -32,6 +32,8 @@ typedef Clock::time_point time_point;
 typedef Clock::duration duration;
 typedef boost::chrono::milliseconds ms;
 typedef boost::chrono::nanoseconds ns;
+time_point t0;
+time_point t1;
 #endif
 boost::mutex m;
 
@@ -42,16 +44,13 @@ const ms max_diff(BOOST_THREAD_TEST_TIME_MS);
 void f()
 {
 #ifdef BOOST_THREAD_USES_CHRONO
-  time_point t0 = Clock::now();
-  time_point t1;
+  t0 = Clock::now();
   {
     m.lock();
     auto&& lg = boost::make_lock_guard(m, boost::adopt_lock); (void)lg;
 
     t1 = Clock::now();
   }
-  ns d = t1 - t0 - ms(250);
-  BOOST_THREAD_TEST_IT(d, ns(max_diff));
 #else
   //time_point t0 = Clock::now();
   //time_point t1;
@@ -72,10 +71,22 @@ int main()
   m.lock();
   boost::thread t(f);
 #ifdef BOOST_THREAD_USES_CHRONO
+  time_point t2 = Clock::now();
   boost::this_thread::sleep_for(ms(250));
+  time_point t3 = Clock::now();
 #endif
   m.unlock();
   t.join();
+
+#if defined BOOST_THREAD_USES_CHRONO
+  ns sleep_time = t3 - t2;
+  ns d_ns = t1 - t0 - sleep_time;
+  ms d_ms = boost::chrono::duration_cast<boost::chrono::milliseconds>(d_ns);
+  // BOOST_TEST_GE(d_ms.count(), 0);
+  BOOST_THREAD_TEST_IT(d_ms, max_diff);
+  BOOST_THREAD_TEST_IT(d_ns, ns(max_diff));
+#endif
+
 #endif
   return boost::report_errors();
 }

--- a/test/sync/mutual_exclusion/locks/lock_guard/make_lock_guard_pass.cpp
+++ b/test/sync/mutual_exclusion/locks/lock_guard/make_lock_guard_pass.cpp
@@ -32,6 +32,8 @@ typedef Clock::time_point time_point;
 typedef Clock::duration duration;
 typedef boost::chrono::milliseconds ms;
 typedef boost::chrono::nanoseconds ns;
+time_point t0;
+time_point t1;
 #endif
 
 boost::mutex m;
@@ -42,27 +44,33 @@ const ms max_diff(BOOST_THREAD_TEST_TIME_MS);
 
 void f()
 {
-  time_point t0 = Clock::now();
-  time_point t1;
+  t0 = Clock::now();
   {
     const auto&& lg = boost::make_lock_guard(m); (void)lg;
     t1 = Clock::now();
   }
-  ns d = t1 - t0 - ms(250);
-  BOOST_THREAD_TEST_IT(d, ns(max_diff));
 }
 #endif
 
 int main()
 {
 
-#if ! defined(BOOST_NO_CXX11_AUTO_DECLARATIONS) && ! defined(BOOST_NO_CXX11_RVALUE_REFERENCES) && ! defined BOOST_THREAD_NO_MAKE_LOCK_GUARD
+#if ! defined(BOOST_NO_CXX11_AUTO_DECLARATIONS) && ! defined(BOOST_NO_CXX11_RVALUE_REFERENCES) && ! defined BOOST_THREAD_NO_MAKE_LOCK_GUARD && defined BOOST_THREAD_USES_CHRONO
   {
     m.lock();
     boost::thread t(f);
+    time_point t2 = Clock::now();
     boost::this_thread::sleep_for(ms(250));
+    time_point t3 = Clock::now();
     m.unlock();
     t.join();
+
+    ns sleep_time = t3 - t2;
+    ns d_ns = t1 - t0 - sleep_time;
+    ms d_ms = boost::chrono::duration_cast<boost::chrono::milliseconds>(d_ns);
+    // BOOST_TEST_GE(d_ms.count(), 0);
+    BOOST_THREAD_TEST_IT(d_ms, max_diff);
+    BOOST_THREAD_TEST_IT(d_ns, ns(max_diff));
   }
 #endif
   return boost::report_errors();

--- a/test/sync/mutual_exclusion/locks/nested_strict_lock/default_pass.cpp
+++ b/test/sync/mutual_exclusion/locks/nested_strict_lock/default_pass.cpp
@@ -22,6 +22,8 @@ typedef Clock::time_point time_point;
 typedef Clock::duration duration;
 typedef boost::chrono::milliseconds ms;
 typedef boost::chrono::nanoseconds ns;
+time_point t0;
+time_point t1;
 #endif
 
 boost::mutex m;
@@ -31,15 +33,12 @@ const ms max_diff(BOOST_THREAD_TEST_TIME_MS);
 void f()
 {
 #ifdef BOOST_THREAD_USES_CHRONO
-  time_point t0 = Clock::now();
-  time_point t1;
+  t0 = Clock::now();
   boost::unique_lock<boost::mutex> lg(m);
   {
     boost::nested_strict_lock<boost::unique_lock<boost::mutex> > nlg(lg);
     t1 = Clock::now();
   }
-  ns d = t1 - t0 - ms(250);
-  BOOST_THREAD_TEST_IT(d, ns(max_diff));
 #else
   //time_point t0 = Clock::now();
   //time_point t1;
@@ -59,10 +58,21 @@ int main()
   m.lock();
   boost::thread t(f);
 #ifdef BOOST_THREAD_USES_CHRONO
+  time_point t2 = Clock::now();
   boost::this_thread::sleep_for(ms(250));
+  time_point t3 = Clock::now();
 #endif
   m.unlock();
   t.join();
+
+#if defined BOOST_THREAD_USES_CHRONO
+  ns sleep_time = t3 - t2;
+  ns d_ns = t1 - t0 - sleep_time;
+  ms d_ms = boost::chrono::duration_cast<boost::chrono::milliseconds>(d_ns);
+  // BOOST_TEST_GE(d_ms.count(), 0);
+  BOOST_THREAD_TEST_IT(d_ms, max_diff);
+  BOOST_THREAD_TEST_IT(d_ns, ns(max_diff));
+#endif
   }
 
   return boost::report_errors();

--- a/test/sync/mutual_exclusion/locks/nested_strict_lock/make_nested_strict_lock_pass.cpp
+++ b/test/sync/mutual_exclusion/locks/nested_strict_lock/make_nested_strict_lock_pass.cpp
@@ -24,6 +24,8 @@ typedef Clock::time_point time_point;
 typedef Clock::duration duration;
 typedef boost::chrono::milliseconds ms;
 typedef boost::chrono::nanoseconds ns;
+time_point t0;
+time_point t1;
 #endif
 
 boost::mutex m;
@@ -34,28 +36,34 @@ const ms max_diff(BOOST_THREAD_TEST_TIME_MS);
 
 void f()
 {
-  time_point t0 = Clock::now();
-  time_point t1;
+  t0 = Clock::now();
   boost::unique_lock<boost::mutex> lg(m);
   {
     const auto&& nlg = boost::make_nested_strict_lock(lg); (void)nlg;
     t1 = Clock::now();
   }
-  ns d = t1 - t0 - ms(250);
-  BOOST_THREAD_TEST_IT(d, ns(max_diff));
 }
 #endif
 
 int main()
 {
 
-#if ! defined(BOOST_NO_CXX11_AUTO_DECLARATIONS) && ! defined(BOOST_NO_CXX11_RVALUE_REFERENCES) && ! defined BOOST_THREAD_NO_MAKE_NESTED_STRICT_LOCK
+#if ! defined(BOOST_NO_CXX11_AUTO_DECLARATIONS) && ! defined(BOOST_NO_CXX11_RVALUE_REFERENCES) && ! defined BOOST_THREAD_NO_MAKE_NESTED_STRICT_LOCK && defined BOOST_THREAD_USES_CHRONO
   {
     m.lock();
     boost::thread t(f);
+    time_point t2 = Clock::now();
     boost::this_thread::sleep_for(ms(250));
+    time_point t3 = Clock::now();
     m.unlock();
     t.join();
+
+    ns sleep_time = t3 - t2;
+    ns d_ns = t1 - t0 - sleep_time;
+    ms d_ms = boost::chrono::duration_cast<boost::chrono::milliseconds>(d_ns);
+    // BOOST_TEST_GE(d_ms.count(), 0);
+    BOOST_THREAD_TEST_IT(d_ms, max_diff);
+    BOOST_THREAD_TEST_IT(d_ns, ns(max_diff));
   }
 #endif
   return boost::report_errors();

--- a/test/sync/mutual_exclusion/locks/shared_lock/cons/mutex_pass.cpp
+++ b/test/sync/mutual_exclusion/locks/shared_lock/cons/mutex_pass.cpp
@@ -27,11 +27,13 @@
 boost::shared_mutex m;
 
 #if defined BOOST_THREAD_USES_CHRONO
-typedef boost::chrono::system_clock Clock;
+typedef boost::chrono::high_resolution_clock Clock;
 typedef Clock::time_point time_point;
 typedef Clock::duration duration;
 typedef boost::chrono::milliseconds ms;
 typedef boost::chrono::nanoseconds ns;
+time_point t0;
+time_point t1;
 #else
 #endif
 
@@ -40,14 +42,11 @@ const ms max_diff(BOOST_THREAD_TEST_TIME_MS);
 void f()
 {
 #if defined BOOST_THREAD_USES_CHRONO
-  time_point t0 = Clock::now();
-  time_point t1;
+  t0 = Clock::now();
   {
     boost::shared_lock<boost::shared_mutex> ul(m);
     t1 = Clock::now();
   }
-  ns d = t1 - t0 - ms(250);
-  BOOST_THREAD_TEST_IT(d, ns(max_diff));
 #else
   //time_point t0 = Clock::now();
   //time_point t1;
@@ -65,11 +64,22 @@ int main()
   m.lock();
   boost::thread t(f);
 #if defined BOOST_THREAD_USES_CHRONO
+  time_point t2 = Clock::now();
   boost::this_thread::sleep_for(ms(250));
+  time_point t3 = Clock::now();
 #else
 #endif
   m.unlock();
   t.join();
+
+#if defined BOOST_THREAD_USES_CHRONO
+  ns sleep_time = t3 - t2;
+  ns d_ns = t1 - t0 - sleep_time;
+  ms d_ms = boost::chrono::duration_cast<boost::chrono::milliseconds>(d_ns);
+  // BOOST_TEST_GE(d_ms.count(), 0);
+  BOOST_THREAD_TEST_IT(d_ms, max_diff);
+  BOOST_THREAD_TEST_IT(d_ns, ns(max_diff));
+#endif
 
   return boost::report_errors();
 }

--- a/test/sync/mutual_exclusion/locks/shared_lock/cons/time_point_pass.cpp
+++ b/test/sync/mutual_exclusion/locks/shared_lock/cons/time_point_pass.cpp
@@ -27,30 +27,30 @@
 
 boost::shared_mutex m;
 
-typedef boost::chrono::steady_clock Clock;
+typedef boost::chrono::high_resolution_clock Clock;
 typedef Clock::time_point time_point;
 typedef Clock::duration duration;
 typedef boost::chrono::milliseconds ms;
 typedef boost::chrono::nanoseconds ns;
+time_point t0;
+time_point t1;
 
 const ms max_diff(BOOST_THREAD_TEST_TIME_MS);
 
 void f1()
 {
-  time_point t0 = Clock::now();
+  t0 = Clock::now();
   boost::shared_lock<boost::shared_mutex> lk(m, Clock::now() + ms(750));
   BOOST_TEST(lk.owns_lock() == true);
-  time_point t1 = Clock::now();
-  ns d = t1 - t0 - ms(250);
-  BOOST_THREAD_TEST_IT(d, ns(max_diff));
+  t1 = Clock::now();
 }
 
 void f2()
 {
-  time_point t0 = Clock::now();
+  t0 = Clock::now();
   boost::shared_lock<boost::shared_mutex> lk(m, Clock::now() + ms(250));
   BOOST_TEST(lk.owns_lock() == false);
-  time_point t1 = Clock::now();
+  t1 = Clock::now();
   ns d = t1 - t0 - ms(250);
   BOOST_THREAD_TEST_IT(d, ns(max_diff));
 }
@@ -60,9 +60,18 @@ int main()
   {
     m.lock();
     boost::thread t(f1);
+    time_point t2 = Clock::now();
     boost::this_thread::sleep_for(ms(250));
+    time_point t3 = Clock::now();
     m.unlock();
     t.join();
+
+    ns sleep_time = t3 - t2;
+    ns d_ns = t1 - t0 - sleep_time;
+    ms d_ms = boost::chrono::duration_cast<boost::chrono::milliseconds>(d_ns);
+    // BOOST_TEST_GE(d_ms.count(), 0);
+    BOOST_THREAD_TEST_IT(d_ms, max_diff);
+    BOOST_THREAD_TEST_IT(d_ns, ns(max_diff));
   }
   {
     m.lock();

--- a/test/sync/mutual_exclusion/locks/shared_lock/cons/try_to_lock_pass.cpp
+++ b/test/sync/mutual_exclusion/locks/shared_lock/cons/try_to_lock_pass.cpp
@@ -27,11 +27,13 @@
 boost::shared_mutex m;
 
 #if defined BOOST_THREAD_USES_CHRONO
-typedef boost::chrono::system_clock Clock;
+typedef boost::chrono::high_resolution_clock Clock;
 typedef Clock::time_point time_point;
 typedef Clock::duration duration;
 typedef boost::chrono::milliseconds ms;
 typedef boost::chrono::nanoseconds ns;
+time_point t0;
+time_point t1;
 #else
 #endif
 
@@ -40,7 +42,7 @@ const ms max_diff(BOOST_THREAD_TEST_TIME_MS);
 void f()
 {
 #if defined BOOST_THREAD_USES_CHRONO
-  time_point t0 = Clock::now();
+  t0 = Clock::now();
   {
     boost::shared_lock<boost::shared_mutex> lk(m, boost::try_to_lock);
     BOOST_TEST(lk.owns_lock() == false);
@@ -56,11 +58,11 @@ void f()
   for (;;)
   {
     boost::shared_lock<boost::shared_mutex> lk(m, boost::try_to_lock);
-    if (lk.owns_lock()) break;
+    if (lk.owns_lock()) {
+      t1 = Clock::now();
+      break;
+    }
   }
-  time_point t1 = Clock::now();
-  ns d = t1 - t0 - ms(250);
-  BOOST_THREAD_TEST_IT(d, ns(max_diff));
 #else
 //  time_point t0 = Clock::now();
 //  {
@@ -91,11 +93,22 @@ int main()
   m.lock();
   boost::thread t(f);
 #if defined BOOST_THREAD_USES_CHRONO
+  time_point t2 = Clock::now();
   boost::this_thread::sleep_for(ms(250));
+  time_point t3 = Clock::now();
 #else
 #endif
   m.unlock();
   t.join();
+
+#if defined BOOST_THREAD_USES_CHRONO
+  ns sleep_time = t3 - t2;
+  ns d_ns = t1 - t0 - sleep_time;
+  ms d_ms = boost::chrono::duration_cast<boost::chrono::milliseconds>(d_ns);
+  // BOOST_TEST_GE(d_ms.count(), 0);
+  BOOST_THREAD_TEST_IT(d_ms, max_diff);
+  BOOST_THREAD_TEST_IT(d_ns, ns(max_diff));
+#endif
 
   return boost::report_errors();
 }

--- a/test/sync/mutual_exclusion/locks/shared_lock/locking/lock_pass.cpp
+++ b/test/sync/mutual_exclusion/locks/shared_lock/locking/lock_pass.cpp
@@ -28,11 +28,13 @@
 boost::shared_mutex m;
 
 #if defined BOOST_THREAD_USES_CHRONO
-typedef boost::chrono::system_clock Clock;
+typedef boost::chrono::high_resolution_clock Clock;
 typedef Clock::time_point time_point;
 typedef Clock::duration duration;
 typedef boost::chrono::milliseconds ms;
 typedef boost::chrono::nanoseconds ns;
+time_point t0;
+time_point t1;
 #else
 #endif
 
@@ -42,12 +44,10 @@ void f()
 {
 #if defined BOOST_THREAD_USES_CHRONO
   boost::shared_lock < boost::shared_mutex > lk(m, boost::defer_lock);
-  time_point t0 = Clock::now();
+  t0 = Clock::now();
   lk.lock();
-  time_point t1 = Clock::now();
+  t1 = Clock::now();
   BOOST_TEST(lk.owns_lock() == true);
-  ns d = t1 - t0 - ms(250);
-  BOOST_THREAD_TEST_IT(d, ns(max_diff));
   try
   {
     lk.lock();
@@ -104,11 +104,22 @@ int main()
   m.lock();
   boost::thread t(f);
 #if defined BOOST_THREAD_USES_CHRONO
+  time_point t2 = Clock::now();
   boost::this_thread::sleep_for(ms(250));
+  time_point t3 = Clock::now();
 #else
 #endif
   m.unlock();
   t.join();
+
+#if defined BOOST_THREAD_USES_CHRONO
+  ns sleep_time = t3 - t2;
+  ns d_ns = t1 - t0 - sleep_time;
+  ms d_ms = boost::chrono::duration_cast<boost::chrono::milliseconds>(d_ns);
+  // BOOST_TEST_GE(d_ms.count(), 0);
+  BOOST_THREAD_TEST_IT(d_ms, max_diff);
+  BOOST_THREAD_TEST_IT(d_ns, ns(max_diff));
+#endif
 
   return boost::report_errors();
 }

--- a/test/sync/mutual_exclusion/locks/shared_lock_guard/adopt_lock_pass.cpp
+++ b/test/sync/mutual_exclusion/locks/shared_lock_guard/adopt_lock_pass.cpp
@@ -30,6 +30,8 @@ typedef Clock::time_point time_point;
 typedef Clock::duration duration;
 typedef boost::chrono::milliseconds ms;
 typedef boost::chrono::nanoseconds ns;
+time_point t0;
+time_point t1;
 #else
 #endif
 
@@ -40,15 +42,12 @@ const ms max_diff(BOOST_THREAD_TEST_TIME_MS);
 void f()
 {
 #if defined BOOST_THREAD_USES_CHRONO
-  time_point t0 = Clock::now();
-  time_point t1;
+  t0 = Clock::now();
   {
     m.lock_shared();
     boost::shared_lock_guard<boost::shared_mutex> lg(m, boost::adopt_lock);
     t1 = Clock::now();
   }
-  ns d = t1 - t0 - ms(250);
-  BOOST_THREAD_TEST_IT(d, ns(max_diff));
 #else
   //time_point t0 = Clock::now();
   //time_point t1;
@@ -67,11 +66,22 @@ int main()
   m.lock();
   boost::thread t(f);
 #if defined BOOST_THREAD_USES_CHRONO
+  time_point t2 = Clock::now();
   boost::this_thread::sleep_for(ms(250));
+  time_point t3 = Clock::now();
 #else
 #endif
   m.unlock();
   t.join();
+
+#if defined BOOST_THREAD_USES_CHRONO
+  ns sleep_time = t3 - t2;
+  ns d_ns = t1 - t0 - sleep_time;
+  ms d_ms = boost::chrono::duration_cast<boost::chrono::milliseconds>(d_ns);
+  // BOOST_TEST_GE(d_ms.count(), 0);
+  BOOST_THREAD_TEST_IT(d_ms, max_diff);
+  BOOST_THREAD_TEST_IT(d_ns, ns(max_diff));
+#endif
 
   return boost::report_errors();
 }

--- a/test/sync/mutual_exclusion/locks/shared_lock_guard/default_pass.cpp
+++ b/test/sync/mutual_exclusion/locks/shared_lock_guard/default_pass.cpp
@@ -31,6 +31,8 @@ typedef Clock::time_point time_point;
 typedef Clock::duration duration;
 typedef boost::chrono::milliseconds ms;
 typedef boost::chrono::nanoseconds ns;
+time_point t0;
+time_point t1;
 #else
 #endif
 
@@ -41,14 +43,11 @@ const ms max_diff(BOOST_THREAD_TEST_TIME_MS);
 void f()
 {
 #if defined BOOST_THREAD_USES_CHRONO
-  time_point t0 = Clock::now();
-  time_point t1;
+  t0 = Clock::now();
   {
     boost::shared_lock_guard<boost::shared_mutex> lg(m);
     t1 = Clock::now();
   }
-  ns d = t1 - t0 - ms(250);
-  BOOST_THREAD_TEST_IT(d, ns(max_diff));
 #else
   //time_point t0 = Clock::now();
   //time_point t1;
@@ -66,11 +65,22 @@ int main()
   m.lock();
   boost::thread t(f);
 #if defined BOOST_THREAD_USES_CHRONO
+  time_point t2 = Clock::now();
   boost::this_thread::sleep_for(ms(250));
+  time_point t3 = Clock::now();
 #else
 #endif
   m.unlock();
   t.join();
+
+#if defined BOOST_THREAD_USES_CHRONO
+  ns sleep_time = t3 - t2;
+  ns d_ns = t1 - t0 - sleep_time;
+  ms d_ms = boost::chrono::duration_cast<boost::chrono::milliseconds>(d_ns);
+  // BOOST_TEST_GE(d_ms.count(), 0);
+  BOOST_THREAD_TEST_IT(d_ms, max_diff);
+  BOOST_THREAD_TEST_IT(d_ns, ns(max_diff));
+#endif
 
   return boost::report_errors();
 }

--- a/test/sync/mutual_exclusion/locks/strict_lock/default_pass.cpp
+++ b/test/sync/mutual_exclusion/locks/strict_lock/default_pass.cpp
@@ -21,6 +21,8 @@ typedef Clock::time_point time_point;
 typedef Clock::duration duration;
 typedef boost::chrono::milliseconds ms;
 typedef boost::chrono::nanoseconds ns;
+time_point t0;
+time_point t1;
 #endif
 
 boost::mutex m;
@@ -30,14 +32,11 @@ const ms max_diff(BOOST_THREAD_TEST_TIME_MS);
 void f()
 {
 #ifdef BOOST_THREAD_USES_CHRONO
-  time_point t0 = Clock::now();
-  time_point t1;
+  t0 = Clock::now();
   {
     boost::strict_lock<boost::mutex> lg(m);
     t1 = Clock::now();
   }
-  ns d = t1 - t0 - ms(250);
-  BOOST_THREAD_TEST_IT(d, ns(max_diff));
 #else
   //time_point t0 = Clock::now();
   //time_point t1;
@@ -55,10 +54,21 @@ int main()
   m.lock();
   boost::thread t(f);
 #ifdef BOOST_THREAD_USES_CHRONO
+  time_point t2 = Clock::now();
   boost::this_thread::sleep_for(ms(250));
+  time_point t3 = Clock::now();
 #endif
   m.unlock();
   t.join();
+
+#if defined BOOST_THREAD_USES_CHRONO
+  ns sleep_time = t3 - t2;
+  ns d_ns = t1 - t0 - sleep_time;
+  ms d_ms = boost::chrono::duration_cast<boost::chrono::milliseconds>(d_ns);
+  // BOOST_TEST_GE(d_ms.count(), 0);
+  BOOST_THREAD_TEST_IT(d_ms, max_diff);
+  BOOST_THREAD_TEST_IT(d_ns, ns(max_diff));
+#endif
 
   return boost::report_errors();
 }

--- a/test/sync/mutual_exclusion/locks/unique_lock/cons/duration_pass.cpp
+++ b/test/sync/mutual_exclusion/locks/unique_lock/cons/duration_pass.cpp
@@ -32,30 +32,30 @@
 
 boost::timed_mutex m;
 
-typedef boost::chrono::steady_clock Clock;
+typedef boost::chrono::high_resolution_clock Clock;
 typedef Clock::time_point time_point;
 typedef Clock::duration duration;
 typedef boost::chrono::milliseconds ms;
 typedef boost::chrono::nanoseconds ns;
+time_point t0;
+time_point t1;
 
 const ms max_diff(BOOST_THREAD_TEST_TIME_MS);
 
 void f1()
 {
-  time_point t0 = Clock::now();
+  t0 = Clock::now();
   boost::unique_lock<boost::timed_mutex> lk(m, ms(750));
   BOOST_TEST(lk.owns_lock() == true);
-  time_point t1 = Clock::now();
-  ns d = t1 - t0 - ms(250);
-  BOOST_THREAD_TEST_IT(d, ns(max_diff));
+  t1 = Clock::now();
 }
 
 void f2()
 {
-  time_point t0 = Clock::now();
+  t0 = Clock::now();
   boost::unique_lock<boost::timed_mutex> lk(m, ms(250));
   BOOST_TEST(lk.owns_lock() == false);
-  time_point t1 = Clock::now();
+  t1 = Clock::now();
   ns d = t1 - t0 - ms(250);
   BOOST_TEST(d < max_diff);
 }
@@ -65,9 +65,18 @@ int main()
   {
     m.lock();
     boost::thread t(f1);
+    time_point t2 = Clock::now();
     boost::this_thread::sleep_for(ms(250));
+    time_point t3 = Clock::now();
     m.unlock();
     t.join();
+
+    ns sleep_time = t3 - t2;
+    ns d_ns = t1 - t0 - sleep_time;
+    ms d_ms = boost::chrono::duration_cast<boost::chrono::milliseconds>(d_ns);
+    // BOOST_TEST_GE(d_ms.count(), 0);
+    BOOST_THREAD_TEST_IT(d_ms, max_diff);
+    BOOST_THREAD_TEST_IT(d_ns, ns(max_diff));
   }
   {
     m.lock();

--- a/test/sync/mutual_exclusion/locks/unique_lock/cons/duration_pass.cpp
+++ b/test/sync/mutual_exclusion/locks/unique_lock/cons/duration_pass.cpp
@@ -57,7 +57,7 @@ void f2()
   BOOST_TEST(lk.owns_lock() == false);
   t1 = Clock::now();
   ns d = t1 - t0 - ms(250);
-  BOOST_TEST(d < max_diff);
+  BOOST_THREAD_TEST_IT(d, ns(max_diff));
 }
 
 int main()

--- a/test/sync/mutual_exclusion/locks/unique_lock/cons/make_unique_lock_mutex_pass.cpp
+++ b/test/sync/mutual_exclusion/locks/unique_lock/cons/make_unique_lock_mutex_pass.cpp
@@ -23,11 +23,13 @@ boost::mutex m;
 
 #if defined BOOST_THREAD_USES_CHRONO
 
-typedef boost::chrono::system_clock Clock;
+typedef boost::chrono::high_resolution_clock Clock;
 typedef Clock::time_point time_point;
 typedef Clock::duration duration;
 typedef boost::chrono::milliseconds ms;
 typedef boost::chrono::nanoseconds ns;
+time_point t0;
+time_point t1;
 #else
 #endif
 
@@ -36,8 +38,7 @@ const ms max_diff(BOOST_THREAD_TEST_TIME_MS);
 void f()
 {
 #if defined BOOST_THREAD_USES_CHRONO
-  time_point t0 = Clock::now();
-  time_point t1;
+  t0 = Clock::now();
   {
 #if ! defined(BOOST_NO_CXX11_AUTO_DECLARATIONS)
   auto
@@ -48,8 +49,6 @@ void f()
     _ = boost::make_unique_lock(m); (void)_;
     t1 = Clock::now();
   }
-  ns d = t1 - t0 - ms(250);
-  BOOST_THREAD_TEST_IT(d, ns(max_diff));
 #else
   //time_point t0 = Clock::now();
   //time_point t1;
@@ -73,11 +72,22 @@ int main()
   m.lock();
   boost::thread t(f);
 #if defined BOOST_THREAD_USES_CHRONO
+  time_point t2 = Clock::now();
   boost::this_thread::sleep_for(ms(250));
+  time_point t3 = Clock::now();
 #else
 #endif
   m.unlock();
   t.join();
+
+#if defined BOOST_THREAD_USES_CHRONO
+  ns sleep_time = t3 - t2;
+  ns d_ns = t1 - t0 - sleep_time;
+  ms d_ms = boost::chrono::duration_cast<boost::chrono::milliseconds>(d_ns);
+  // BOOST_TEST_GE(d_ms.count(), 0);
+  BOOST_THREAD_TEST_IT(d_ms, max_diff);
+  BOOST_THREAD_TEST_IT(d_ns, ns(max_diff));
+#endif
 
   return boost::report_errors();
 }

--- a/test/sync/mutual_exclusion/locks/unique_lock/cons/make_unique_lock_try_to_lock_pass.cpp
+++ b/test/sync/mutual_exclusion/locks/unique_lock/cons/make_unique_lock_try_to_lock_pass.cpp
@@ -20,11 +20,13 @@
 boost::mutex m;
 
 #if defined BOOST_THREAD_USES_CHRONO
-typedef boost::chrono::system_clock Clock;
+typedef boost::chrono::high_resolution_clock Clock;
 typedef Clock::time_point time_point;
 typedef Clock::duration duration;
 typedef boost::chrono::milliseconds ms;
 typedef boost::chrono::nanoseconds ns;
+time_point t0;
+time_point t1;
 #else
 #endif
 
@@ -34,7 +36,7 @@ void f()
 {
 #if defined BOOST_THREAD_USES_CHRONO
   {
-    time_point t0 = Clock::now();
+    t0 = Clock::now();
 #if ! defined(BOOST_NO_CXX11_AUTO_DECLARATIONS)
   auto
 #else
@@ -42,12 +44,12 @@ void f()
 #endif
     lk = boost::make_unique_lock(m, boost::try_to_lock);
     BOOST_TEST(lk.owns_lock() == false);
-    time_point t1 = Clock::now();
-    ns d = t1 - t0 - ms(250);
+    t1 = Clock::now();
+    ns d = t1 - t0;
     BOOST_THREAD_TEST_IT(d, ns(max_diff));
   }
   {
-    time_point t0 = Clock::now();
+    t0 = Clock::now();
 #if ! defined(BOOST_NO_CXX11_AUTO_DECLARATIONS)
   auto
 #else
@@ -55,12 +57,12 @@ void f()
 #endif
     lk = boost::make_unique_lock(m, boost::try_to_lock);
     BOOST_TEST(lk.owns_lock() == false);
-    time_point t1 = Clock::now();
-    ns d = t1 - t0 - ms(250);
+    t1 = Clock::now();
+    ns d = t1 - t0;
     BOOST_THREAD_TEST_IT(d, ns(max_diff));
   }
   {
-    time_point t0 = Clock::now();
+    t0 = Clock::now();
 #if ! defined(BOOST_NO_CXX11_AUTO_DECLARATIONS)
   auto
 #else
@@ -68,12 +70,12 @@ void f()
 #endif
     lk = boost::make_unique_lock(m, boost::try_to_lock);
     BOOST_TEST(lk.owns_lock() == false);
-    time_point t1 = Clock::now();
-    ns d = t1 - t0 - ms(250);
+    t1 = Clock::now();
+    ns d = t1 - t0;
     BOOST_THREAD_TEST_IT(d, ns(max_diff));
   }
   {
-    time_point t0 = Clock::now();
+    t0 = Clock::now();
     for (;;)
     {
 #if ! defined(BOOST_NO_CXX11_AUTO_DECLARATIONS)
@@ -82,11 +84,11 @@ void f()
       boost::unique_lock<boost::mutex>
 #endif
       lk = boost::make_unique_lock(m, boost::try_to_lock);
-      if (lk.owns_lock()) break;
+      if (lk.owns_lock()) {
+        t1 = Clock::now();
+        break;
+      }
     }
-    time_point t1 = Clock::now();
-    ns d = t1 - t0 - ms(250);
-    BOOST_THREAD_TEST_IT(d, ns(max_diff));
   }
 #else
 //  time_point t0 = Clock::now();
@@ -123,11 +125,22 @@ int main()
   m.lock();
   boost::thread t(f);
 #if defined BOOST_THREAD_USES_CHRONO
+  time_point t2 = Clock::now();
   boost::this_thread::sleep_for(ms(250));
+  time_point t3 = Clock::now();
 #else
 #endif
   m.unlock();
   t.join();
+
+#if defined BOOST_THREAD_USES_CHRONO
+  ns sleep_time = t3 - t2;
+  ns d_ns = t1 - t0 - sleep_time;
+  ms d_ms = boost::chrono::duration_cast<boost::chrono::milliseconds>(d_ns);
+  // BOOST_TEST_GE(d_ms.count(), 0);
+  BOOST_THREAD_TEST_IT(d_ms, max_diff);
+  BOOST_THREAD_TEST_IT(d_ns, ns(max_diff));
+#endif
 
   return boost::report_errors();
 }

--- a/test/sync/mutual_exclusion/locks/unique_lock/cons/make_unique_locks_mutex_pass.cpp
+++ b/test/sync/mutual_exclusion/locks/unique_lock/cons/make_unique_locks_mutex_pass.cpp
@@ -25,11 +25,13 @@ boost::mutex m3;
 
 #if defined BOOST_THREAD_USES_CHRONO
 
-typedef boost::chrono::system_clock Clock;
+typedef boost::chrono::high_resolution_clock Clock;
 typedef Clock::time_point time_point;
 typedef Clock::duration duration;
 typedef boost::chrono::milliseconds ms;
 typedef boost::chrono::nanoseconds ns;
+time_point t0;
+time_point t1;
 #else
 #endif
 
@@ -38,14 +40,11 @@ const ms max_diff(BOOST_THREAD_TEST_TIME_MS);
 void f()
 {
 #if defined BOOST_THREAD_USES_CHRONO
-  time_point t0 = Clock::now();
-  time_point t1;
+  t0 = Clock::now();
   {
     auto&& _ = boost::make_unique_locks(m1,m2,m3); (void)_;
     t1 = Clock::now();
   }
-  ns d = t1 - t0 - ms(250);
-  BOOST_THREAD_TEST_IT(d, ns(max_diff));
 #else
   //time_point t0 = Clock::now();
   //time_point t1;
@@ -65,13 +64,24 @@ int main()
   m3.lock();
   boost::thread t(f);
 #if defined BOOST_THREAD_USES_CHRONO
+  time_point t2 = Clock::now();
   boost::this_thread::sleep_for(ms(250));
+  time_point t3 = Clock::now();
 #else
 #endif
   m1.unlock();
   m2.unlock();
   m3.unlock();
   t.join();
+
+#if defined BOOST_THREAD_USES_CHRONO
+  ns sleep_time = t3 - t2;
+  ns d_ns = t1 - t0 - sleep_time;
+  ms d_ms = boost::chrono::duration_cast<boost::chrono::milliseconds>(d_ns);
+  // BOOST_TEST_GE(d_ms.count(), 0);
+  BOOST_THREAD_TEST_IT(d_ms, max_diff);
+  BOOST_THREAD_TEST_IT(d_ns, ns(max_diff));
+#endif
 
   return boost::report_errors();
 }

--- a/test/sync/mutual_exclusion/locks/unique_lock/cons/mutex_pass.cpp
+++ b/test/sync/mutual_exclusion/locks/unique_lock/cons/mutex_pass.cpp
@@ -30,11 +30,13 @@
 boost::mutex m;
 
 #if defined BOOST_THREAD_USES_CHRONO
-typedef boost::chrono::system_clock Clock;
+typedef boost::chrono::high_resolution_clock Clock;
 typedef Clock::time_point time_point;
 typedef Clock::duration duration;
 typedef boost::chrono::milliseconds ms;
 typedef boost::chrono::nanoseconds ns;
+time_point t0;
+time_point t1;
 #else
 #endif
 
@@ -43,14 +45,11 @@ const ms max_diff(BOOST_THREAD_TEST_TIME_MS);
 void f()
 {
 #if defined BOOST_THREAD_USES_CHRONO
-  time_point t0 = Clock::now();
-  time_point t1;
+  t0 = Clock::now();
   {
     boost::unique_lock<boost::mutex> ul(m);
     t1 = Clock::now();
   }
-  ns d = t1 - t0 - ms(250);
-  BOOST_THREAD_TEST_IT(d, ns(max_diff));
 #else
   //time_point t0 = Clock::now();
   //time_point t1;
@@ -68,11 +67,22 @@ int main()
   m.lock();
   boost::thread t(f);
 #if defined BOOST_THREAD_USES_CHRONO
+  time_point t2 = Clock::now();
   boost::this_thread::sleep_for(ms(250));
+  time_point t3 = Clock::now();
 #else
 #endif
   m.unlock();
   t.join();
+
+#if defined BOOST_THREAD_USES_CHRONO
+  ns sleep_time = t3 - t2;
+  ns d_ns = t1 - t0 - sleep_time;
+  ms d_ms = boost::chrono::duration_cast<boost::chrono::milliseconds>(d_ns);
+  // BOOST_TEST_GE(d_ms.count(), 0);
+  BOOST_THREAD_TEST_IT(d_ms, max_diff);
+  BOOST_THREAD_TEST_IT(d_ns, ns(max_diff));
+#endif
 
   return boost::report_errors();
 }

--- a/test/sync/mutual_exclusion/locks/unique_lock/cons/time_point_pass.cpp
+++ b/test/sync/mutual_exclusion/locks/unique_lock/cons/time_point_pass.cpp
@@ -31,30 +31,30 @@
 
 boost::timed_mutex m;
 
-typedef boost::chrono::steady_clock Clock;
+typedef boost::chrono::high_resolution_clock Clock;
 typedef Clock::time_point time_point;
 typedef Clock::duration duration;
 typedef boost::chrono::milliseconds ms;
 typedef boost::chrono::nanoseconds ns;
+time_point t0;
+time_point t1;
 
 const ms max_diff(BOOST_THREAD_TEST_TIME_MS);
 
 void f1()
 {
-  time_point t0 = Clock::now();
+  t0 = Clock::now();
   boost::unique_lock<boost::timed_mutex> lk(m, Clock::now() + ms(750));
   BOOST_TEST(lk.owns_lock() == true);
-  time_point t1 = Clock::now();
-  ns d = t1 - t0 - ms(250);
-  BOOST_THREAD_TEST_IT(d, ns(max_diff));
+  t1 = Clock::now();
 }
 
 void f2()
 {
-  time_point t0 = Clock::now();
+  t0 = Clock::now();
   boost::unique_lock<boost::timed_mutex> lk(m, Clock::now() + ms(250));
   BOOST_TEST(lk.owns_lock() == false);
-  time_point t1 = Clock::now();
+  t1 = Clock::now();
   ns d = t1 - t0 - ms(250);
   BOOST_TEST(d < max_diff);
 }
@@ -64,9 +64,18 @@ int main()
   {
     m.lock();
     boost::thread t(f1);
+    time_point t2 = Clock::now();
     boost::this_thread::sleep_for(ms(250));
+    time_point t3 = Clock::now();
     m.unlock();
     t.join();
+
+    ns sleep_time = t3 - t2;
+    ns d_ns = t1 - t0 - sleep_time;
+    ms d_ms = boost::chrono::duration_cast<boost::chrono::milliseconds>(d_ns);
+    // BOOST_TEST_GE(d_ms.count(), 0);
+    BOOST_THREAD_TEST_IT(d_ms, max_diff);
+    BOOST_THREAD_TEST_IT(d_ns, ns(max_diff));
   }
   {
     m.lock();

--- a/test/sync/mutual_exclusion/locks/unique_lock/cons/try_to_lock_pass.cpp
+++ b/test/sync/mutual_exclusion/locks/unique_lock/cons/try_to_lock_pass.cpp
@@ -29,11 +29,13 @@
 boost::mutex m;
 
 #if defined BOOST_THREAD_USES_CHRONO
-typedef boost::chrono::system_clock Clock;
+typedef boost::chrono::high_resolution_clock Clock;
 typedef Clock::time_point time_point;
 typedef Clock::duration duration;
 typedef boost::chrono::milliseconds ms;
 typedef boost::chrono::nanoseconds ns;
+time_point t0;
+time_point t1;
 #else
 #endif
 
@@ -42,7 +44,7 @@ const ms max_diff(BOOST_THREAD_TEST_TIME_MS);
 void f()
 {
 #if defined BOOST_THREAD_USES_CHRONO
-  time_point t0 = Clock::now();
+  t0 = Clock::now();
   {
     boost::unique_lock<boost::mutex> lk(m, boost::try_to_lock);
     BOOST_TEST(lk.owns_lock() == false);
@@ -58,12 +60,12 @@ void f()
   for (;;)
   {
     boost::unique_lock<boost::mutex> lk(m, boost::try_to_lock);
-    if (lk.owns_lock()) break;
+    if (lk.owns_lock()) {
+      t1 = Clock::now();
+      break;
+    }
   }
-  time_point t1 = Clock::now();
   //m.unlock();
-  ns d = t1 - t0 - ms(250);
-  BOOST_THREAD_TEST_IT(d, ns(max_diff));
 #else
 //  time_point t0 = Clock::now();
 //  {
@@ -94,11 +96,24 @@ int main()
   m.lock();
   boost::thread t(f);
 #if defined BOOST_THREAD_USES_CHRONO
+  time_point t2 = Clock::now();
   boost::this_thread::sleep_for(ms(250));
+  time_point t3 = Clock::now();
 #else
 #endif
   m.unlock();
   t.join();
+
+#if defined BOOST_THREAD_USES_CHRONO
+  ns sleep_time = t3 - t2;
+  ns d_ns = t1 - t0 - sleep_time;
+  ms d_ms = boost::chrono::duration_cast<boost::chrono::milliseconds>(d_ns);
+  std::cout << "d_ns: " << d_ns.count() << std::endl;
+  std::cout << "d_ms: " << d_ms.count() << std::endl;
+  // BOOST_TEST_GE(d_ms.count(), 0);
+  BOOST_THREAD_TEST_IT(d_ms, max_diff);
+  BOOST_THREAD_TEST_IT(d_ns, ns(max_diff));
+#endif
 
   return boost::report_errors();
 }

--- a/test/sync/mutual_exclusion/locks/unique_lock/locking/lock_pass.cpp
+++ b/test/sync/mutual_exclusion/locks/unique_lock/locking/lock_pass.cpp
@@ -28,11 +28,13 @@
 boost::mutex m;
 
 #if defined BOOST_THREAD_USES_CHRONO
-typedef boost::chrono::system_clock Clock;
+typedef boost::chrono::high_resolution_clock Clock;
 typedef Clock::time_point time_point;
 typedef Clock::duration duration;
 typedef boost::chrono::milliseconds ms;
 typedef boost::chrono::nanoseconds ns;
+time_point t0;
+time_point t1;
 #else
 #endif
 
@@ -42,12 +44,10 @@ void f()
 {
 #if defined BOOST_THREAD_USES_CHRONO
   boost::unique_lock < boost::mutex > lk(m, boost::defer_lock);
-  time_point t0 = Clock::now();
+  t0 = Clock::now();
   lk.lock();
-  time_point t1 = Clock::now();
+  t1 = Clock::now();
   BOOST_TEST(lk.owns_lock() == true);
-  ns d = t1 - t0 - ms(250);
-  BOOST_THREAD_TEST_IT(d, ns(max_diff));
   try
   {
     lk.lock();
@@ -104,11 +104,22 @@ int main()
   m.lock();
   boost::thread t(f);
 #if defined BOOST_THREAD_USES_CHRONO
+  time_point t2 = Clock::now();
   boost::this_thread::sleep_for(ms(250));
+  time_point t3 = Clock::now();
 #else
 #endif
   m.unlock();
   t.join();
+
+#if defined BOOST_THREAD_USES_CHRONO
+  ns sleep_time = t3 - t2;
+  ns d_ns = t1 - t0 - sleep_time;
+  ms d_ms = boost::chrono::duration_cast<boost::chrono::milliseconds>(d_ns);
+  // BOOST_TEST_GE(d_ms.count(), 0);
+  BOOST_THREAD_TEST_IT(d_ms, max_diff);
+  BOOST_THREAD_TEST_IT(d_ns, ns(max_diff));
+#endif
 
   return boost::report_errors();
 }

--- a/test/sync/mutual_exclusion/locks/upgrade_lock/cons/duration_pass.cpp
+++ b/test/sync/mutual_exclusion/locks/upgrade_lock/cons/duration_pass.cpp
@@ -30,30 +30,30 @@
 
 boost::shared_mutex m;
 
-typedef boost::chrono::steady_clock Clock;
+typedef boost::chrono::high_resolution_clock Clock;
 typedef Clock::time_point time_point;
 typedef Clock::duration duration;
 typedef boost::chrono::milliseconds ms;
 typedef boost::chrono::nanoseconds ns;
+time_point t0;
+time_point t1;
 
 const ms max_diff(BOOST_THREAD_TEST_TIME_MS);
 
 void f1()
 {
-  time_point t0 = Clock::now();
+  t0 = Clock::now();
   boost::upgrade_lock<boost::shared_mutex> lk(m, ms(750));
   BOOST_TEST(lk.owns_lock() == true);
-  time_point t1 = Clock::now();
-  ns d = t1 - t0 - ms(250);
-  BOOST_THREAD_TEST_IT(d, ns(max_diff));
+  t1 = Clock::now();
 }
 
 void f2()
 {
-  time_point t0 = Clock::now();
+  t0 = Clock::now();
   boost::upgrade_lock<boost::shared_mutex> lk(m, ms(250));
   BOOST_TEST(lk.owns_lock() == false);
-  time_point t1 = Clock::now();
+  t1 = Clock::now();
   ns d = t1 - t0 - ms(250);
   BOOST_THREAD_TEST_IT(d, ns(max_diff));
 }
@@ -63,9 +63,18 @@ int main()
   {
     m.lock();
     boost::thread t(f1);
+    time_point t2 = Clock::now();
     boost::this_thread::sleep_for(ms(250));
+    time_point t3 = Clock::now();
     m.unlock();
     t.join();
+
+    ns sleep_time = t3 - t2;
+    ns d_ns = t1 - t0 - sleep_time;
+    ms d_ms = boost::chrono::duration_cast<boost::chrono::milliseconds>(d_ns);
+    // BOOST_TEST_GE(d_ms.count(), 0);
+    BOOST_THREAD_TEST_IT(d_ms, max_diff);
+    BOOST_THREAD_TEST_IT(d_ns, ns(max_diff));
   }
   {
     m.lock();

--- a/test/sync/mutual_exclusion/locks/upgrade_lock/cons/mutex_pass.cpp
+++ b/test/sync/mutual_exclusion/locks/upgrade_lock/cons/mutex_pass.cpp
@@ -29,11 +29,13 @@
 boost::shared_mutex m;
 
 #if defined BOOST_THREAD_USES_CHRONO
-typedef boost::chrono::system_clock Clock;
+typedef boost::chrono::high_resolution_clock Clock;
 typedef Clock::time_point time_point;
 typedef Clock::duration duration;
 typedef boost::chrono::milliseconds ms;
 typedef boost::chrono::nanoseconds ns;
+time_point t0;
+time_point t1;
 #else
 #endif
 
@@ -42,16 +44,11 @@ const ms max_diff(BOOST_THREAD_TEST_TIME_MS);
 void f()
 {
 #if defined BOOST_THREAD_USES_CHRONO
-  time_point t0 = Clock::now();
-  time_point t1;
+  t0 = Clock::now();
   {
     boost::upgrade_lock<boost::shared_mutex> ul(m);
     t1 = Clock::now();
   }
-  ns d = t1 - t0 - ms(250);
-  std::cout << "diff= " << d.count() << std::endl;
-  std::cout << "max_diff= " << max_diff.count() << std::endl;
-  BOOST_THREAD_TEST_IT(d, ns(max_diff));
 #else
   //time_point t0 = Clock::now();
   //time_point t1;
@@ -69,11 +66,22 @@ int main()
   m.lock();
   boost::thread t(f);
 #if defined BOOST_THREAD_USES_CHRONO
+  time_point t2 = Clock::now();
   boost::this_thread::sleep_for(ms(250));
+  time_point t3 = Clock::now();
 #else
 #endif
   m.unlock();
   t.join();
+
+#if defined BOOST_THREAD_USES_CHRONO
+  ns sleep_time = t3 - t2;
+  ns d_ns = t1 - t0 - sleep_time;
+  ms d_ms = boost::chrono::duration_cast<boost::chrono::milliseconds>(d_ns);
+  // BOOST_TEST_GE(d_ms.count(), 0);
+  BOOST_THREAD_TEST_IT(d_ms, max_diff);
+  BOOST_THREAD_TEST_IT(d_ns, ns(max_diff));
+#endif
 
   return boost::report_errors();
 }

--- a/test/sync/mutual_exclusion/locks/upgrade_lock/cons/time_point_pass.cpp
+++ b/test/sync/mutual_exclusion/locks/upgrade_lock/cons/time_point_pass.cpp
@@ -29,30 +29,30 @@
 
 boost::shared_mutex m;
 
-typedef boost::chrono::steady_clock Clock;
+typedef boost::chrono::high_resolution_clock Clock;
 typedef Clock::time_point time_point;
 typedef Clock::duration duration;
 typedef boost::chrono::milliseconds ms;
 typedef boost::chrono::nanoseconds ns;
+time_point t0;
+time_point t1;
 
 const ms max_diff(BOOST_THREAD_TEST_TIME_MS);
 
 void f1()
 {
-  time_point t0 = Clock::now();
+  t0 = Clock::now();
   boost::upgrade_lock<boost::shared_mutex> lk(m, Clock::now() + ms(750));
   BOOST_TEST(lk.owns_lock() == true);
-  time_point t1 = Clock::now();
-  ns d = t1 - t0 - ms(250);
-  BOOST_THREAD_TEST_IT(d, ns(max_diff));
+  t1 = Clock::now();
 }
 
 void f2()
 {
-  time_point t0 = Clock::now();
+  t0 = Clock::now();
   boost::upgrade_lock<boost::shared_mutex> lk(m, Clock::now() + ms(250));
   BOOST_TEST(lk.owns_lock() == false);
-  time_point t1 = Clock::now();
+  t1 = Clock::now();
   ns d = t1 - t0 - ms(250);
   BOOST_THREAD_TEST_IT(d, ns(max_diff));
 }
@@ -62,9 +62,18 @@ int main()
   {
     m.lock();
     boost::thread t(f1);
+    time_point t2 = Clock::now();
     boost::this_thread::sleep_for(ms(250));
+    time_point t3 = Clock::now();
     m.unlock();
     t.join();
+
+    ns sleep_time = t3 - t2;
+    ns d_ns = t1 - t0 - sleep_time;
+    ms d_ms = boost::chrono::duration_cast<boost::chrono::milliseconds>(d_ns);
+    // BOOST_TEST_GE(d_ms.count(), 0);
+    BOOST_THREAD_TEST_IT(d_ms, max_diff);
+    BOOST_THREAD_TEST_IT(d_ns, ns(max_diff));
   }
   {
     m.lock();

--- a/test/sync/mutual_exclusion/locks/upgrade_lock/cons/try_to_lock_pass.cpp
+++ b/test/sync/mutual_exclusion/locks/upgrade_lock/cons/try_to_lock_pass.cpp
@@ -28,11 +28,13 @@
 boost::shared_mutex m;
 
 #if defined BOOST_THREAD_USES_CHRONO
-typedef boost::chrono::system_clock Clock;
+typedef boost::chrono::high_resolution_clock Clock;
 typedef Clock::time_point time_point;
 typedef Clock::duration duration;
 typedef boost::chrono::milliseconds ms;
 typedef boost::chrono::nanoseconds ns;
+time_point t0;
+time_point t1;
 #else
 #endif
 
@@ -41,7 +43,7 @@ const ms max_diff(BOOST_THREAD_TEST_TIME_MS);
 void f()
 {
 #if defined BOOST_THREAD_USES_CHRONO
-  time_point t0 = Clock::now();
+  t0 = Clock::now();
   {
     boost::upgrade_lock<boost::shared_mutex> lk(m, boost::try_to_lock);
     BOOST_TEST(lk.owns_lock() == false);
@@ -57,12 +59,12 @@ void f()
   for (;;)
   {
     boost::upgrade_lock<boost::shared_mutex> lk(m, boost::try_to_lock);
-    if (lk.owns_lock()) break;
+    if (lk.owns_lock()) {
+      t1 = Clock::now();
+      break;
+    }
   }
-  time_point t1 = Clock::now();
   //m.unlock();
-  ns d = t1 - t0 - ms(250);
-  BOOST_THREAD_TEST_IT(d, ns(max_diff));
 #else
 //  time_point t0 = Clock::now();
 //  {
@@ -93,11 +95,22 @@ int main()
   m.lock();
   boost::thread t(f);
 #if defined BOOST_THREAD_USES_CHRONO
+  time_point t2 = Clock::now();
   boost::this_thread::sleep_for(ms(250));
+  time_point t3 = Clock::now();
 #else
 #endif
   m.unlock();
   t.join();
+
+#if defined BOOST_THREAD_USES_CHRONO
+  ns sleep_time = t3 - t2;
+  ns d_ns = t1 - t0 - sleep_time;
+  ms d_ms = boost::chrono::duration_cast<boost::chrono::milliseconds>(d_ns);
+  // BOOST_TEST_GE(d_ms.count(), 0);
+  BOOST_THREAD_TEST_IT(d_ms, max_diff);
+  BOOST_THREAD_TEST_IT(d_ns, ns(max_diff));
+#endif
 
   return boost::report_errors();
 }

--- a/test/sync/mutual_exclusion/locks/upgrade_lock/locking/lock_pass.cpp
+++ b/test/sync/mutual_exclusion/locks/upgrade_lock/locking/lock_pass.cpp
@@ -28,11 +28,13 @@
 boost::shared_mutex m;
 
 #if defined BOOST_THREAD_USES_CHRONO
-typedef boost::chrono::system_clock Clock;
+typedef boost::chrono::high_resolution_clock Clock;
 typedef Clock::time_point time_point;
 typedef Clock::duration duration;
 typedef boost::chrono::milliseconds ms;
 typedef boost::chrono::nanoseconds ns;
+time_point t0;
+time_point t1;
 #else
 #endif
 
@@ -42,12 +44,10 @@ void f()
 {
 #if defined BOOST_THREAD_USES_CHRONO
   boost::upgrade_lock < boost::shared_mutex > lk(m, boost::defer_lock);
-  time_point t0 = Clock::now();
+  t0 = Clock::now();
   lk.lock();
-  time_point t1 = Clock::now();
+  t1 = Clock::now();
   BOOST_TEST(lk.owns_lock() == true);
-  ns d = t1 - t0 - ms(250);
-  BOOST_THREAD_TEST_IT(d, ns(max_diff));
   try
   {
     lk.lock();
@@ -104,11 +104,22 @@ int main()
   m.lock();
   boost::thread t(f);
 #if defined BOOST_THREAD_USES_CHRONO
+  time_point t2 = Clock::now();
   boost::this_thread::sleep_for(ms(250));
+  time_point t3 = Clock::now();
 #else
 #endif
   m.unlock();
   t.join();
+
+#if defined BOOST_THREAD_USES_CHRONO
+  ns sleep_time = t3 - t2;
+  ns d_ns = t1 - t0 - sleep_time;
+  ms d_ms = boost::chrono::duration_cast<boost::chrono::milliseconds>(d_ns);
+  // BOOST_TEST_GE(d_ms.count(), 0);
+  BOOST_THREAD_TEST_IT(d_ms, max_diff);
+  BOOST_THREAD_TEST_IT(d_ns, ns(max_diff));
+#endif
 
   return boost::report_errors();
 }

--- a/test/sync/mutual_exclusion/mutex/lock_pass.cpp
+++ b/test/sync/mutual_exclusion/mutex/lock_pass.cpp
@@ -26,11 +26,13 @@
 boost::mutex m;
 
 #if defined BOOST_THREAD_USES_CHRONO
-typedef boost::chrono::system_clock Clock;
+typedef boost::chrono::high_resolution_clock Clock;
 typedef Clock::time_point time_point;
 typedef Clock::duration duration;
 typedef boost::chrono::milliseconds ms;
 typedef boost::chrono::nanoseconds ns;
+time_point t0;
+time_point t1;
 #else
 #endif
 
@@ -39,12 +41,10 @@ const ms max_diff(BOOST_THREAD_TEST_TIME_MS);
 void f()
 {
 #if defined BOOST_THREAD_USES_CHRONO
-  time_point t0 = Clock::now();
+  t0 = Clock::now();
   m.lock();
-  time_point t1 = Clock::now();
+  t1 = Clock::now();
   m.unlock();
-  ns d = t1 - t0 - ms(250);
-  BOOST_THREAD_TEST_IT(d, ns(max_diff));
 #else
   //time_point t0 = Clock::now();
   m.lock();
@@ -60,10 +60,21 @@ int main()
   m.lock();
   boost::thread t(f);
 #if defined BOOST_THREAD_USES_CHRONO
+  time_point t2 = Clock::now();
   boost::this_thread::sleep_for(ms(250));
+  time_point t3 = Clock::now();
 #endif
   m.unlock();
   t.join();
+
+#if defined BOOST_THREAD_USES_CHRONO
+  ns sleep_time = t3 - t2;
+  ns d_ns = t1 - t0 - sleep_time;
+  ms d_ms = boost::chrono::duration_cast<boost::chrono::milliseconds>(d_ns);
+  // BOOST_TEST_GE(d_ms.count(), 0);
+  BOOST_THREAD_TEST_IT(d_ms, max_diff);
+  BOOST_THREAD_TEST_IT(d_ns, ns(max_diff));
+#endif
 
   return boost::report_errors();
 }

--- a/test/sync/mutual_exclusion/mutex/try_lock_pass.cpp
+++ b/test/sync/mutual_exclusion/mutex/try_lock_pass.cpp
@@ -27,11 +27,13 @@
 boost::mutex m;
 
 #if defined BOOST_THREAD_USES_CHRONO
-typedef boost::chrono::system_clock Clock;
+typedef boost::chrono::high_resolution_clock Clock;
 typedef Clock::time_point time_point;
 typedef Clock::duration duration;
 typedef boost::chrono::milliseconds ms;
 typedef boost::chrono::nanoseconds ns;
+time_point t0;
+time_point t1;
 #endif
 
 const ms max_diff(BOOST_THREAD_TEST_TIME_MS);
@@ -39,16 +41,14 @@ const ms max_diff(BOOST_THREAD_TEST_TIME_MS);
 void f()
 {
 #if defined BOOST_THREAD_USES_CHRONO
-  time_point t0 = Clock::now();
+  t0 = Clock::now();
   BOOST_TEST(!m.try_lock());
   BOOST_TEST(!m.try_lock());
   BOOST_TEST(!m.try_lock());
   while (!m.try_lock())
     ;
-  time_point t1 = Clock::now();
+  t1 = Clock::now();
   m.unlock();
-  ns d = t1 - t0 - ms(250);
-  BOOST_THREAD_TEST_IT(d, ns(max_diff));
 #else
   //time_point t0 = Clock::now();
   //BOOST_TEST(!m.try_lock());
@@ -69,10 +69,21 @@ int main()
   m.lock();
   boost::thread t(f);
 #if defined BOOST_THREAD_USES_CHRONO
+  time_point t2 = Clock::now();
   boost::this_thread::sleep_for(ms(250));
+  time_point t3 = Clock::now();
 #endif
   m.unlock();
   t.join();
+
+#if defined BOOST_THREAD_USES_CHRONO
+  ns sleep_time = t3 - t2;
+  ns d_ns = t1 - t0 - sleep_time;
+  ms d_ms = boost::chrono::duration_cast<boost::chrono::milliseconds>(d_ns);
+  // BOOST_TEST_GE(d_ms.count(), 0);
+  BOOST_THREAD_TEST_IT(d_ms, max_diff);
+  BOOST_THREAD_TEST_IT(d_ns, ns(max_diff));
+#endif
 
   return boost::report_errors();
 }

--- a/test/sync/mutual_exclusion/null_mutex/lock_pass.cpp
+++ b/test/sync/mutual_exclusion/null_mutex/lock_pass.cpp
@@ -26,7 +26,7 @@
 boost::null_mutex m;
 
 #if defined BOOST_THREAD_USES_CHRONO
-typedef boost::chrono::system_clock Clock;
+typedef boost::chrono::high_resolution_clock Clock;
 typedef Clock::time_point time_point;
 typedef Clock::duration duration;
 typedef boost::chrono::milliseconds ms;

--- a/test/sync/mutual_exclusion/null_mutex/try_lock_for_pass.cpp
+++ b/test/sync/mutual_exclusion/null_mutex/try_lock_for_pass.cpp
@@ -29,7 +29,7 @@
 
 boost::null_mutex m;
 
-typedef boost::chrono::steady_clock Clock;
+typedef boost::chrono::high_resolution_clock Clock;
 typedef Clock::time_point time_point;
 typedef Clock::duration duration;
 typedef boost::chrono::milliseconds ms;

--- a/test/sync/mutual_exclusion/null_mutex/try_lock_pass.cpp
+++ b/test/sync/mutual_exclusion/null_mutex/try_lock_pass.cpp
@@ -28,7 +28,7 @@
 boost::null_mutex m;
 
 #if defined BOOST_THREAD_USES_CHRONO
-typedef boost::chrono::system_clock Clock;
+typedef boost::chrono::high_resolution_clock Clock;
 typedef Clock::time_point time_point;
 typedef Clock::duration duration;
 typedef boost::chrono::milliseconds ms;

--- a/test/sync/mutual_exclusion/recursive_mutex/lock_pass.cpp
+++ b/test/sync/mutual_exclusion/recursive_mutex/lock_pass.cpp
@@ -27,11 +27,13 @@
 boost::recursive_mutex m;
 
 #if defined BOOST_THREAD_USES_CHRONO
-typedef boost::chrono::system_clock Clock;
+typedef boost::chrono::high_resolution_clock Clock;
 typedef Clock::time_point time_point;
 typedef Clock::duration duration;
 typedef boost::chrono::milliseconds ms;
 typedef boost::chrono::nanoseconds ns;
+time_point t0;
+time_point t1;
 #else
 #endif
 
@@ -40,14 +42,12 @@ const ms max_diff(BOOST_THREAD_TEST_TIME_MS);
 void f()
 {
 #if defined BOOST_THREAD_USES_CHRONO
-  time_point t0 = Clock::now();
+  t0 = Clock::now();
   m.lock();
-  time_point t1 = Clock::now();
+  t1 = Clock::now();
   m.lock();
   m.unlock();
   m.unlock();
-  ns d = t1 - t0 - ms(250);
-  BOOST_THREAD_TEST_IT(d, ns(max_diff));
 #else
   //time_point t0 = Clock::now();
   m.lock();
@@ -65,11 +65,22 @@ int main()
   m.lock();
   boost::thread t(f);
 #if defined BOOST_THREAD_USES_CHRONO
+  time_point t2 = Clock::now();
   boost::this_thread::sleep_for(ms(250));
+  time_point t3 = Clock::now();
 #else
 #endif
   m.unlock();
   t.join();
+
+#if defined BOOST_THREAD_USES_CHRONO
+  ns sleep_time = t3 - t2;
+  ns d_ns = t1 - t0 - sleep_time;
+  ms d_ms = boost::chrono::duration_cast<boost::chrono::milliseconds>(d_ns);
+  // BOOST_TEST_GE(d_ms.count(), 0);
+  BOOST_THREAD_TEST_IT(d_ms, max_diff);
+  BOOST_THREAD_TEST_IT(d_ns, ns(max_diff));
+#endif
 
   return boost::report_errors();
 }

--- a/test/sync/mutual_exclusion/recursive_mutex/try_lock_pass.cpp
+++ b/test/sync/mutual_exclusion/recursive_mutex/try_lock_pass.cpp
@@ -27,11 +27,13 @@
 boost::recursive_mutex m;
 
 #if defined BOOST_THREAD_USES_CHRONO
-typedef boost::chrono::system_clock Clock;
+typedef boost::chrono::high_resolution_clock Clock;
 typedef Clock::time_point time_point;
 typedef Clock::duration duration;
 typedef boost::chrono::milliseconds ms;
 typedef boost::chrono::nanoseconds ns;
+time_point t0;
+time_point t1;
 #else
 #endif
 
@@ -40,18 +42,16 @@ const ms max_diff(BOOST_THREAD_TEST_TIME_MS);
 void f()
 {
 #if defined BOOST_THREAD_USES_CHRONO
-  time_point t0 = Clock::now();
+  t0 = Clock::now();
 //  BOOST_TEST(!m.try_lock());
 //  BOOST_TEST(!m.try_lock());
 //  BOOST_TEST(!m.try_lock());
   while (!m.try_lock())
     ;
-  time_point t1 = Clock::now();
+  t1 = Clock::now();
   BOOST_TEST(m.try_lock());
   m.unlock();
   m.unlock();
-  ns d = t1 - t0 - ms(250);
-  BOOST_THREAD_TEST_IT(d, ns(max_diff));
 #else
   //time_point t0 = Clock::now();
   //BOOST_TEST(!m.try_lock());
@@ -73,11 +73,22 @@ int main()
   m.lock();
   boost::thread t(f);
 #if defined BOOST_THREAD_USES_CHRONO
+  time_point t2 = Clock::now();
   boost::this_thread::sleep_for(ms(250));
+  time_point t3 = Clock::now();
 #else
 #endif
   m.unlock();
   t.join();
+
+#if defined BOOST_THREAD_USES_CHRONO
+  ns sleep_time = t3 - t2;
+  ns d_ns = t1 - t0 - sleep_time;
+  ms d_ms = boost::chrono::duration_cast<boost::chrono::milliseconds>(d_ns);
+  // BOOST_TEST_GE(d_ms.count(), 0);
+  BOOST_THREAD_TEST_IT(d_ms, max_diff);
+  BOOST_THREAD_TEST_IT(d_ns, ns(max_diff));
+#endif
 
   return boost::report_errors();
 }

--- a/test/sync/mutual_exclusion/recursive_timed_mutex/lock_pass.cpp
+++ b/test/sync/mutual_exclusion/recursive_timed_mutex/lock_pass.cpp
@@ -27,11 +27,13 @@
 boost::recursive_timed_mutex m;
 
 #if defined BOOST_THREAD_USES_CHRONO
-typedef boost::chrono::system_clock Clock;
+typedef boost::chrono::high_resolution_clock Clock;
 typedef Clock::time_point time_point;
 typedef Clock::duration duration;
 typedef boost::chrono::milliseconds ms;
 typedef boost::chrono::nanoseconds ns;
+time_point t0;
+time_point t1;
 #else
 #endif
 
@@ -40,14 +42,12 @@ const ms max_diff(BOOST_THREAD_TEST_TIME_MS);
 void f()
 {
 #if defined BOOST_THREAD_USES_CHRONO
-  time_point t0 = Clock::now();
+  t0 = Clock::now();
   m.lock();
-  time_point t1 = Clock::now();
+  t1 = Clock::now();
   m.lock();
   m.unlock();
   m.unlock();
-  ns d = t1 - t0 - ms(250);
-  BOOST_THREAD_TEST_IT(d, ns(max_diff));
 #else
   //time_point t0 = Clock::now();
   m.lock();
@@ -65,11 +65,22 @@ int main()
   m.lock();
   boost::thread t(f);
 #if defined BOOST_THREAD_USES_CHRONO
+  time_point t2 = Clock::now();
   boost::this_thread::sleep_for(ms(250));
+  time_point t3 = Clock::now();
 #else
 #endif
   m.unlock();
   t.join();
+
+#if defined BOOST_THREAD_USES_CHRONO
+  ns sleep_time = t3 - t2;
+  ns d_ns = t1 - t0 - sleep_time;
+  ms d_ms = boost::chrono::duration_cast<boost::chrono::milliseconds>(d_ns);
+  // BOOST_TEST_GE(d_ms.count(), 0);
+  BOOST_THREAD_TEST_IT(d_ms, max_diff);
+  BOOST_THREAD_TEST_IT(d_ns, ns(max_diff));
+#endif
 
   return boost::report_errors();
 }

--- a/test/sync/mutual_exclusion/recursive_timed_mutex/try_lock_for_pass.cpp
+++ b/test/sync/mutual_exclusion/recursive_timed_mutex/try_lock_for_pass.cpp
@@ -28,24 +28,24 @@
 
 boost::recursive_timed_mutex m;
 
-typedef boost::chrono::steady_clock Clock;
+typedef boost::chrono::high_resolution_clock Clock;
 typedef Clock::time_point time_point;
 typedef Clock::duration duration;
 typedef boost::chrono::milliseconds ms;
 typedef boost::chrono::nanoseconds ns;
+time_point t0;
+time_point t1;
 
 const ms max_diff(BOOST_THREAD_TEST_TIME_MS);
 
 void f1()
 {
-  time_point t0 = Clock::now();
+  t0 = Clock::now();
   BOOST_TEST(m.try_lock_for(ms(750)) == true);
-  time_point t1 = Clock::now();
+  t1 = Clock::now();
   BOOST_TEST(m.try_lock());
   m.unlock();
   m.unlock();
-  ns d = t1 - t0 - ms(250);
-  BOOST_THREAD_TEST_IT(d, ns(max_diff));
 }
 
 void f2()
@@ -62,9 +62,18 @@ int main()
   {
     m.lock();
     boost::thread t(f1);
+    time_point t2 = Clock::now();
     boost::this_thread::sleep_for(ms(250));
+    time_point t3 = Clock::now();
     m.unlock();
     t.join();
+
+    ns sleep_time = t3 - t2;
+    ns d_ns = t1 - t0 - sleep_time;
+    ms d_ms = boost::chrono::duration_cast<boost::chrono::milliseconds>(d_ns);
+    // BOOST_TEST_GE(d_ms.count(), 0);
+    BOOST_THREAD_TEST_IT(d_ms, max_diff);
+    BOOST_THREAD_TEST_IT(d_ns, ns(max_diff));
   }
   {
     m.lock();

--- a/test/sync/mutual_exclusion/recursive_timed_mutex/try_lock_pass.cpp
+++ b/test/sync/mutual_exclusion/recursive_timed_mutex/try_lock_pass.cpp
@@ -26,11 +26,13 @@
 boost::recursive_timed_mutex m;
 
 #if defined BOOST_THREAD_USES_CHRONO
-typedef boost::chrono::system_clock Clock;
+typedef boost::chrono::high_resolution_clock Clock;
 typedef Clock::time_point time_point;
 typedef Clock::duration duration;
 typedef boost::chrono::milliseconds ms;
 typedef boost::chrono::nanoseconds ns;
+time_point t0;
+time_point t1;
 #else
 #endif
 
@@ -39,18 +41,16 @@ const ms max_diff(BOOST_THREAD_TEST_TIME_MS);
 void f()
 {
 #if defined BOOST_THREAD_USES_CHRONO
-  time_point t0 = Clock::now();
+  t0 = Clock::now();
   BOOST_TEST(!m.try_lock());
   BOOST_TEST(!m.try_lock());
   BOOST_TEST(!m.try_lock());
   while (!m.try_lock())
     ;
-  time_point t1 = Clock::now();
+  t1 = Clock::now();
   BOOST_TEST(m.try_lock());
   m.unlock();
   m.unlock();
-  ns d = t1 - t0 - ms(250);
-  BOOST_THREAD_TEST_IT(d, ns(max_diff));
 #else
   //time_point t0 = Clock::now();
   //BOOST_TEST(!m.try_lock());
@@ -72,11 +72,22 @@ int main()
   m.lock();
   boost::thread t(f);
 #if defined BOOST_THREAD_USES_CHRONO
+  time_point t2 = Clock::now();
   boost::this_thread::sleep_for(ms(250));
+  time_point t3 = Clock::now();
 #else
 #endif
   m.unlock();
   t.join();
+
+#if defined BOOST_THREAD_USES_CHRONO
+  ns sleep_time = t3 - t2;
+  ns d_ns = t1 - t0 - sleep_time;
+  ms d_ms = boost::chrono::duration_cast<boost::chrono::milliseconds>(d_ns);
+  // BOOST_TEST_GE(d_ms.count(), 0);
+  BOOST_THREAD_TEST_IT(d_ms, max_diff);
+  BOOST_THREAD_TEST_IT(d_ns, ns(max_diff));
+#endif
 
   return boost::report_errors();
 }

--- a/test/sync/mutual_exclusion/recursive_timed_mutex/try_lock_until_pass.cpp
+++ b/test/sync/mutual_exclusion/recursive_timed_mutex/try_lock_until_pass.cpp
@@ -28,29 +28,29 @@
 
 boost::recursive_timed_mutex m;
 
-typedef boost::chrono::steady_clock Clock;
+typedef boost::chrono::high_resolution_clock Clock;
 typedef Clock::time_point time_point;
 typedef Clock::duration duration;
 typedef boost::chrono::milliseconds ms;
 typedef boost::chrono::nanoseconds ns;
+time_point t0;
+time_point t1;
 
 const ms max_diff(BOOST_THREAD_TEST_TIME_MS);
 
 void f1()
 {
-  time_point t0 = Clock::now();
+  t0 = Clock::now();
   BOOST_TEST(m.try_lock_until(Clock::now() + ms(750)) == true);
-  time_point t1 = Clock::now();
+  t1 = Clock::now();
   m.unlock();
-  ns d = t1 - t0 - ms(250);
-  BOOST_THREAD_TEST_IT(d, ns(max_diff));
 }
 
 void f2()
 {
-  time_point t0 = Clock::now();
+  t0 = Clock::now();
   BOOST_TEST(m.try_lock_until(Clock::now() + ms(250)) == false);
-  time_point t1 = Clock::now();
+  t1 = Clock::now();
   ns d = t1 - t0 - ms(250);
   BOOST_THREAD_TEST_IT(d, ns(max_diff));
 }
@@ -60,9 +60,20 @@ int main()
   {
     m.lock();
     boost::thread t(f1);
+    time_point t2 = Clock::now();
     boost::this_thread::sleep_for(ms(250));
+    time_point t3 = Clock::now();
     m.unlock();
     t.join();
+
+#if defined BOOST_THREAD_USES_CHRONO
+    ns sleep_time = t3 - t2;
+    ns d_ns = t1 - t0 - sleep_time;
+    ms d_ms = boost::chrono::duration_cast<boost::chrono::milliseconds>(d_ns);
+    // BOOST_TEST_GE(d_ms.count(), 0);
+    BOOST_THREAD_TEST_IT(d_ms, max_diff);
+    BOOST_THREAD_TEST_IT(d_ns, ns(max_diff));
+#endif
   }
   {
     m.lock();

--- a/test/sync/mutual_exclusion/shared_mutex/lock_pass.cpp
+++ b/test/sync/mutual_exclusion/shared_mutex/lock_pass.cpp
@@ -26,11 +26,13 @@
 boost::shared_mutex m;
 
 #if defined BOOST_THREAD_USES_CHRONO
-typedef boost::chrono::system_clock Clock;
+typedef boost::chrono::high_resolution_clock Clock;
 typedef Clock::time_point time_point;
 typedef Clock::duration duration;
 typedef boost::chrono::milliseconds ms;
 typedef boost::chrono::nanoseconds ns;
+time_point t0;
+time_point t1;
 #else
 #endif
 
@@ -39,12 +41,10 @@ const ms max_diff(BOOST_THREAD_TEST_TIME_MS);
 void f()
 {
 #if defined BOOST_THREAD_USES_CHRONO
-  time_point t0 = Clock::now();
+  t0 = Clock::now();
   m.lock();
-  time_point t1 = Clock::now();
+  t1 = Clock::now();
   m.unlock();
-  ns d = t1 - t0 - ms(250);
-  BOOST_THREAD_TEST_IT(d, ns(max_diff));
 #else
   //time_point t0 = Clock::now();
   m.lock();
@@ -60,11 +60,22 @@ int main()
   m.lock();
   boost::thread t(f);
 #if defined BOOST_THREAD_USES_CHRONO
+  time_point t2 = Clock::now();
   boost::this_thread::sleep_for(ms(250));
+  time_point t3 = Clock::now();
 #else
 #endif
   m.unlock();
   t.join();
+
+#if defined BOOST_THREAD_USES_CHRONO
+  ns sleep_time = t3 - t2;
+  ns d_ns = t1 - t0 - sleep_time;
+  ms d_ms = boost::chrono::duration_cast<boost::chrono::milliseconds>(d_ns);
+  // BOOST_TEST_GE(d_ms.count(), 0);
+  BOOST_THREAD_TEST_IT(d_ms, max_diff);
+  BOOST_THREAD_TEST_IT(d_ns, ns(max_diff));
+#endif
 
   return boost::report_errors();
 }

--- a/test/sync/mutual_exclusion/shared_mutex/try_lock_for_pass.cpp
+++ b/test/sync/mutual_exclusion/shared_mutex/try_lock_for_pass.cpp
@@ -26,29 +26,29 @@
 
 boost::shared_mutex m;
 
-typedef boost::chrono::steady_clock Clock;
+typedef boost::chrono::high_resolution_clock Clock;
 typedef Clock::time_point time_point;
 typedef Clock::duration duration;
 typedef boost::chrono::milliseconds ms;
 typedef boost::chrono::nanoseconds ns;
+time_point t0;
+time_point t1;
 
 const ms max_diff(BOOST_THREAD_TEST_TIME_MS);
 
 void f1()
 {
-  time_point t0 = Clock::now();
+  t0 = Clock::now();
   BOOST_TEST(m.try_lock_for(ms(750)) == true);
-  time_point t1 = Clock::now();
+  t1 = Clock::now();
   m.unlock();
-  ns d = t1 - t0 - ms(250);
-  BOOST_THREAD_TEST_IT(d, ns(max_diff));
 }
 
 void f2()
 {
-  time_point t0 = Clock::now();
+  t0 = Clock::now();
   BOOST_TEST(m.try_lock_for(ms(250)) == false);
-  time_point t1 = Clock::now();
+  t1 = Clock::now();
   ns d = t1 - t0 - ms(250);
   BOOST_THREAD_TEST_IT(d, ns(max_diff));
 }
@@ -58,9 +58,20 @@ int main()
   {
     m.lock();
     boost::thread t(f1);
+    time_point t2 = Clock::now();
     boost::this_thread::sleep_for(ms(250));
+    time_point t3 = Clock::now();
     m.unlock();
     t.join();
+
+#if defined BOOST_THREAD_USES_CHRONO
+    ns sleep_time = t3 - t2;
+    ns d_ns = t1 - t0 - sleep_time;
+    ms d_ms = boost::chrono::duration_cast<boost::chrono::milliseconds>(d_ns);
+    // BOOST_TEST_GE(d_ms.count(), 0);
+    BOOST_THREAD_TEST_IT(d_ms, max_diff);
+    BOOST_THREAD_TEST_IT(d_ns, ns(max_diff));
+#endif
   }
   {
     m.lock();

--- a/test/sync/mutual_exclusion/shared_mutex/try_lock_pass.cpp
+++ b/test/sync/mutual_exclusion/shared_mutex/try_lock_pass.cpp
@@ -26,11 +26,13 @@
 boost::shared_mutex m;
 
 #if defined BOOST_THREAD_USES_CHRONO
-typedef boost::chrono::system_clock Clock;
+typedef boost::chrono::high_resolution_clock Clock;
 typedef Clock::time_point time_point;
 typedef Clock::duration duration;
 typedef boost::chrono::milliseconds ms;
 typedef boost::chrono::nanoseconds ns;
+time_point t0;
+time_point t1;
 #else
 #endif
 
@@ -39,16 +41,14 @@ const ms max_diff(BOOST_THREAD_TEST_TIME_MS);
 void f()
 {
 #if defined BOOST_THREAD_USES_CHRONO
-  time_point t0 = Clock::now();
+  t0 = Clock::now();
   BOOST_TEST(!m.try_lock());
   BOOST_TEST(!m.try_lock());
   BOOST_TEST(!m.try_lock());
   while (!m.try_lock())
     ;
-  time_point t1 = Clock::now();
+  t1 = Clock::now();
   m.unlock();
-  ns d = t1 - t0 - ms(250);
-  BOOST_THREAD_TEST_IT(d, ns(max_diff));
 #else
   //time_point t0 = Clock::now();
   //BOOST_TEST(!m.try_lock());
@@ -68,11 +68,22 @@ int main()
   m.lock();
   boost::thread t(f);
 #if defined BOOST_THREAD_USES_CHRONO
+  time_point t2 = Clock::now();
   boost::this_thread::sleep_for(ms(250));
+  time_point t3 = Clock::now();
 #else
 #endif
   m.unlock();
   t.join();
+
+#if defined BOOST_THREAD_USES_CHRONO
+  ns sleep_time = t3 - t2;
+  ns d_ns = t1 - t0 - sleep_time;
+  ms d_ms = boost::chrono::duration_cast<boost::chrono::milliseconds>(d_ns);
+  // BOOST_TEST_GE(d_ms.count(), 0);
+  BOOST_THREAD_TEST_IT(d_ms, max_diff);
+  BOOST_THREAD_TEST_IT(d_ns, ns(max_diff));
+#endif
 
   return boost::report_errors();
 }

--- a/test/sync/mutual_exclusion/shared_mutex/try_lock_until_pass.cpp
+++ b/test/sync/mutual_exclusion/shared_mutex/try_lock_until_pass.cpp
@@ -26,29 +26,29 @@
 
 boost::shared_mutex m;
 
-typedef boost::chrono::steady_clock Clock;
+typedef boost::chrono::high_resolution_clock Clock;
 typedef Clock::time_point time_point;
 typedef Clock::duration duration;
 typedef boost::chrono::milliseconds ms;
 typedef boost::chrono::nanoseconds ns;
+time_point t0;
+time_point t1;
 
 const ms max_diff(BOOST_THREAD_TEST_TIME_MS);
 
 void f1()
 {
-  time_point t0 = Clock::now();
+  t0 = Clock::now();
   BOOST_TEST(m.try_lock_until(Clock::now() + ms(750)) == true);
-  time_point t1 = Clock::now();
+  t1 = Clock::now();
   m.unlock();
-  ns d = t1 - t0 - ms(250);
-  BOOST_THREAD_TEST_IT(d, ns(max_diff));
 }
 
 void f2()
 {
-  time_point t0 = Clock::now();
+  t0 = Clock::now();
   BOOST_TEST(m.try_lock_until(Clock::now() + ms(250)) == false);
-  time_point t1 = Clock::now();
+  t1 = Clock::now();
   ns d = t1 - t0 - ms(250);
   BOOST_THREAD_TEST_IT(d, ns(max_diff));
 }
@@ -58,9 +58,18 @@ int main()
   {
     m.lock();
     boost::thread t(f1);
+    time_point t2 = Clock::now();
     boost::this_thread::sleep_for(ms(250));
+    time_point t3 = Clock::now();
     m.unlock();
     t.join();
+
+    ns sleep_time = t3 - t2;
+    ns d_ns = t1 - t0 - sleep_time;
+    ms d_ms = boost::chrono::duration_cast<boost::chrono::milliseconds>(d_ns);
+    // BOOST_TEST_GE(d_ms.count(), 0);
+    BOOST_THREAD_TEST_IT(d_ms, max_diff);
+    BOOST_THREAD_TEST_IT(d_ns, ns(max_diff));
   }
   {
     m.lock();

--- a/test/sync/mutual_exclusion/timed_mutex/try_lock_for_pass.cpp
+++ b/test/sync/mutual_exclusion/timed_mutex/try_lock_for_pass.cpp
@@ -28,29 +28,29 @@
 
 boost::timed_mutex m;
 
-typedef boost::chrono::steady_clock Clock;
+typedef boost::chrono::high_resolution_clock Clock;
 typedef Clock::time_point time_point;
 typedef Clock::duration duration;
 typedef boost::chrono::milliseconds ms;
 typedef boost::chrono::nanoseconds ns;
+time_point t0;
+time_point t1;
 
 const ms max_diff(BOOST_THREAD_TEST_TIME_MS);
 
 void f1()
 {
-  time_point t0 = Clock::now();
+  t0 = Clock::now();
   BOOST_TEST(m.try_lock_for(ms(750)) == true);
-  time_point t1 = Clock::now();
+  t1 = Clock::now();
   m.unlock();
-  ns d = t1 - t0 - ms(250);
-  BOOST_THREAD_TEST_IT(d, ns(max_diff));
 }
 
 void f2()
 {
-  time_point t0 = Clock::now();
+  t0 = Clock::now();
   BOOST_TEST(m.try_lock_for(ms(250)) == false);
-  time_point t1 = Clock::now();
+  t1 = Clock::now();
   ns d = t1 - t0 - ms(250);
   BOOST_THREAD_TEST_IT(d, ns(max_diff));
 }
@@ -60,9 +60,18 @@ int main()
   {
     m.lock();
     boost::thread t(f1);
+    time_point t2 = Clock::now();
     boost::this_thread::sleep_for(ms(250));
+    time_point t3 = Clock::now();
     m.unlock();
     t.join();
+
+    ns sleep_time = t3 - t2;
+    ns d_ns = t1 - t0 - sleep_time;
+    ms d_ms = boost::chrono::duration_cast<boost::chrono::milliseconds>(d_ns);
+    // BOOST_TEST_GE(d_ms.count(), 0);
+    BOOST_THREAD_TEST_IT(d_ms, max_diff);
+    BOOST_THREAD_TEST_IT(d_ns, ns(max_diff));
   }
   {
     m.lock();

--- a/test/sync/mutual_exclusion/timed_mutex/try_lock_pass.cpp
+++ b/test/sync/mutual_exclusion/timed_mutex/try_lock_pass.cpp
@@ -27,11 +27,13 @@
 boost::timed_mutex m;
 
 #if defined BOOST_THREAD_USES_CHRONO
-typedef boost::chrono::system_clock Clock;
+typedef boost::chrono::high_resolution_clock Clock;
 typedef Clock::time_point time_point;
 typedef Clock::duration duration;
 typedef boost::chrono::milliseconds ms;
 typedef boost::chrono::nanoseconds ns;
+time_point t0;
+time_point t1;
 #else
 #endif
 
@@ -40,16 +42,14 @@ const ms max_diff(BOOST_THREAD_TEST_TIME_MS);
 void f()
 {
 #if defined BOOST_THREAD_USES_CHRONO
-  time_point t0 = Clock::now();
+  t0 = Clock::now();
   BOOST_TEST(!m.try_lock());
   BOOST_TEST(!m.try_lock());
   BOOST_TEST(!m.try_lock());
   while (!m.try_lock())
     ;
-  time_point t1 = Clock::now();
+  t1 = Clock::now();
   m.unlock();
-  ns d = t1 - t0 - ms(250);
-  BOOST_THREAD_TEST_IT(d, ns(max_diff));
 #else
   //time_point t0 = Clock::now();
   //BOOST_TEST(!m.try_lock());
@@ -69,11 +69,22 @@ int main()
   m.lock();
   boost::thread t(f);
 #if defined BOOST_THREAD_USES_CHRONO
+  time_point t2 = Clock::now();
   boost::this_thread::sleep_for(ms(250));
+  time_point t3 = Clock::now();
 #else
 #endif
   m.unlock();
   t.join();
+
+#if defined BOOST_THREAD_USES_CHRONO
+  ns sleep_time = t3 - t2;
+  ns d_ns = t1 - t0 - sleep_time;
+  ms d_ms = boost::chrono::duration_cast<boost::chrono::milliseconds>(d_ns);
+  // BOOST_TEST_GE(d_ms.count(), 0);
+  BOOST_THREAD_TEST_IT(d_ms, max_diff);
+  BOOST_THREAD_TEST_IT(d_ns, ns(max_diff));
+#endif
 
   return boost::report_errors();
 }

--- a/test/sync/mutual_exclusion/timed_mutex/try_lock_until_pass.cpp
+++ b/test/sync/mutual_exclusion/timed_mutex/try_lock_until_pass.cpp
@@ -28,29 +28,29 @@
 
 boost::timed_mutex m;
 
-typedef boost::chrono::steady_clock Clock;
+typedef boost::chrono::high_resolution_clock Clock;
 typedef Clock::time_point time_point;
 typedef Clock::duration duration;
 typedef boost::chrono::milliseconds ms;
 typedef boost::chrono::nanoseconds ns;
+time_point t0;
+time_point t1;
 
 const ms max_diff(BOOST_THREAD_TEST_TIME_MS);
 
 void f1()
 {
-  time_point t0 = Clock::now();
+  t0 = Clock::now();
   BOOST_TEST(m.try_lock_until(Clock::now() + ms(750)) == true);
-  time_point t1 = Clock::now();
+  t1 = Clock::now();
   m.unlock();
-  ns d = t1 - t0 - ms(250);
-  BOOST_THREAD_TEST_IT(d, ns(max_diff));
 }
 
 void f2()
 {
-  time_point t0 = Clock::now();
+  t0 = Clock::now();
   BOOST_TEST(m.try_lock_until(Clock::now() + ms(250)) == false);
-  time_point t1 = Clock::now();
+  t1 = Clock::now();
   ns d = t1 - t0 - ms(250);
   BOOST_THREAD_TEST_IT(d, ns(max_diff));
 }
@@ -60,9 +60,18 @@ int main()
   {
     m.lock();
     boost::thread t(f1);
+    time_point t2 = Clock::now();
     boost::this_thread::sleep_for(ms(250));
+    time_point t3 = Clock::now();
     m.unlock();
     t.join();
+
+    ns sleep_time = t3 - t2;
+    ns d_ns = t1 - t0 - sleep_time;
+    ms d_ms = boost::chrono::duration_cast<boost::chrono::milliseconds>(d_ns);
+    // BOOST_TEST_GE(d_ms.count(), 0);
+    BOOST_THREAD_TEST_IT(d_ms, max_diff);
+    BOOST_THREAD_TEST_IT(d_ns, ns(max_diff));
   }
   {
     m.lock();


### PR DESCRIPTION
As discussed in https://github.com/boostorg/thread/pull/213#issuecomment-380600387

Note that the one type of timing test I couldn't apply this approach to are those that involve condition variables, since there's no way to account for oversleeping (i.e., longer than requested) in `pthread_cond_timedwait`. That is why the mac builds still use a slightly higher timeout. See this [build output for an example](https://circleci.com/gh/thughes/thread/483).

Overall this makes the tests much more reliable on CircleCI. I think it will help other people making PRs so they don't wonder why the unit tests randomly fail in tests unrelated to their changes.