### PR TITLE
Fix Issue 275

### DIFF
--- a/include/boost/thread/pthread/condition_variable.hpp
+++ b/include/boost/thread/pthread/condition_variable.hpp
@@ -76,18 +76,18 @@ namespace boost
             detail::interruption_checker check_for_interruption(&internal_mutex,&cond);
             pthread_mutex_t* the_mutex = &internal_mutex;
             guard.activate(m);
-            res = pthread_cond_wait(&cond,the_mutex);
+            res = posix::pthread_cond_wait(&cond,the_mutex);
             check_for_interruption.unlock_if_locked();
             guard.deactivate();
 #else
             pthread_mutex_t* the_mutex = m.mutex()->native_handle();
-            res = pthread_cond_wait(&cond,the_mutex);
+            res = posix::pthread_cond_wait(&cond,the_mutex);
 #endif
         }
 #if defined BOOST_THREAD_PROVIDES_INTERRUPTIONS
         this_thread::interruption_point();
 #endif
-        if(res && res != EINTR)
+        if(res)
         {
             boost::throw_exception(condition_error(res, "boost::condition_variable::wait failed in pthread_cond_wait"));
         }
@@ -119,12 +119,12 @@ namespace boost
             detail::interruption_checker check_for_interruption(&internal_mutex,&cond);
             pthread_mutex_t* the_mutex = &internal_mutex;
             guard.activate(m);
-            cond_res=pthread_cond_timedwait(&cond,the_mutex,&timeout.getTs());
+            cond_res=posix::pthread_cond_timedwait(&cond,the_mutex,&timeout.getTs());
             check_for_interruption.unlock_if_locked();
             guard.deactivate();
 #else
             pthread_mutex_t* the_mutex = m.mutex()->native_handle();
-            cond_res=pthread_cond_timedwait(&cond,the_mutex,&timeout.getTs());
+            cond_res=posix::pthread_cond_timedwait(&cond,the_mutex,&timeout.getTs());
 #endif
         }
 #if defined BOOST_THREAD_PROVIDES_INTERRUPTIONS
@@ -146,7 +146,7 @@ namespace boost
 #if defined BOOST_THREAD_PROVIDES_INTERRUPTIONS
         boost::pthread::pthread_mutex_scoped_lock internal_lock(&internal_mutex);
 #endif
-        BOOST_VERIFY(!pthread_cond_signal(&cond));
+        BOOST_VERIFY(!posix::pthread_cond_signal(&cond));
     }
 
     inline void condition_variable::notify_all() BOOST_NOEXCEPT
@@ -154,7 +154,7 @@ namespace boost
 #if defined BOOST_THREAD_PROVIDES_INTERRUPTIONS
         boost::pthread::pthread_mutex_scoped_lock internal_lock(&internal_mutex);
 #endif
-        BOOST_VERIFY(!pthread_cond_broadcast(&cond));
+        BOOST_VERIFY(!posix::pthread_cond_broadcast(&cond));
     }
 
     class condition_variable_any
@@ -166,22 +166,22 @@ namespace boost
         BOOST_THREAD_NO_COPYABLE(condition_variable_any)
         condition_variable_any()
         {
-            int const res=pthread_mutex_init(&internal_mutex,NULL);
+            int const res=posix::pthread_mutex_init(&internal_mutex);
             if(res)
             {
                 boost::throw_exception(thread_resource_error(res, "boost::condition_variable_any::condition_variable_any() failed in pthread_mutex_init"));
             }
-            int const res2 = pthread::cond_init(cond);
+            int const res2 = posix::pthread_cond_init(&cond);
             if(res2)
             {
-                BOOST_VERIFY(!pthread_mutex_destroy(&internal_mutex));
-                boost::throw_exception(thread_resource_error(res2, "boost::condition_variable_any::condition_variable_any() failed in pthread::cond_init"));
+                BOOST_VERIFY(!posix::pthread_mutex_destroy(&internal_mutex));
+                boost::throw_exception(thread_resource_error(res2, "boost::condition_variable_any::condition_variable_any() failed in pthread_cond_init"));
             }
         }
         ~condition_variable_any()
         {
-            BOOST_VERIFY(!pthread_mutex_destroy(&internal_mutex));
-            BOOST_VERIFY(!pthread_cond_destroy(&cond));
+            BOOST_VERIFY(!posix::pthread_mutex_destroy(&internal_mutex));
+            BOOST_VERIFY(!posix::pthread_cond_destroy(&cond));
         }
 
         template<typename lock_type>
@@ -196,7 +196,7 @@ namespace boost
                 boost::pthread::pthread_mutex_scoped_lock check_for_interruption(&internal_mutex);
 #endif
                 guard.activate(m);
-                res=pthread_cond_wait(&cond,&internal_mutex);
+                res=posix::pthread_cond_wait(&cond,&internal_mutex);
                 check_for_interruption.unlock_if_locked();
                 guard.deactivate();
             }
@@ -438,13 +438,13 @@ namespace boost
         void notify_one() BOOST_NOEXCEPT
         {
             boost::pthread::pthread_mutex_scoped_lock internal_lock(&internal_mutex);
-            BOOST_VERIFY(!pthread_cond_signal(&cond));
+            BOOST_VERIFY(!posix::pthread_cond_signal(&cond));
         }
 
         void notify_all() BOOST_NOEXCEPT
         {
             boost::pthread::pthread_mutex_scoped_lock internal_lock(&internal_mutex);
-            BOOST_VERIFY(!pthread_cond_broadcast(&cond));
+            BOOST_VERIFY(!posix::pthread_cond_broadcast(&cond));
         }
     private:
 
@@ -471,7 +471,7 @@ namespace boost
               boost::pthread::pthread_mutex_scoped_lock check_for_interruption(&internal_mutex);
 #endif
               guard.activate(m);
-              res=pthread_cond_timedwait(&cond,&internal_mutex,&timeout.getTs());
+              res=posix::pthread_cond_timedwait(&cond,&internal_mutex,&timeout.getTs());
               check_for_interruption.unlock_if_locked();
               guard.deactivate();
           }

--- a/include/boost/thread/pthread/condition_variable_fwd.hpp
+++ b/include/boost/thread/pthread/condition_variable_fwd.hpp
@@ -58,20 +58,20 @@ namespace boost
             // above) and must be initialized (etc) in case some
             // compilation units provide interruptions and others
             // don't.
-            res=pthread_mutex_init(&internal_mutex,NULL);
+            res=posix::pthread_mutex_init(&internal_mutex);
             if(res)
             {
                 boost::throw_exception(thread_resource_error(res, "boost::condition_variable::condition_variable() constructor failed in pthread_mutex_init"));
             }
 //#endif
-            res = pthread::cond_init(cond);
+            res = posix::pthread_cond_init(&cond);
             if (res)
             {
 //#if defined BOOST_THREAD_PROVIDES_INTERRUPTIONS
                 // ditto
-                BOOST_VERIFY(!pthread_mutex_destroy(&internal_mutex));
+                BOOST_VERIFY(!posix::pthread_mutex_destroy(&internal_mutex));
 //#endif
-                boost::throw_exception(thread_resource_error(res, "boost::condition_variable::condition_variable() constructor failed in pthread::cond_init"));
+                boost::throw_exception(thread_resource_error(res, "boost::condition_variable::condition_variable() constructor failed in pthread_cond_init"));
             }
         }
         ~condition_variable()
@@ -79,14 +79,10 @@ namespace boost
             int ret;
 //#if defined BOOST_THREAD_PROVIDES_INTERRUPTIONS
             // ditto
-            do {
-              ret = pthread_mutex_destroy(&internal_mutex);
-            } while (ret == EINTR);
+            ret = posix::pthread_mutex_destroy(&internal_mutex);
             BOOST_ASSERT(!ret);
 //#endif
-            do {
-              ret = pthread_cond_destroy(&cond);
-            } while (ret == EINTR);
+            ret = posix::pthread_cond_destroy(&cond);
             BOOST_ASSERT(!ret);
         }
 

--- a/include/boost/thread/pthread/once.hpp
+++ b/include/boost/thread/pthread/once.hpp
@@ -14,6 +14,7 @@
 #include <boost/thread/detail/move.hpp>
 #include <boost/thread/detail/invoke.hpp>
 
+#include <boost/thread/pthread/pthread_helpers.hpp>
 #include <boost/thread/pthread/pthread_mutex_scoped_lock.hpp>
 #include <boost/thread/detail/delete.hpp>
 #include <boost/core/no_exceptions_support.hpp>
@@ -149,18 +150,18 @@ namespace boost
                 BOOST_CATCH (...)
                 {
                     flag.epoch=uninitialized_flag;
-                    BOOST_VERIFY(!pthread_cond_broadcast(&thread_detail::once_epoch_cv));
+                    BOOST_VERIFY(!posix::pthread_cond_broadcast(&thread_detail::once_epoch_cv));
                     BOOST_RETHROW
                 }
                 BOOST_CATCH_END
                 flag.epoch=--thread_detail::once_global_epoch;
-                BOOST_VERIFY(!pthread_cond_broadcast(&thread_detail::once_epoch_cv));
+                BOOST_VERIFY(!posix::pthread_cond_broadcast(&thread_detail::once_epoch_cv));
             }
             else
             {
                 while(flag.epoch==being_initialized)
                 {
-                    BOOST_VERIFY(!pthread_cond_wait(&thread_detail::once_epoch_cv,&thread_detail::once_epoch_mutex));
+                    BOOST_VERIFY(!posix::pthread_cond_wait(&thread_detail::once_epoch_cv,&thread_detail::once_epoch_mutex));
                 }
             }
         }
@@ -194,18 +195,18 @@ namespace boost
                 BOOST_CATCH (...)
                 {
                     flag.epoch=uninitialized_flag;
-                    BOOST_VERIFY(!pthread_cond_broadcast(&thread_detail::once_epoch_cv));
+                    BOOST_VERIFY(!posix::pthread_cond_broadcast(&thread_detail::once_epoch_cv));
                     BOOST_RETHROW
                 }
                 BOOST_CATCH_END
                 flag.epoch=--thread_detail::once_global_epoch;
-                BOOST_VERIFY(!pthread_cond_broadcast(&thread_detail::once_epoch_cv));
+                BOOST_VERIFY(!posix::pthread_cond_broadcast(&thread_detail::once_epoch_cv));
             }
             else
             {
                 while(flag.epoch==being_initialized)
                 {
-                    BOOST_VERIFY(!pthread_cond_wait(&thread_detail::once_epoch_cv,&thread_detail::once_epoch_mutex));
+                    BOOST_VERIFY(!posix::pthread_cond_wait(&thread_detail::once_epoch_cv,&thread_detail::once_epoch_mutex));
                 }
             }
         }
@@ -238,18 +239,18 @@ namespace boost
                 BOOST_CATCH (...)
                 {
                     flag.epoch=uninitialized_flag;
-                    BOOST_VERIFY(!pthread_cond_broadcast(&thread_detail::once_epoch_cv));
+                    BOOST_VERIFY(!posix::pthread_cond_broadcast(&thread_detail::once_epoch_cv));
                     BOOST_RETHROW
                 }
                 BOOST_CATCH_END
                 flag.epoch=--thread_detail::once_global_epoch;
-                BOOST_VERIFY(!pthread_cond_broadcast(&thread_detail::once_epoch_cv));
+                BOOST_VERIFY(!posix::pthread_cond_broadcast(&thread_detail::once_epoch_cv));
             }
             else
             {
                 while(flag.epoch==being_initialized)
                 {
-                    BOOST_VERIFY(!pthread_cond_wait(&thread_detail::once_epoch_cv,&thread_detail::once_epoch_mutex));
+                    BOOST_VERIFY(!posix::pthread_cond_wait(&thread_detail::once_epoch_cv,&thread_detail::once_epoch_mutex));
                 }
             }
         }
@@ -281,18 +282,18 @@ namespace boost
                 BOOST_CATCH (...)
                 {
                     flag.epoch=uninitialized_flag;
-                    BOOST_VERIFY(!pthread_cond_broadcast(&thread_detail::once_epoch_cv));
+                    BOOST_VERIFY(!posix::pthread_cond_broadcast(&thread_detail::once_epoch_cv));
                     BOOST_RETHROW
                 }
                 BOOST_CATCH_END
                 flag.epoch=--thread_detail::once_global_epoch;
-                BOOST_VERIFY(!pthread_cond_broadcast(&thread_detail::once_epoch_cv));
+                BOOST_VERIFY(!posix::pthread_cond_broadcast(&thread_detail::once_epoch_cv));
             }
             else
             {
                 while(flag.epoch==being_initialized)
                 {
-                    BOOST_VERIFY(!pthread_cond_wait(&thread_detail::once_epoch_cv,&thread_detail::once_epoch_mutex));
+                    BOOST_VERIFY(!posix::pthread_cond_wait(&thread_detail::once_epoch_cv,&thread_detail::once_epoch_mutex));
                 }
             }
         }
@@ -325,18 +326,18 @@ namespace boost
                 BOOST_CATCH (...)
                 {
                     flag.epoch=uninitialized_flag;
-                    BOOST_VERIFY(!pthread_cond_broadcast(&thread_detail::once_epoch_cv));
+                    BOOST_VERIFY(!posix::pthread_cond_broadcast(&thread_detail::once_epoch_cv));
                     BOOST_RETHROW
                 }
                 BOOST_CATCH_END
                 flag.epoch=--thread_detail::once_global_epoch;
-                BOOST_VERIFY(!pthread_cond_broadcast(&thread_detail::once_epoch_cv));
+                BOOST_VERIFY(!posix::pthread_cond_broadcast(&thread_detail::once_epoch_cv));
             }
             else
             {
                 while(flag.epoch==being_initialized)
                 {
-                    BOOST_VERIFY(!pthread_cond_wait(&thread_detail::once_epoch_cv,&thread_detail::once_epoch_mutex));
+                    BOOST_VERIFY(!posix::pthread_cond_wait(&thread_detail::once_epoch_cv,&thread_detail::once_epoch_mutex));
                 }
             }
         }
@@ -369,18 +370,18 @@ namespace boost
                 BOOST_CATCH (...)
                 {
                     flag.epoch=uninitialized_flag;
-                    BOOST_VERIFY(!pthread_cond_broadcast(&thread_detail::once_epoch_cv));
+                    BOOST_VERIFY(!posix::pthread_cond_broadcast(&thread_detail::once_epoch_cv));
                     BOOST_RETHROW
                 }
                 BOOST_CATCH_END
                 flag.epoch=--thread_detail::once_global_epoch;
-                BOOST_VERIFY(!pthread_cond_broadcast(&thread_detail::once_epoch_cv));
+                BOOST_VERIFY(!posix::pthread_cond_broadcast(&thread_detail::once_epoch_cv));
             }
             else
             {
                 while(flag.epoch==being_initialized)
                 {
-                    BOOST_VERIFY(!pthread_cond_wait(&thread_detail::once_epoch_cv,&thread_detail::once_epoch_mutex));
+                    BOOST_VERIFY(!posix::pthread_cond_wait(&thread_detail::once_epoch_cv,&thread_detail::once_epoch_mutex));
                 }
             }
         }
@@ -416,18 +417,18 @@ namespace boost
                 BOOST_CATCH (...)
                 {
                     flag.epoch=uninitialized_flag;
-                    BOOST_VERIFY(!pthread_cond_broadcast(&thread_detail::once_epoch_cv));
+                    BOOST_VERIFY(!posix::pthread_cond_broadcast(&thread_detail::once_epoch_cv));
                     BOOST_RETHROW
                 }
                 BOOST_CATCH_END
                 flag.epoch=--thread_detail::once_global_epoch;
-                BOOST_VERIFY(!pthread_cond_broadcast(&thread_detail::once_epoch_cv));
+                BOOST_VERIFY(!posix::pthread_cond_broadcast(&thread_detail::once_epoch_cv));
             }
             else
             {
                 while(flag.epoch==being_initialized)
                 {
-                    BOOST_VERIFY(!pthread_cond_wait(&thread_detail::once_epoch_cv,&thread_detail::once_epoch_mutex));
+                    BOOST_VERIFY(!posix::pthread_cond_wait(&thread_detail::once_epoch_cv,&thread_detail::once_epoch_mutex));
                 }
             }
         }
@@ -463,18 +464,18 @@ namespace boost
                 BOOST_CATCH (...)
                 {
                     flag.epoch=uninitialized_flag;
-                    BOOST_VERIFY(!pthread_cond_broadcast(&thread_detail::once_epoch_cv));
+                    BOOST_VERIFY(!posix::pthread_cond_broadcast(&thread_detail::once_epoch_cv));
                     BOOST_RETHROW
                 }
                 BOOST_CATCH_END
                 flag.epoch=--thread_detail::once_global_epoch;
-                BOOST_VERIFY(!pthread_cond_broadcast(&thread_detail::once_epoch_cv));
+                BOOST_VERIFY(!posix::pthread_cond_broadcast(&thread_detail::once_epoch_cv));
             }
             else
             {
                 while(flag.epoch==being_initialized)
                 {
-                    BOOST_VERIFY(!pthread_cond_wait(&thread_detail::once_epoch_cv,&thread_detail::once_epoch_mutex));
+                    BOOST_VERIFY(!posix::pthread_cond_wait(&thread_detail::once_epoch_cv,&thread_detail::once_epoch_mutex));
                 }
             }
         }
@@ -512,18 +513,18 @@ namespace boost
                 BOOST_CATCH (...)
                 {
                     flag.epoch=uninitialized_flag;
-                    BOOST_VERIFY(!pthread_cond_broadcast(&thread_detail::once_epoch_cv));
+                    BOOST_VERIFY(!posix::pthread_cond_broadcast(&thread_detail::once_epoch_cv));
                     BOOST_RETHROW
                 }
                 BOOST_CATCH_END
                 flag.epoch=--thread_detail::once_global_epoch;
-                BOOST_VERIFY(!pthread_cond_broadcast(&thread_detail::once_epoch_cv));
+                BOOST_VERIFY(!posix::pthread_cond_broadcast(&thread_detail::once_epoch_cv));
             }
             else
             {
                 while(flag.epoch==being_initialized)
                 {
-                    BOOST_VERIFY(!pthread_cond_wait(&thread_detail::once_epoch_cv,&thread_detail::once_epoch_mutex));
+                    BOOST_VERIFY(!posix::pthread_cond_wait(&thread_detail::once_epoch_cv,&thread_detail::once_epoch_mutex));
                 }
             }
         }

--- a/include/boost/thread/pthread/pthread_helpers.hpp
+++ b/include/boost/thread/pthread/pthread_helpers.hpp
@@ -8,33 +8,178 @@
 //  http://www.boost.org/LICENSE_1_0.txt)
 
 #include <boost/thread/detail/config.hpp>
+#include <boost/throw_exception.hpp>
 #include <pthread.h>
+#include <errno.h>
 
 #include <boost/config/abi_prefix.hpp>
 
+#ifndef BOOST_THREAD_HAS_NO_EINTR_BUG
+#define BOOST_THREAD_HAS_EINTR_BUG
+#endif
+
 namespace boost
 {
-    namespace pthread
+  namespace posix
+  {
+    BOOST_FORCEINLINE BOOST_THREAD_DISABLE_THREAD_SAFETY_ANALYSIS
+    int pthread_mutex_init(pthread_mutex_t* m, const pthread_mutexattr_t* attr = NULL)
     {
-      inline int cond_init(pthread_cond_t& cond) {
-
-  #ifdef BOOST_THREAD_INTERNAL_CLOCK_IS_MONO
-              pthread_condattr_t attr;
-              int res = pthread_condattr_init(&attr);
-              if (res)
-              {
-                return res;
-              }
-              pthread_condattr_setclock(&attr, CLOCK_MONOTONIC);
-              res=pthread_cond_init(&cond,&attr);
-              pthread_condattr_destroy(&attr);
-              return res;
-  #else
-              return pthread_cond_init(&cond,NULL);
-  #endif
-
-      }
+      return ::pthread_mutex_init(m, attr);
     }
+
+    BOOST_FORCEINLINE BOOST_THREAD_DISABLE_THREAD_SAFETY_ANALYSIS
+    int pthread_cond_init(pthread_cond_t* c)
+    {
+#ifdef BOOST_THREAD_INTERNAL_CLOCK_IS_MONO
+      pthread_condattr_t attr;
+      int res = pthread_condattr_init(&attr);
+      if (res)
+      {
+        return res;
+      }
+      BOOST_VERIFY(!pthread_condattr_setclock(&attr, CLOCK_MONOTONIC));
+      res = ::pthread_cond_init(c, &attr);
+      BOOST_VERIFY(!pthread_condattr_destroy(&attr));
+      return res;
+#else
+      return ::pthread_cond_init(c, NULL);
+#endif
+    }
+
+#ifdef BOOST_THREAD_HAS_EINTR_BUG
+    BOOST_FORCEINLINE BOOST_THREAD_DISABLE_THREAD_SAFETY_ANALYSIS
+    int pthread_mutex_destroy(pthread_mutex_t* m)
+    {
+      int ret;
+      do
+      {
+          ret = ::pthread_mutex_destroy(m);
+      } while (ret == EINTR);
+      return ret;
+    }
+
+    BOOST_FORCEINLINE BOOST_THREAD_DISABLE_THREAD_SAFETY_ANALYSIS
+    int pthread_cond_destroy(pthread_cond_t* c)
+    {
+      int ret;
+      do
+      {
+          ret = ::pthread_cond_destroy(c);
+      } while (ret == EINTR);
+      return ret;
+    }
+
+    BOOST_FORCEINLINE BOOST_THREAD_DISABLE_THREAD_SAFETY_ANALYSIS
+    int pthread_mutex_lock(pthread_mutex_t* m)
+    {
+      int ret;
+      do
+      {
+          ret = ::pthread_mutex_lock(m);
+      } while (ret == EINTR);
+      return ret;
+    }
+
+    BOOST_FORCEINLINE BOOST_THREAD_DISABLE_THREAD_SAFETY_ANALYSIS
+    int pthread_mutex_trylock(pthread_mutex_t* m)
+    {
+      int ret;
+      do
+      {
+          ret = ::pthread_mutex_trylock(m);
+      } while (ret == EINTR);
+      return ret;
+    }
+
+    BOOST_FORCEINLINE BOOST_THREAD_DISABLE_THREAD_SAFETY_ANALYSIS
+    int pthread_mutex_unlock(pthread_mutex_t* m)
+    {
+      int ret;
+      do
+      {
+          ret = ::pthread_mutex_unlock(m);
+      } while (ret == EINTR);
+      return ret;
+    }
+
+    BOOST_FORCEINLINE BOOST_THREAD_DISABLE_THREAD_SAFETY_ANALYSIS
+    int pthread_cond_wait(pthread_cond_t* c, pthread_mutex_t* m)
+    {
+      int ret;
+      do
+      {
+          ret = ::pthread_cond_wait(c, m);
+      } while (ret == EINTR);
+      return ret;
+    }
+
+    BOOST_FORCEINLINE BOOST_THREAD_DISABLE_THREAD_SAFETY_ANALYSIS
+    int pthread_cond_timedwait(pthread_cond_t* c, pthread_mutex_t* m, const struct timespec* t)
+    {
+      int ret;
+      do
+      {
+          ret = ::pthread_cond_timedwait(c, m, t);
+      } while (ret == EINTR);
+      return ret;
+    }
+#else
+    BOOST_FORCEINLINE BOOST_THREAD_DISABLE_THREAD_SAFETY_ANALYSIS
+    int pthread_mutex_destroy(pthread_mutex_t* m)
+    {
+      return ::pthread_mutex_destroy(m);
+    }
+
+    BOOST_FORCEINLINE BOOST_THREAD_DISABLE_THREAD_SAFETY_ANALYSIS
+    int pthread_cond_destroy(pthread_cond_t* c)
+    {
+      return ::pthread_cond_destroy(c);
+    }
+
+    BOOST_FORCEINLINE BOOST_THREAD_DISABLE_THREAD_SAFETY_ANALYSIS
+    int pthread_mutex_lock(pthread_mutex_t* m)
+    {
+      return ::pthread_mutex_lock(m);
+    }
+
+    BOOST_FORCEINLINE BOOST_THREAD_DISABLE_THREAD_SAFETY_ANALYSIS
+    int pthread_mutex_trylock(pthread_mutex_t* m)
+    {
+      return ::pthread_mutex_trylock(m);
+    }
+
+    BOOST_FORCEINLINE BOOST_THREAD_DISABLE_THREAD_SAFETY_ANALYSIS
+    int pthread_mutex_unlock(pthread_mutex_t* m)
+    {
+      return ::pthread_mutex_unlock(m);
+    }
+
+    BOOST_FORCEINLINE BOOST_THREAD_DISABLE_THREAD_SAFETY_ANALYSIS
+    int pthread_cond_wait(pthread_cond_t* c, pthread_mutex_t* m)
+    {
+      return ::pthread_cond_wait(c, m);
+    }
+
+    BOOST_FORCEINLINE BOOST_THREAD_DISABLE_THREAD_SAFETY_ANALYSIS
+    int pthread_cond_timedwait(pthread_cond_t* c, pthread_mutex_t* m, const struct timespec* t)
+    {
+      return ::pthread_cond_timedwait(c, m, t);
+    }
+#endif
+
+    BOOST_FORCEINLINE BOOST_THREAD_DISABLE_THREAD_SAFETY_ANALYSIS
+    int pthread_cond_signal(pthread_cond_t* c)
+    {
+      return ::pthread_cond_signal(c);
+    }
+
+    BOOST_FORCEINLINE BOOST_THREAD_DISABLE_THREAD_SAFETY_ANALYSIS
+    int pthread_cond_broadcast(pthread_cond_t* c)
+    {
+      return ::pthread_cond_broadcast(c);
+    }
+  }
 }
 
 #include <boost/config/abi_suffix.hpp>

--- a/include/boost/thread/pthread/pthread_mutex_scoped_lock.hpp
+++ b/include/boost/thread/pthread/pthread_mutex_scoped_lock.hpp
@@ -8,80 +8,12 @@
 
 #include <pthread.h>
 #include <boost/assert.hpp>
+#include <boost/thread/pthread/pthread_helpers.hpp>
 
 #include <boost/config/abi_prefix.hpp>
 
 namespace boost
 {
-namespace posix {
-#ifdef BOOST_THREAD_HAS_EINTR_BUG
-  BOOST_FORCEINLINE BOOST_THREAD_DISABLE_THREAD_SAFETY_ANALYSIS
-  int pthread_mutex_destroy(pthread_mutex_t* m)
-  {
-    int ret;
-    do
-    {
-        ret = ::pthread_mutex_destroy(m);
-    } while (ret == EINTR);
-    return ret;
-  }
-  BOOST_FORCEINLINE BOOST_THREAD_DISABLE_THREAD_SAFETY_ANALYSIS
-  int pthread_mutex_lock(pthread_mutex_t* m)
-  {
-    int ret;
-    do
-    {
-        ret = ::pthread_mutex_lock(m);
-    } while (ret == EINTR);
-    return ret;
-  }
-  BOOST_FORCEINLINE BOOST_THREAD_DISABLE_THREAD_SAFETY_ANALYSIS
-  int pthread_mutex_unlock(pthread_mutex_t* m)
-  {
-    int ret;
-    do
-    {
-        ret = ::pthread_mutex_unlock(m);
-    } while (ret == EINTR);
-    return ret;
-  }
-#else
-  BOOST_FORCEINLINE BOOST_THREAD_DISABLE_THREAD_SAFETY_ANALYSIS
-  int pthread_mutex_destroy(pthread_mutex_t* m)
-  {
-    return ::pthread_mutex_destroy(m);
-  }
-  BOOST_FORCEINLINE BOOST_THREAD_DISABLE_THREAD_SAFETY_ANALYSIS
-  int pthread_mutex_lock(pthread_mutex_t* m)
-  {
-    return ::pthread_mutex_lock(m);
-  }
-  BOOST_FORCEINLINE BOOST_THREAD_DISABLE_THREAD_SAFETY_ANALYSIS
-  int pthread_mutex_unlock(pthread_mutex_t* m)
-  {
-    return ::pthread_mutex_unlock(m);
-  }
-
-#endif
-  BOOST_FORCEINLINE BOOST_THREAD_DISABLE_THREAD_SAFETY_ANALYSIS
-  int pthread_mutex_trylock(pthread_mutex_t* m)
-  {
-    return ::pthread_mutex_trylock(m);
-  }
-
-  BOOST_FORCEINLINE BOOST_THREAD_DISABLE_THREAD_SAFETY_ANALYSIS
-  int pthread_cond_wait(pthread_cond_t *cond, pthread_mutex_t *mutex)
-  {
-    return ::pthread_cond_wait(cond, mutex);
-  }
-  BOOST_FORCEINLINE BOOST_THREAD_DISABLE_THREAD_SAFETY_ANALYSIS
-  int pthread_cond_signal(pthread_cond_t *cond)
-  {
-    return ::pthread_cond_signal(cond);
-  }
-
-
-}
     namespace pthread
     {
         class pthread_mutex_scoped_lock

--- a/include/boost/thread/pthread/recursive_mutex.hpp
+++ b/include/boost/thread/pthread/recursive_mutex.hpp
@@ -71,7 +71,7 @@ namespace boost
                 boost::throw_exception(thread_resource_error(set_attr_res, "boost:: recursive_mutex constructor failed in pthread_mutexattr_settype"));
             }
 
-            int const res=pthread_mutex_init(&m,&attr);
+            int const res=posix::pthread_mutex_init(&m,&attr);
             if(res)
             {
                 BOOST_VERIFY(!pthread_mutexattr_destroy(&attr));
@@ -79,16 +79,16 @@ namespace boost
             }
             BOOST_VERIFY(!pthread_mutexattr_destroy(&attr));
 #else
-            int const res=pthread_mutex_init(&m,NULL);
+            int const res=posix::pthread_mutex_init(&m);
             if(res)
             {
                 boost::throw_exception(thread_resource_error(res, "boost:: recursive_mutex constructor failed in pthread_mutex_init"));
             }
-            int const res2=pthread::cond_init(cond);
+            int const res2=posix::pthread_cond_init(&cond);
             if(res2)
             {
-                BOOST_VERIFY(!pthread_mutex_destroy(&m));
-                boost::throw_exception(thread_resource_error(res2, "boost:: recursive_mutex constructor failed in pthread::cond_init"));
+                BOOST_VERIFY(!posix::pthread_mutex_destroy(&m));
+                boost::throw_exception(thread_resource_error(res2, "boost:: recursive_mutex constructor failed in pthread_cond_init"));
             }
             is_locked=false;
             count=0;
@@ -96,9 +96,9 @@ namespace boost
         }
         ~recursive_mutex()
         {
-            BOOST_VERIFY(!pthread_mutex_destroy(&m));
+            BOOST_VERIFY(!posix::pthread_mutex_destroy(&m));
 #ifndef BOOST_THREAD_HAS_PTHREAD_MUTEXATTR_SETTYPE
-            BOOST_VERIFY(!pthread_cond_destroy(&cond));
+            BOOST_VERIFY(!posix::pthread_cond_destroy(&cond));
 #endif
         }
 
@@ -138,7 +138,7 @@ namespace boost
 
             while(is_locked)
             {
-                BOOST_VERIFY(!pthread_cond_wait(&cond,&m));
+                BOOST_VERIFY(!posix::pthread_cond_wait(&cond,&m));
             }
             is_locked=true;
             ++count;
@@ -152,7 +152,7 @@ namespace boost
             {
                 is_locked=false;
             }
-            BOOST_VERIFY(!pthread_cond_signal(&cond));
+            BOOST_VERIFY(!posix::pthread_cond_signal(&cond));
         }
 
         bool try_lock()
@@ -206,7 +206,7 @@ namespace boost
                 boost::throw_exception(thread_resource_error(set_attr_res, "boost:: recursive_timed_mutex constructor failed in pthread_mutexattr_settype"));
             }
 
-            int const res=pthread_mutex_init(&m,&attr);
+            int const res=posix::pthread_mutex_init(&m,&attr);
             if(res)
             {
                 BOOST_VERIFY(!pthread_mutexattr_destroy(&attr));
@@ -214,16 +214,16 @@ namespace boost
             }
             BOOST_VERIFY(!pthread_mutexattr_destroy(&attr));
 #else
-            int const res=pthread_mutex_init(&m,NULL);
+            int const res=posix::pthread_mutex_init(&m);
             if(res)
             {
                 boost::throw_exception(thread_resource_error(res, "boost:: recursive_timed_mutex constructor failed in pthread_mutex_init"));
             }
-            int const res2=pthread::cond_init(cond);
+            int const res2=posix::pthread_cond_init(&cond);
             if(res2)
             {
-                BOOST_VERIFY(!pthread_mutex_destroy(&m));
-                boost::throw_exception(thread_resource_error(res2, "boost:: recursive_timed_mutex constructor failed in pthread::cond_init"));
+                BOOST_VERIFY(!posix::pthread_mutex_destroy(&m));
+                boost::throw_exception(thread_resource_error(res2, "boost:: recursive_timed_mutex constructor failed in pthread_cond_init"));
             }
             is_locked=false;
             count=0;
@@ -231,9 +231,9 @@ namespace boost
         }
         ~recursive_timed_mutex()
         {
-            BOOST_VERIFY(!pthread_mutex_destroy(&m));
+            BOOST_VERIFY(!posix::pthread_mutex_destroy(&m));
 #ifndef BOOST_USE_PTHREAD_RECURSIVE_TIMEDLOCK
-            BOOST_VERIFY(!pthread_cond_destroy(&cond));
+            BOOST_VERIFY(!posix::pthread_cond_destroy(&cond));
 #endif
         }
 
@@ -306,7 +306,7 @@ namespace boost
 
             while(is_locked)
             {
-                BOOST_VERIFY(!pthread_cond_wait(&cond,&m));
+                BOOST_VERIFY(!posix::pthread_cond_wait(&cond,&m));
             }
             is_locked=true;
             ++count;
@@ -320,7 +320,7 @@ namespace boost
             {
                 is_locked=false;
             }
-            BOOST_VERIFY(!pthread_cond_signal(&cond));
+            BOOST_VERIFY(!posix::pthread_cond_signal(&cond));
         }
 
         bool try_lock() BOOST_NOEXCEPT
@@ -347,7 +347,7 @@ namespace boost
             }
             while(is_locked)
             {
-                int const cond_res=pthread_cond_timedwait(&cond,&m,&timeout.getTs());
+                int const cond_res=posix::pthread_cond_timedwait(&cond,&m,&timeout.getTs());
                 if(cond_res==ETIMEDOUT)
                 {
                     break;

--- a/include/boost/thread/pthread/thread_data.hpp
+++ b/include/boost/thread/pthread/thread_data.hpp
@@ -12,7 +12,7 @@
 #include <boost/thread/lock_types.hpp>
 #include <boost/thread/mutex.hpp>
 #include <boost/thread/pthread/condition_variable_fwd.hpp>
-#include <boost/thread/pthread/pthread_mutex_scoped_lock.hpp>
+#include <boost/thread/pthread/pthread_helpers.hpp>
 
 #include <boost/shared_ptr.hpp>
 #include <boost/enable_shared_from_this.hpp>

--- a/src/pthread/once.cpp
+++ b/src/pthread/once.cpp
@@ -8,7 +8,6 @@
 #include "./once_atomic.cpp"
 #else
 #define __STDC_CONSTANT_MACROS
-#include <boost/thread/pthread/pthread_mutex_scoped_lock.hpp>
 #include <boost/thread/once.hpp>
 #include <boost/assert.hpp>
 #include <boost/throw_exception.hpp>

--- a/src/pthread/once_atomic.cpp
+++ b/src/pthread/once_atomic.cpp
@@ -7,6 +7,7 @@
 //#define __STDC_CONSTANT_MACROS
 #include <boost/thread/detail/config.hpp>
 #include <boost/thread/once.hpp>
+#include <boost/thread/pthread/pthread_helpers.hpp>
 #include <boost/thread/pthread/pthread_mutex_scoped_lock.hpp>
 #include <boost/assert.hpp>
 #include <boost/static_assert.hpp>
@@ -57,7 +58,7 @@ namespace boost
             {
               // Wait until the initialization is complete
               //pthread::pthread_mutex_scoped_lock lk(&once_mutex);
-              BOOST_VERIFY(!pthread_cond_wait(&once_cv, &once_mutex));
+              BOOST_VERIFY(!posix::pthread_cond_wait(&once_cv, &once_mutex));
             }
           }
         }
@@ -72,7 +73,7 @@ namespace boost
         pthread::pthread_mutex_scoped_lock lk(&once_mutex);
         f.store(initialized, memory_order_release);
       }
-      BOOST_VERIFY(!pthread_cond_broadcast(&once_cv));
+      BOOST_VERIFY(!posix::pthread_cond_broadcast(&once_cv));
     }
 
     BOOST_THREAD_DECL void rollback_once_region(once_flag& flag) BOOST_NOEXCEPT
@@ -82,7 +83,7 @@ namespace boost
         pthread::pthread_mutex_scoped_lock lk(&once_mutex);
         f.store(uninitialized, memory_order_release);
       }
-      BOOST_VERIFY(!pthread_cond_broadcast(&once_cv));
+      BOOST_VERIFY(!posix::pthread_cond_broadcast(&once_cv));
     }
 
   } // namespace thread_detail

--- a/src/pthread/thread.cpp
+++ b/src/pthread/thread.cpp
@@ -17,6 +17,8 @@
 #include <boost/thread/once.hpp>
 #include <boost/thread/tss.hpp>
 #include <boost/thread/future.hpp>
+#include <boost/thread/pthread/pthread_helpers.hpp>
+#include <boost/thread/pthread/pthread_mutex_scoped_lock.hpp>
 
 #ifdef __GLIBC__
 #include <sys/sysinfo.h>
@@ -581,7 +583,7 @@ namespace boost
             if(local_thread_info->current_cond)
             {
                 boost::pthread::pthread_mutex_scoped_lock internal_lock(local_thread_info->cond_mutex);
-                BOOST_VERIFY(!pthread_cond_broadcast(local_thread_info->current_cond));
+                BOOST_VERIFY(!posix::pthread_cond_broadcast(local_thread_info->current_cond));
             }
         }
     }


### PR DESCRIPTION
* Re-fixed the EINTR bug that exists in some pthreads implementations.
It was originally fixed in https://svn.boost.org/trac10/ticket/6200 and
was accidentally disabled in 5b209c2e834a89c93d308aa7ddb1dfd1207d929d.
* Made sure that the fix for the EINTR bug was consistently applied to
all code in the library.
* Made sure that all pthread_mutex_*() and pthread_cond_*() function
calls in the library were consistently decorated with
BOOST_THREAD_DISABLE_THREAD_SAFETY_ANALYSIS.