### PR TITLE
Fixed lockable_traits bugs

### DIFF
--- a/include/boost/thread/lockable_traits.hpp
+++ b/include/boost/thread/lockable_traits.hpp
@@ -11,7 +11,12 @@
 
 #include <boost/assert.hpp>
 #include <boost/detail/workaround.hpp>
+#include <boost/type_traits/integral_constant.hpp>
+#ifdef BOOST_NO_CXX11_SFINAE_EXPR
 #include <boost/type_traits/is_class.hpp>
+#else
+#include <boost/type_traits/declval.hpp>
+#endif
 
 #include <boost/config/abi_prefix.hpp>
 
@@ -33,6 +38,7 @@ namespace boost
 #ifndef BOOST_THREAD_NO_AUTO_DETECT_MUTEX_TYPES
     namespace detail
     {
+#ifdef BOOST_NO_CXX11_SFINAE_EXPR
 #define BOOST_THREAD_DEFINE_HAS_MEMBER_CALLED(member_name)                     \
         template<typename T, bool=boost::is_class<T>::value>            \
         struct has_member_called_##member_name                          \
@@ -142,6 +148,31 @@ namespace boost
         BOOST_STATIC_CONSTANT(
             bool,value=sizeof(has_member_try_lock<T>::has_member(&T::try_lock))==sizeof(true_type));
       };
+#else
+      template<typename T,typename Enabled=void>
+      struct has_member_lock : false_type {};
+
+      template<typename T>
+      struct has_member_lock<T,
+          decltype(void(boost::declval<T&>().lock()))
+      > : true_type {};
+
+      template<typename T,typename Enabled=void>
+      struct has_member_unlock : false_type {};
+
+      template<typename T>
+      struct has_member_unlock<T,
+          decltype(void(boost::declval<T&>().unlock()))
+      > : true_type {};
+
+      template<typename T,typename Enabled=bool>
+      struct has_member_try_lock : false_type {};
+
+      template<typename T>
+      struct has_member_try_lock<T,
+          decltype(bool(boost::declval<T&>().try_lock()))
+      > : true_type {};
+#endif
 
     }
 


### PR DESCRIPTION
Traits does not handle `noexcept` qualifiers (which are part of function type in C++17) and wrongly did not detect methods.
Because of this on MSVC 14.1 with -std=c++17 `boost::is_mutex_type<boost::mutex>::value` is false and `boost::lock(mutex)` does not compile.

Fixes #222.