### PR TITLE
Remove linking with Boost.System

### DIFF
--- a/build/Jamfile.v2
+++ b/build/Jamfile.v2
@@ -54,7 +54,6 @@ project boost/thread
       #<define>BOOST_SYSTEM_NO_DEPRECATED
       #<define>BOOST_THREAD_DONT_PROVIDE_INTERRUPTIONS
 
-      <library>/boost/system//boost_system
        #-pedantic -ansi -std=gnu++0x -Wextra -fpermissive
         <warnings>all
         <toolset>gcc:<cxxflags>-Wextra
@@ -140,7 +139,6 @@ project boost/thread
       #<define>BOOST_THREAD_THROW_IF_PRECONDITION_NOT_SATISFIED
       #<define>BOOST_SYSTEM_NO_DEPRECATED
       #<define>BOOST_THREAD_DONT_PROVIDE_INTERRUPTIONS
-      <library>/boost/system//boost_system
     ;
 
 rule tag ( name : type ? : property-set )

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -180,7 +180,6 @@ rule thread-run2-h ( sources : name )
     sources = $(sources) winrt_init.cpp ;
     return
     [ run $(sources) : : :
-      <library>/boost/system//boost_system
       <define>BOOST_THREAD_DONT_PROVIDE_INTERRUPTIONS
       <define>BOOST_THREAD_VERSION=3
     : $(name)_h ]


### PR DESCRIPTION
Since Boost.System is now header-only, no need to link with the library.