### PR TITLE
Add self contained header tests and fix discovered bugs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ matrix:
   include:
     - os: linux
       compiler: g++
-      env: TOOLSET=gcc COMPILER=g++ CXXSTD=c++11
+      env: TOOLSET=gcc COMPILER=g++ CXXSTD=c++11 SELF_CONTAINED_HEADER_TESTS=1
 
 #    - os: linux
 #      compiler: g++-4.7
@@ -331,7 +331,7 @@ matrix:
 
     - os: osx
       compiler: clang++
-      env: TOOLSET=clang COMPILER=clang++ CXXSTD=c++98
+      env: TOOLSET=clang COMPILER=clang++ CXXSTD=c++98 SELF_CONTAINED_HEADER_TESTS=1
 
 #    - os: osx
 #      compiler: clang++
@@ -346,23 +346,28 @@ matrix:
       env: TOOLSET=clang COMPILER=clang++ CXXSTD=c++1z
 
 install:
-  - BOOST_BRANCH=develop && [ "$TRAVIS_BRANCH" == "master" ] && BOOST_BRANCH=master || true
+  - GIT_FETCH_JOBS=8
+  - BOOST_BRANCH=develop
+  - if [ "$TRAVIS_BRANCH" = "master" ]; then BOOST_BRANCH=master; fi
   - cd ..
   - git clone -b $BOOST_BRANCH --depth 1 https://github.com/boostorg/boost.git boost-root
   - cd boost-root
-  - git submodule update --init tools/build
-  - git submodule update --init libs/config
-  - git submodule update --init tools/boostdep
+  - git submodule init tools/build
+  - git submodule init libs/config
+  - git submodule init tools/boostdep
+  - git submodule update --jobs $GIT_FETCH_JOBS
   - mkdir -p libs/thread
   - cp -r $TRAVIS_BUILD_DIR/* libs/thread
-  - python tools/boostdep/depinst/depinst.py thread
+  - python tools/boostdep/depinst/depinst.py --git_args "--jobs $GIT_FETCH_JOBS" thread
   - ./bootstrap.sh
   - ./b2 headers
 
 script:
   - |-
     echo "using $TOOLSET : : $COMPILER : <cxxflags>-std=$CXXSTD ;" > ~/user-config.jam
-  - ./b2 -j3 -l60 libs/thread/test toolset=$TOOLSET
+  - BUILD_JOBS=`(nproc || sysctl -n hw.ncpu) 2> /dev/null`
+  - if [ -z "$SELF_CONTAINED_HEADER_TESTS" ]; then export BOOST_THREAD_TEST_WITHOUT_SELF_CONTAINED_HEADER_TESTS=1; fi
+  - ./b2 -j $BUILD_JOBS -l60 libs/thread/test toolset=$TOOLSET
 
 notifications:
   email:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,6 +18,7 @@ environment:
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2013
 #      TOOLSET: msvc-9.0,msvc-10.0,msvc-11.0,msvc-12.0
       TOOLSET: msvc-12.0
+      SELF_CONTAINED_HEADER_TESTS: 1
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
       TOOLSET: msvc-14.0
       ADDRMD: 32
@@ -29,30 +30,36 @@ environment:
       ADDPATH: C:\cygwin\bin;
       TOOLSET: gcc
       CXXSTD: 14
+      SELF_CONTAINED_HEADER_TESTS: 1
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2013
       ADDPATH: C:\cygwin64\bin;
       TOOLSET: gcc
       CXXSTD: 14
+      SELF_CONTAINED_HEADER_TESTS: 1
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2013
       ADDPATH: C:\mingw\bin;
       TOOLSET: gcc
       CXXSTD: 14
+      SELF_CONTAINED_HEADER_TESTS: 1
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2013
       ADDPATH: C:\mingw-w64\x86_64-6.3.0-posix-seh-rt_v5-rev1\mingw64\bin;
       TOOLSET: gcc
       CXXSTD: 14
+      SELF_CONTAINED_HEADER_TESTS: 1
 
 install:
+  - set GIT_FETCH_JOBS=8
   - set BOOST_BRANCH=develop
   - if "%APPVEYOR_REPO_BRANCH%" == "master" set BOOST_BRANCH=master
   - cd ..
   - git clone -b %BOOST_BRANCH% --depth 1 https://github.com/boostorg/boost.git boost-root
   - cd boost-root
-  - git submodule update --init tools/build
-  - git submodule update --init libs/config
-  - git submodule update --init tools/boostdep
+  - git submodule init tools/build
+  - git submodule init libs/config
+  - git submodule init tools/boostdep
+  - git submodule update --jobs %GIT_FETCH_JOBS%
   - xcopy /s /e /q %APPVEYOR_BUILD_FOLDER% libs\thread
-  - python tools/boostdep/depinst/depinst.py thread
+  - python tools/boostdep/depinst/depinst.py --git_args "--jobs %GIT_FETCH_JOBS%" thread
   - cmd /c bootstrap
   - b2 -d0 headers
 
@@ -60,6 +67,7 @@ build: off
 
 test_script:
   - PATH=%ADDPATH%%PATH%
+  - if "%SELF_CONTAINED_HEADER_TESTS%" == "" set BOOST_THREAD_TEST_WITHOUT_SELF_CONTAINED_HEADER_TESTS=1
   - if not "%CXXSTD%" == "" set CXXSTD=cxxstd=%CXXSTD%
   - if not "%ADDRMD%" == "" set ADDRMD=address-model=%ADDRMD%
-  - b2 -j3 libs/thread/test toolset=%TOOLSET% %CXXSTD% %ADDRMD% variant=debug,release
+  - b2 -j %NUMBER_OF_PROCESSORS% libs/thread/test toolset=%TOOLSET% %CXXSTD% %ADDRMD% variant=debug,release

--- a/include/boost/thread/concurrent_queues/queue_op_status.hpp
+++ b/include/boost/thread/concurrent_queues/queue_op_status.hpp
@@ -11,6 +11,8 @@
 //
 //////////////////////////////////////////////////////////////////////////////
 
+#include <exception>
+#include <boost/core/scoped_enum.hpp>
 #include <boost/thread/detail/config.hpp>
 #include <boost/thread/detail/move.hpp>
 
@@ -25,7 +27,7 @@ namespace concurrent
   { success = 0, empty, full, closed, busy, timeout, not_ready }
   BOOST_SCOPED_ENUM_DECLARE_END(queue_op_status)
 
-  struct sync_queue_is_closed : std::exception
+  struct BOOST_SYMBOL_VISIBLE sync_queue_is_closed : std::exception
   {
   };
 

--- a/include/boost/thread/executors/inline_executor.hpp
+++ b/include/boost/thread/executors/inline_executor.hpp
@@ -9,10 +9,15 @@
 #ifndef BOOST_THREAD_INLINE_EXECUTOR_HPP
 #define BOOST_THREAD_INLINE_EXECUTOR_HPP
 
+#include <exception> // std::terminate
+#include <boost/throw_exception.hpp>
 #include <boost/thread/detail/config.hpp>
 #include <boost/thread/detail/delete.hpp>
 #include <boost/thread/detail/move.hpp>
 #include <boost/thread/executors/work.hpp>
+#include <boost/thread/mutex.hpp>
+#include <boost/thread/lock_guard.hpp>
+#include <boost/thread/concurrent_queues/queue_op_status.hpp> // sync_queue_is_closed
 
 #include <boost/config/abi_prefix.hpp>
 

--- a/include/boost/thread/executors/serial_executor.hpp
+++ b/include/boost/thread/executors/serial_executor.hpp
@@ -9,6 +9,7 @@
 #ifndef BOOST_THREAD_SERIAL_EXECUTOR_HPP
 #define BOOST_THREAD_SERIAL_EXECUTOR_HPP
 
+#include <exception>
 #include <boost/thread/detail/config.hpp>
 #include <boost/thread/detail/delete.hpp>
 #include <boost/thread/detail/move.hpp>

--- a/include/boost/thread/executors/serial_executor_cont.hpp
+++ b/include/boost/thread/executors/serial_executor_cont.hpp
@@ -10,13 +10,20 @@
 #define BOOST_THREAD_SERIAL_EXECUTOR_CONT_HPP
 
 #include <boost/thread/detail/config.hpp>
+
+#if defined(BOOST_THREAD_PROVIDES_FUTURE_CONTINUATION) && defined(BOOST_THREAD_PROVIDES_EXECUTORS)
+
+#include <exception> // std::terminate
+#include <boost/throw_exception.hpp>
 #include <boost/thread/detail/delete.hpp>
 #include <boost/thread/detail/move.hpp>
 #include <boost/thread/concurrent_queues/sync_queue.hpp>
 #include <boost/thread/executors/work.hpp>
 #include <boost/thread/executors/generic_executor_ref.hpp>
+#include <boost/thread/mutex.hpp>
 #include <boost/thread/future.hpp>
 #include <boost/thread/scoped_thread.hpp>
+#include <boost/thread/lock_guard.hpp>
 
 #include <boost/config/abi_prefix.hpp>
 
@@ -32,7 +39,7 @@ namespace executors
   private:
 
     generic_executor_ref ex_;
-    future<void> fut_; // protected by mtx_
+    BOOST_THREAD_FUTURE<void> fut_; // protected by mtx_
     bool closed_; // protected by mtx_
     mutex mtx_;
 
@@ -44,7 +51,7 @@ namespace executors
       };
       continuation(BOOST_THREAD_RV_REF(work) tsk)
       : task(boost::move(tsk)) {}
-      void operator()(future<void> f)
+      void operator()(BOOST_THREAD_FUTURE<void> f)
       {
         try {
           task();
@@ -166,5 +173,7 @@ using executors::serial_executor_cont;
 }
 
 #include <boost/config/abi_suffix.hpp>
+
+#endif // defined(BOOST_THREAD_PROVIDES_FUTURE_CONTINUATION) && defined(BOOST_THREAD_PROVIDES_EXECUTORS)
 
 #endif

--- a/include/boost/thread/executors/thread_executor.hpp
+++ b/include/boost/thread/executors/thread_executor.hpp
@@ -9,11 +9,14 @@
 #ifndef BOOST_THREAD_THREAD_EXECUTOR_HPP
 #define BOOST_THREAD_THREAD_EXECUTOR_HPP
 
+#include <boost/throw_exception.hpp>
 #include <boost/thread/detail/config.hpp>
 #include <boost/thread/detail/delete.hpp>
 #include <boost/thread/detail/move.hpp>
 #include <boost/thread/executors/work.hpp>
 #include <boost/thread/executors/executor.hpp>
+#include <boost/thread/mutex.hpp>
+#include <boost/thread/lock_guard.hpp>
 #include <boost/thread/thread_only.hpp>
 #include <boost/thread/scoped_thread.hpp>
 #include <boost/thread/csbl/vector.hpp>

--- a/include/boost/thread/experimental/parallel/v2/task_region.hpp
+++ b/include/boost/thread/experimental/parallel/v2/task_region.hpp
@@ -10,6 +10,9 @@
 // See http://www.boost.org/libs/thread for documentation.
 //
 //////////////////////////////////////////////////////////////////////////////
+
+#include <exception>
+#include <boost/throw_exception.hpp>
 #include <boost/thread/detail/config.hpp>
 
 #include <boost/thread/future.hpp>
@@ -18,6 +21,7 @@
 #endif
 #include <boost/thread/experimental/exception_list.hpp>
 #include <boost/thread/experimental/parallel/v2/inline_namespace.hpp>
+#include <boost/thread/csbl/vector.hpp>
 #include <boost/thread/detail/move.hpp>
 
 #include <boost/config/abi_prefix.hpp>
@@ -126,7 +130,7 @@ BOOST_THREAD_INLINE_NAMESPACE(v2)
 
       for (group_type::iterator it = group.begin(); it != group.end(); ++it)
       {
-        future<void>& f = *it;
+        BOOST_THREAD_FUTURE<void>& f = *it;
         if (f.has_exception())
         {
           try
@@ -191,7 +195,7 @@ protected:
     Executor* ex;
 #endif
     exception_list exs;
-    typedef csbl::vector<future<void> > group_type;
+    typedef csbl::vector<BOOST_THREAD_FUTURE<void> > group_type;
     group_type group;
 
   public:

--- a/include/boost/thread/externally_locked.hpp
+++ b/include/boost/thread/externally_locked.hpp
@@ -24,6 +24,7 @@
 
 namespace boost
 {
+  class mutex;
 
   /**
    * externally_locked cloaks an object of type T, and actually provides full

--- a/include/boost/thread/futures/wait_for_any.hpp
+++ b/include/boost/thread/futures/wait_for_any.hpp
@@ -14,6 +14,7 @@
 #include <boost/thread/futures/is_future_type.hpp>
 #include <boost/thread/lock_algorithms.hpp>
 #include <boost/thread/mutex.hpp>
+#include <boost/thread/condition_variable.hpp>
 
 #include <boost/core/enable_if.hpp>
 #include <boost/next_prior.hpp>

--- a/include/boost/thread/poly_lockable.hpp
+++ b/include/boost/thread/poly_lockable.hpp
@@ -30,6 +30,9 @@ namespace boost
   };
   //]
 
+  // A proper name for basic_poly_lockable, consistent with naming scheme of other polymorphic wrappers
+  typedef basic_poly_lockable poly_basic_lockable;
+
   //[poly_lockable
   class poly_lockable : public basic_poly_lockable
   {
@@ -51,18 +54,20 @@ namespace boost
     template <typename Clock, typename Duration>
     bool try_lock_until(chrono::time_point<Clock, Duration> const & abs_time)
     {
-      return try_lock_until(time_point_cast<Clock::time_point>(abs_time));
+      return try_lock_until(chrono::time_point_cast<Clock::time_point>(abs_time));
     }
 
     virtual bool try_lock_for(chrono::nanoseconds const & relative_time)=0;
     template <typename Rep, typename Period>
     bool try_lock_for(chrono::duration<Rep, Period> const & rel_time)
     {
-      return try_lock_for(duration_cast<Clock::duration>(rel_time));
+      return try_lock_for(chrono::duration_cast<chrono::nanoseconds>(rel_time));
     }
 
   };
   //]
 
+  // A proper name for timed_poly_lockable, consistent with naming scheme of other polymorphic wrappers
+  typedef timed_poly_lockable poly_timed_lockable;
 }
 #endif

--- a/include/boost/thread/poly_shared_lockable.hpp
+++ b/include/boost/thread/poly_shared_lockable.hpp
@@ -33,19 +33,21 @@ namespace boost
     template <typename Clock, typename Duration>
     bool try_lock_shared_until(chrono::time_point<Clock, Duration> const & abs_time)
     {
-      return try_lock_shared_until(time_point_cast<Clock::time_point>(abs_time));
+      return try_lock_shared_until(chrono::time_point_cast<Clock::time_point>(abs_time));
     }
 
     virtual bool try_lock_shared_for(chrono::nanoseconds const & relative_time)=0;
     template <typename Rep, typename Period>
     bool try_lock_shared_for(chrono::duration<Rep, Period> const & rel_time)
     {
-      return try_lock_shared_for(duration_cast<Clock::duration>(rel_time));
+      return try_lock_shared_for(chrono::duration_cast<chrono::nanoseconds>(rel_time));
     }
 
   };
-
   //]
+
+  // A proper name for shared_poly_lockable, consistent with naming scheme of other polymorphic wrappers
+  typedef shared_poly_lockable poly_shared_lockable;
 
   //[upgrade_poly_lockable
   class upgrade_poly_lockable: public shared_poly_lockable
@@ -62,14 +64,14 @@ namespace boost
     template <typename Clock, typename Duration>
     bool try_lock_upgrade_until(chrono::time_point<Clock, Duration> const & abs_time)
     {
-      return try_lock_upgrade_until(time_point_cast<Clock::time_point>(abs_time));
+      return try_lock_upgrade_until(chrono::time_point_cast<Clock::time_point>(abs_time));
     }
 
     virtual bool try_lock_upgrade_for(chrono::nanoseconds const & relative_time)=0;
     template <typename Rep, typename Period>
     bool try_lock_upgrade_for(chrono::duration<Rep, Period> const & rel_time)
     {
-      return try_lock_upgrade_for(duration_cast<Clock::duration>(rel_time));
+      return try_lock_upgrade_for(chrono::duration_cast<chrono::nanoseconds>(rel_time));
     }
 
     virtual bool try_unlock_shared_and_lock() = 0;
@@ -79,14 +81,14 @@ namespace boost
     template <typename Clock, typename Duration>
     bool try_unlock_shared_and_lock_until(chrono::time_point<Clock, Duration> const & abs_time)
     {
-      return try_unlock_shared_and_lock_until(time_point_cast<Clock::time_point>(abs_time));
+      return try_unlock_shared_and_lock_until(chrono::time_point_cast<Clock::time_point>(abs_time));
     }
 
     virtual bool try_unlock_shared_and_lock_for(chrono::nanoseconds const & relative_time)=0;
     template <typename Rep, typename Period>
     bool try_unlock_shared_and_lock_for(chrono::duration<Rep, Period> const & rel_time)
     {
-      return try_unlock_shared_and_lock_for(duration_cast<Clock::duration>(rel_time));
+      return try_unlock_shared_and_lock_for(chrono::duration_cast<chrono::nanoseconds>(rel_time));
     }
 
     virtual void unlock_and_lock_shared() = 0;
@@ -97,14 +99,14 @@ namespace boost
     template <typename Clock, typename Duration>
     bool try_unlock_shared_and_lock_upgrade_until(chrono::time_point<Clock, Duration> const & abs_time)
     {
-      return try_unlock_shared_and_lock_upgrade_until(time_point_cast<Clock::time_point>(abs_time));
+      return try_unlock_shared_and_lock_upgrade_until(chrono::time_point_cast<Clock::time_point>(abs_time));
     }
 
     virtual bool try_unlock_shared_and_lock_upgrade_for(chrono::nanoseconds const & relative_time)=0;
     template <typename Rep, typename Period>
     bool try_unlock_shared_and_lock_upgrade_for(chrono::duration<Rep, Period> const & rel_time)
     {
-      return try_unlock_shared_and_lock_upgrade_for(duration_cast<Clock::duration>(rel_time));
+      return try_unlock_shared_and_lock_upgrade_for(chrono::duration_cast<chrono::nanoseconds>(rel_time));
     }
 
     virtual void unlock_and_lock_upgrade() = 0;
@@ -116,20 +118,22 @@ namespace boost
     template <typename Clock, typename Duration>
     bool try_unlock_upgrade_and_lock_until(chrono::time_point<Clock, Duration> const & abs_time)
     {
-      return try_unlock_upgrade_and_lock_until(time_point_cast<Clock::time_point>(abs_time));
+      return try_unlock_upgrade_and_lock_until(chrono::time_point_cast<Clock::time_point>(abs_time));
     }
 
     virtual bool try_unlock_upgrade_and_lock_for(chrono::nanoseconds const & relative_time)=0;
     template <typename Rep, typename Period>
     bool try_unlock_upgrade_and_lock_for(chrono::duration<Rep, Period> const & rel_time)
     {
-      return try_unlock_upgrade_and_lock_for(duration_cast<Clock::duration>(rel_time));
+      return try_unlock_upgrade_and_lock_for(chrono::duration_cast<chrono::nanoseconds>(rel_time));
     }
 
     virtual void unlock_upgrade_and_lock_shared() = 0;
 
   };
-//]
+  //]
 
+  // A proper name for upgrade_poly_lockable, consistent with naming scheme of other polymorphic wrappers
+  typedef upgrade_poly_lockable poly_upgrade_lockable;
 }
 #endif

--- a/include/boost/thread/poly_shared_lockable_adapter.hpp
+++ b/include/boost/thread/poly_shared_lockable_adapter.hpp
@@ -17,7 +17,7 @@
 namespace boost
 {
 
-  //[shared_lockable_adapter
+  //[poly_shared_lockable_adapter
   template <typename Mutex, typename Base=poly_shared_lockable>
   class poly_shared_lockable_adapter: public poly_timed_lockable_adapter<Mutex, Base>
   {
@@ -54,9 +54,9 @@ namespace boost
 
   //]
 
-  //[upgrade_lockable_adapter
+  //[poly_upgrade_lockable_adapter
   template <typename Mutex, typename Base=poly_shared_lockable>
-  class upgrade_lockable_adapter: public shared_lockable_adapter<Mutex, Base>
+  class poly_upgrade_lockable_adapter: public poly_shared_lockable_adapter<Mutex, Base>
   {
   public:
     typedef Mutex mutex_type;
@@ -102,7 +102,6 @@ namespace boost
     {
       return this->mtx().try_unlock_shared_and_lock_until(abs_time);
     }
-    template <typename Rep, typename Period>
     bool try_unlock_shared_and_lock_for(chrono::nanoseconds const & rel_time)
     {
       return this->mtx().try_unlock_shared_and_lock_for(rel_time);

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -18,6 +18,9 @@
 
 # bring in rules for testing
 import testing ;
+import regex ;
+import path ;
+import os ;
 
 project
     : requirements
@@ -244,6 +247,42 @@ rule thread-compile ( sources : reqs * : name )
         : $(reqs)
         : $(name) ]
     ;
+}
+
+rule windows-cygwin-specific ( properties * )
+{
+    if <target-os>windows in $(properties) || <target-os>cygwin in $(properties)
+    {
+        return <build>yes ;
+    }
+    else
+    {
+        return <build>no ;
+    }
+}
+
+rule generate_self_contained_header_tests
+{
+    local all_rules ;
+    local file ;
+
+    if ! [ os.environ BOOST_THREAD_TEST_WITHOUT_SELF_CONTAINED_HEADER_TESTS ]
+    {
+        local headers_path = [ path.make $(BOOST_ROOT)/libs/thread/include/boost/thread ] ;
+        for file in [ path.glob-tree $(headers_path) : *.hpp : detail pthread win32 ]
+        {
+            local rel_file = [ path.relative-to $(headers_path) $(file) ] ;
+            # Note: The test name starts with '~' in order to group these tests in the test report table, preferably at the end.
+            #       All '/' are replaced with '-' because apparently test scripts have a problem with test names containing slashes.
+            local test_name = [ regex.replace ~hdr/$(rel_file) "/" "-" ] ;
+            #ECHO $(rel_file) ;
+            all_rules += [ compile self_contained_header.cpp : <define>"BOOST_THREAD_TEST_HEADER=$(rel_file)" <dependency>$(file) : $(test_name) ] ;
+            all_rules += [ compile self_contained_header.cpp : <define>"BOOST_THREAD_TEST_HEADER=$(rel_file)" <define>"BOOST_THREAD_TEST_POST_WINDOWS_H" <dependency>$(file) <conditional>@windows-cygwin-specific : $(test_name)-post_winh ] ;
+        }
+    }
+
+    #ECHO All rules: $(all_rules) ;
+    return $(all_rules) ;
 }
 
 {
@@ -1055,4 +1094,5 @@ rule thread-compile ( sources : reqs * : name )
           [ exe test_time_jumps_3 : test_time_jumps_3_obj ../build//boost_thread ]
     ;
 
+    test-suite test_self_contained_headers : [ generate_self_contained_header_tests ] ;
 }

--- a/test/self_contained_header.cpp
+++ b/test/self_contained_header.cpp
@@ -1,0 +1,26 @@
+/*
+ *             Copyright Andrey Semashev 2019.
+ * Distributed under the Boost Software License, Version 1.0.
+ *    (See accompanying file LICENSE_1_0.txt or copy at
+ *          http://www.boost.org/LICENSE_1_0.txt)
+ */
+/*!
+ * \file   self_contained_header.cpp
+ * \author Andrey Semashev
+ * \date   2019-01-19
+ *
+ * \brief  This file contains a test boilerplate for checking that every public header is self-contained and does not have any missing #includes.
+ */
+
+#if defined(BOOST_THREAD_TEST_POST_WINDOWS_H)
+#include <windows.h>
+#endif
+
+#define BOOST_THREAD_TEST_INCLUDE_HEADER() <boost/thread/BOOST_THREAD_TEST_HEADER>
+
+#include BOOST_THREAD_TEST_INCLUDE_HEADER()
+
+int main(int, char*[])
+{
+    return 0;
+}


### PR DESCRIPTION
Added tests for self-contained headers.

The new set of tests iterates over Boost.Thread public headers and verifies that
each header is self-contained, i.e. doesn't have any missing includes and
contains syntactically correct content. On Windows and Cygwin, a second test
per each header is generated, which includes the header after windows.h. This
verifies that the header doesn't have conflicts with Windows SDK and that
including windows.h does not break platform detection in Boost.Thread.

This set of tests would have detected the bug fixed by https://github.com/boostorg/thread/pull/263.

Fixed bugs discovered by the standalone header tests.

- Added missing includes.
- Added missing namespace qualification for Boost.Chrono casts.
- Added typedefs renaming polymorphic lockable wrappers to a more consistent
  naming scheme. This fixes incorrect name references.
- Fixed incorrect duration casts in polymorphic lockable wrappers.
- Renamed upgrade_lockable_adapter to poly_upgrade_lockable_adapter, since
  upgrade_lockable_adapter already exists and has a different meaning.
- Use BOOST_THREAD_FUTURE instead of future in executors and task region.
- Disable serial_executor_cont when executors or future continuations
  are not enabled.
- Marked sync_queue_is_closed exception as visible.
