### PR TITLE
Fix Issue 271

### DIFF
--- a/include/boost/thread/concurrent_queues/detail/sync_deque_base.hpp
+++ b/include/boost/thread/concurrent_queues/detail/sync_deque_base.hpp
@@ -63,7 +63,7 @@ namespace detail
 
   protected:
     mutable mutex mtx_;
-    condition_variable not_empty_;
+    condition_variable cond_;
     underlying_queue_type data_;
     bool closed_;
 
@@ -91,16 +91,14 @@ namespace detail
     inline bool wait_until_not_empty_or_closed(unique_lock<mutex>& lk);
     template <class WClock, class Duration>
     queue_op_status wait_until_not_empty_or_closed_until(unique_lock<mutex>& lk, chrono::time_point<WClock,Duration> const&tp);
-    template <class WClock, class Duration>
-    queue_op_status wait_until_closed_until(unique_lock<mutex>& lk, chrono::time_point<WClock,Duration> const&tp);
 
-    inline void notify_not_empty_if_needed(unique_lock<mutex>& )
+    inline void notify_elem_added(unique_lock<mutex>& )
     {
-      not_empty_.notify_one();
+      cond_.notify_all();
     }
-    inline void notify_not_empty_if_needed(lock_guard<mutex>& )
+    inline void notify_elem_added(lock_guard<mutex>& )
     {
-      not_empty_.notify_one();
+      cond_.notify_all();
     }
 
   };
@@ -124,7 +122,7 @@ namespace detail
       lock_guard<mutex> lk(mtx_);
       closed_ = true;
     }
-    not_empty_.notify_all();
+    cond_.notify_all();
   }
 
   template <class ValueType, class Queue>
@@ -189,7 +187,7 @@ namespace detail
   template <class ValueType, class Queue>
   bool sync_deque_base<ValueType, Queue>::wait_until_not_empty_or_closed(unique_lock<mutex>& lk)
   {
-    not_empty_.wait(lk, boost::bind(&sync_deque_base<ValueType, Queue>::not_empty_or_closed, boost::ref(*this), boost::ref(lk)));
+    cond_.wait(lk, boost::bind(&sync_deque_base<ValueType, Queue>::not_empty_or_closed, boost::ref(*this), boost::ref(lk)));
     if (! empty(lk)) return false; // success
     return true; // closed
   }
@@ -198,19 +196,9 @@ namespace detail
   template <class WClock, class Duration>
   queue_op_status sync_deque_base<ValueType, Queue>::wait_until_not_empty_or_closed_until(unique_lock<mutex>& lk, chrono::time_point<WClock,Duration> const&tp)
   {
-    if (! not_empty_.wait_until(lk, tp, boost::bind(&sync_deque_base<ValueType, Queue>::not_empty_or_closed, boost::ref(*this), boost::ref(lk))))
+    if (! cond_.wait_until(lk, tp, boost::bind(&sync_deque_base<ValueType, Queue>::not_empty_or_closed, boost::ref(*this), boost::ref(lk))))
       return queue_op_status::timeout;
     if (! empty(lk)) return queue_op_status::success;
-    return queue_op_status::closed;
-  }
-
-  template <class ValueType, class Queue>
-  template <class WClock, class Duration>
-  queue_op_status sync_deque_base<ValueType, Queue>::wait_until_closed_until(unique_lock<mutex>& lk, chrono::time_point<WClock,Duration> const&tp)
-  {
-    bool (sync_queue_base<ValueType, Queue>::*closed_function_ptr)(unique_lock<mutex>&) const = &sync_queue_base<ValueType, Queue>::closed;
-    if (! not_empty_.wait_until(lk, tp, boost::bind(closed_function_ptr, boost::ref(*this), boost::ref(lk))))
-      return queue_op_status::timeout;
     return queue_op_status::closed;
   }
 

--- a/include/boost/thread/concurrent_queues/detail/sync_queue_base.hpp
+++ b/include/boost/thread/concurrent_queues/detail/sync_queue_base.hpp
@@ -63,7 +63,7 @@ namespace detail
 
   protected:
     mutable mutex mtx_;
-    condition_variable not_empty_;
+    condition_variable cond_;
     underlying_queue_type data_;
     bool closed_;
 
@@ -91,16 +91,14 @@ namespace detail
     inline bool wait_until_not_empty_or_closed(unique_lock<mutex>& lk);
     template <class WClock, class Duration>
     queue_op_status wait_until_not_empty_or_closed_until(unique_lock<mutex>& lk, chrono::time_point<WClock,Duration> const&tp);
-    template <class WClock, class Duration>
-    queue_op_status wait_until_closed_until(unique_lock<mutex>& lk, chrono::time_point<WClock,Duration> const&tp);
 
-    inline void notify_not_empty_if_needed(unique_lock<mutex>& )
+    inline void notify_elem_added(unique_lock<mutex>& )
     {
-      not_empty_.notify_one();
+      cond_.notify_all();
     }
-    inline void notify_not_empty_if_needed(lock_guard<mutex>& )
+    inline void notify_elem_added(lock_guard<mutex>& )
     {
-      not_empty_.notify_one();
+      cond_.notify_all();
     }
 
   };
@@ -124,7 +122,7 @@ namespace detail
       lock_guard<mutex> lk(mtx_);
       closed_ = true;
     }
-    not_empty_.notify_all();
+    cond_.notify_all();
   }
 
   template <class ValueType, class Queue>
@@ -189,7 +187,7 @@ namespace detail
   template <class ValueType, class Queue>
   bool sync_queue_base<ValueType, Queue>::wait_until_not_empty_or_closed(unique_lock<mutex>& lk)
   {
-    not_empty_.wait(lk, boost::bind(&sync_queue_base<ValueType, Queue>::not_empty_or_closed, boost::ref(*this), boost::ref(lk)));
+    cond_.wait(lk, boost::bind(&sync_queue_base<ValueType, Queue>::not_empty_or_closed, boost::ref(*this), boost::ref(lk)));
     if (! empty(lk)) return false; // success
     return true; // closed
   }
@@ -198,19 +196,9 @@ namespace detail
   template <class WClock, class Duration>
   queue_op_status sync_queue_base<ValueType, Queue>::wait_until_not_empty_or_closed_until(unique_lock<mutex>& lk, chrono::time_point<WClock,Duration> const&tp)
   {
-    if (! not_empty_.wait_until(lk, tp, boost::bind(&sync_queue_base<ValueType, Queue>::not_empty_or_closed, boost::ref(*this), boost::ref(lk))))
+    if (! cond_.wait_until(lk, tp, boost::bind(&sync_queue_base<ValueType, Queue>::not_empty_or_closed, boost::ref(*this), boost::ref(lk))))
       return queue_op_status::timeout;
     if (! empty(lk)) return queue_op_status::success;
-    return queue_op_status::closed;
-  }
-
-  template <class ValueType, class Queue>
-  template <class WClock, class Duration>
-  queue_op_status sync_queue_base<ValueType, Queue>::wait_until_closed_until(unique_lock<mutex>& lk, chrono::time_point<WClock,Duration> const&tp)
-  {
-    bool (sync_queue_base<ValueType, Queue>::*closed_function_ptr)(unique_lock<mutex>&) const = &sync_queue_base<ValueType, Queue>::closed;
-    if (! not_empty_.wait_until(lk, tp, boost::bind(closed_function_ptr, boost::ref(*this), boost::ref(lk))))
-      return queue_op_status::timeout;
     return queue_op_status::closed;
   }
 

--- a/include/boost/thread/concurrent_queues/sync_deque.hpp
+++ b/include/boost/thread/concurrent_queues/sync_deque.hpp
@@ -92,13 +92,13 @@ namespace concurrent
     inline void push_back(const value_type& elem, unique_lock<mutex>& lk)
     {
       super::data_.push_back(elem);
-      super::notify_not_empty_if_needed(lk);
+      super::notify_elem_added(lk);
     }
 
     inline void push_back(BOOST_THREAD_RV_REF(value_type) elem, unique_lock<mutex>& lk)
     {
       super::data_.push_back(boost::move(elem));
-      super::notify_not_empty_if_needed(lk);
+      super::notify_elem_added(lk);
     }
   };
 
@@ -122,7 +122,7 @@ namespace concurrent
 //      {
 //        data_.push(boost::move(*cur));;
 //      }
-//      notify_not_empty_if_needed(lk);
+//      notify_elem_added(lk);
 //    }
 //    catch (...)
 //    {

--- a/include/boost/thread/concurrent_queues/sync_priority_queue.hpp
+++ b/include/boost/thread/concurrent_queues/sync_priority_queue.hpp
@@ -174,14 +174,14 @@ namespace concurrent
   {
     super::throw_if_closed(lk);
     super::data_.push(elem);
-    super::notify_not_empty_if_needed(lk);
+    super::notify_elem_added(lk);
   }
   template <class T, class Container,class Cmp>
   void sync_priority_queue<T,Container,Cmp>::push(lock_guard<mutex>& lk, const T& elem)
   {
     super::throw_if_closed(lk);
     super::data_.push(elem);
-    super::notify_not_empty_if_needed(lk);
+    super::notify_elem_added(lk);
   }
   template <class T, class Container,class Cmp>
   void sync_priority_queue<T,Container,Cmp>::push(const T& elem)
@@ -196,14 +196,14 @@ namespace concurrent
   {
     super::throw_if_closed(lk);
     super::data_.push(boost::move(elem));
-    super::notify_not_empty_if_needed(lk);
+    super::notify_elem_added(lk);
   }
   template <class T, class Container,class Cmp>
   void sync_priority_queue<T,Container,Cmp>::push(lock_guard<mutex>& lk, BOOST_THREAD_RV_REF(T) elem)
   {
     super::throw_if_closed(lk);
     super::data_.push(boost::move(elem));
-    super::notify_not_empty_if_needed(lk);
+    super::notify_elem_added(lk);
   }
   template <class T, class Container,class Cmp>
   void sync_priority_queue<T,Container,Cmp>::push(BOOST_THREAD_RV_REF(T) elem)

--- a/include/boost/thread/concurrent_queues/sync_queue.hpp
+++ b/include/boost/thread/concurrent_queues/sync_queue.hpp
@@ -92,13 +92,13 @@ namespace concurrent
     inline void push(const value_type& elem, unique_lock<mutex>& lk)
     {
       super::data_.push_back(elem);
-      super::notify_not_empty_if_needed(lk);
+      super::notify_elem_added(lk);
     }
 
     inline void push(BOOST_THREAD_RV_REF(value_type) elem, unique_lock<mutex>& lk)
     {
       super::data_.push_back(boost::move(elem));
-      super::notify_not_empty_if_needed(lk);
+      super::notify_elem_added(lk);
     }
   };
 
@@ -122,7 +122,7 @@ namespace concurrent
 //      {
 //        data_.push(boost::move(*cur));;
 //      }
-//      notify_not_empty_if_needed(lk);
+//      notify_elem_added(lk);
 //    }
 //    catch (...)
 //    {

--- a/include/boost/thread/concurrent_queues/sync_timed_queue.hpp
+++ b/include/boost/thread/concurrent_queues/sync_timed_queue.hpp
@@ -229,7 +229,7 @@ namespace detail
       if (super::closed(lk)) return true; // closed
 
       const time_point tp(super::data_.top().time);
-      super::wait_until_closed_until(lk, tp);
+      super::cond_.wait_until(lk, tp);
     }
   }
 
@@ -250,7 +250,7 @@ namespace detail
       if (clock::now() >= tp) return super::empty(lk) ? queue_op_status::timeout : queue_op_status::not_ready;
 
       const time_point tpmin(tp < super::data_.top().time ? tp : super::data_.top().time);
-      super::wait_until_closed_until(lk, tpmin);
+      super::cond_.wait_until(lk, tpmin);
     }
   }
 


### PR DESCRIPTION
* If thread A was waiting to pull the earliest element off of a
sync_timed_queue, and while it was waiting thread B added a new element with an
earlier time to the queue, thread A wouldn't reduce how long it waited before
pulling the earliest element off of the queue.

* Also refactored a function name and a variable name since their names no
longer accurately described what they do:
  * notify_not_empty_if_needed() -> notify_elem_added()
  * not_empty_ -> cond_

* Also deleted a no-longer-used function:
  * wait_until_closed_until()