### PR TITLE
Simplify thread specific storage

### DIFF
--- a/include/boost/thread/pthread/thread_data.hpp
+++ b/include/boost/thread/pthread/thread_data.hpp
@@ -92,16 +92,7 @@ namespace boost
         struct shared_state_base;
         struct tss_cleanup_function;
         struct thread_exit_callback_node;
-        struct tss_data_node
-        {
-            boost::shared_ptr<boost::detail::tss_cleanup_function> func;
-            void* value;
-
-            tss_data_node(boost::shared_ptr<boost::detail::tss_cleanup_function> func_,
-                          void* value_):
-                func(func_),value(value_)
-            {}
-        };
+        typedef boost::shared_ptr<void> tss_data_node;
 
         struct thread_data_base;
         typedef boost::shared_ptr<thread_data_base> thread_data_ptr;

--- a/include/boost/thread/win32/thread_data.hpp
+++ b/include/boost/thread/win32/thread_data.hpp
@@ -78,16 +78,7 @@ namespace boost
         struct shared_state_base;
         struct tss_cleanup_function;
         struct thread_exit_callback_node;
-        struct tss_data_node
-        {
-            boost::shared_ptr<boost::detail::tss_cleanup_function> func;
-            void* value;
-
-            tss_data_node(boost::shared_ptr<boost::detail::tss_cleanup_function> func_,
-                          void* value_):
-                func(func_),value(value_)
-            {}
-        };
+        typedef boost::shared_ptr<void> tss_data_node;
 
         struct thread_data_base;
         void intrusive_ptr_add_ref(thread_data_base * p);


### PR DESCRIPTION
I have used `shared_ptr` for storing user data directly and custom destructor to handle user supplied destructor and lack of `release` on `shared_ptr`.

This can be further improved by replacing `shared_ptr` with `local_shared_ptr`.

Fixes #236.