### PR TITLE
Fix "interruption_point" defined twice

### DIFF
--- a/include/boost/thread/detail/thread.hpp
+++ b/include/boost/thread/detail/thread.hpp
@@ -18,6 +18,9 @@
 #if defined BOOST_THREAD_USES_DATETIME
 #include <boost/thread/xtime.hpp>
 #endif
+#if defined BOOST_THREAD_PROVIDES_INTERRUPTIONS
+#include <boost/thread/interruption.hpp>
+#endif
 #include <boost/thread/detail/thread_heap_alloc.hpp>
 #include <boost/thread/detail/make_tuple_indices.hpp>
 #include <boost/thread/detail/invoke.hpp>
@@ -585,12 +588,6 @@ namespace boost
         thread::id get_id() BOOST_NOEXCEPT;
 #else
         thread::id BOOST_THREAD_DECL get_id() BOOST_NOEXCEPT;
-#endif
-
-#if defined BOOST_THREAD_PROVIDES_INTERRUPTIONS
-        void BOOST_THREAD_DECL interruption_point();
-        bool BOOST_THREAD_DECL interruption_enabled() BOOST_NOEXCEPT;
-        bool BOOST_THREAD_DECL interruption_requested() BOOST_NOEXCEPT;
 #endif
 
 #if defined BOOST_THREAD_USES_DATETIME

--- a/include/boost/thread/interruption.hpp
+++ b/include/boost/thread/interruption.hpp
@@ -1,0 +1,22 @@
+// (C) Copyright 2013 Vicente J. Botet Escriba
+// Distributed under the Boost Software License, Version 1.0. (See
+// accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+
+#ifndef BOOST_THREAD_INTERRUPTION_HPP
+#define BOOST_THREAD_INTERRUPTION_HPP
+
+#include <boost/thread/detail/config.hpp>
+
+namespace boost
+{
+    namespace this_thread
+    {
+        void BOOST_THREAD_DECL interruption_point();
+        bool BOOST_THREAD_DECL interruption_enabled() BOOST_NOEXCEPT;
+        bool BOOST_THREAD_DECL interruption_requested() BOOST_NOEXCEPT;
+    }
+}
+
+#endif // header

--- a/include/boost/thread/pthread/condition_variable.hpp
+++ b/include/boost/thread/pthread/condition_variable.hpp
@@ -11,6 +11,7 @@
 #include <boost/thread/pthread/pthread_helpers.hpp>
 
 #if defined BOOST_THREAD_PROVIDES_INTERRUPTIONS
+#include <boost/thread/interruption.hpp>
 #include <boost/thread/pthread/thread_data.hpp>
 #endif
 #include <boost/thread/pthread/condition_variable_fwd.hpp>
@@ -26,13 +27,6 @@
 
 namespace boost
 {
-#if defined BOOST_THREAD_PROVIDES_INTERRUPTIONS
-    namespace this_thread
-    {
-        void BOOST_THREAD_DECL interruption_point();
-    }
-#endif
-
     namespace thread_cv_detail
     {
         template<typename MutexType>


### PR DESCRIPTION
```
In file included from /usr/local/include/boost/thread/thread_only.hpp:22,
                 from /usr/local/include/boost/thread/thread.hpp:12,
                 from /usr/local/include/boost/thread.hpp:13,
                 from validation.cpp:48:
/usr/local/include/boost/thread/detail/thread.hpp:591:32: warning: redundant redeclaration of 'void boost::this_thread::interruption_point()' in same scope [-Wredundant-decls]
         void BOOST_THREAD_DECL interruption_point();
                                ^~~~~~~~~~~~~~~~~~
In file included from /usr/local/include/boost/thread/condition_variable.hpp:16,
                 from ./checkqueue.h:13,
                 from validation.cpp:12:
/usr/local/include/boost/thread/pthread/condition_variable.hpp:32:32: note: previous declaration of 'void boost::this_thread::interruption_point()'
         void BOOST_THREAD_DECL interruption_point();
                                ^~~~~~~~~~~~~~~~~~
```