### PR TITLE
Fix sync_timed_queue time jump issues

### DIFF
--- a/include/boost/thread/concurrent_queues/sync_timed_queue.hpp
+++ b/include/boost/thread/concurrent_queues/sync_timed_queue.hpp
@@ -16,6 +16,8 @@
 #include <boost/chrono/system_clocks.hpp>
 #include <boost/chrono/chrono_io.hpp>
 
+#include <algorithm> // std::min
+
 #include <boost/config/abi_prefix.hpp>
 
 namespace boost
@@ -58,6 +60,45 @@ namespace detail
       return this->time > other.time;
     }
   }; //end struct
+
+  template <class Duration>
+  chrono::time_point<chrono::steady_clock,Duration>
+  limit_timepoint(chrono::time_point<chrono::steady_clock,Duration> const& tp)
+  {
+    // Clock == chrono::steady_clock
+    return tp;
+  }
+
+  template <class Clock, class Duration>
+  chrono::time_point<Clock,Duration>
+  limit_timepoint(chrono::time_point<Clock,Duration> const& tp)
+  {
+    // Clock != chrono::steady_clock
+    // The system time may jump while wait_until() is waiting. To compensate for this and time out near
+    // the correct time, we limit how long wait_until() can wait before going around the loop again.
+    const chrono::time_point<Clock,Duration> tpmax(chrono::time_point_cast<Duration>(Clock::now() + chrono::milliseconds(BOOST_THREAD_POLL_INTERVAL_MILLISECONDS)));
+    return (std::min)(tp, tpmax);
+  }
+
+  template <class Duration>
+  chrono::steady_clock::time_point
+  convert_to_steady_clock_timepoint(chrono::time_point<chrono::steady_clock,Duration> const& tp)
+  {
+    // Clock == chrono::steady_clock
+    return chrono::time_point_cast<chrono::steady_clock::duration>(tp);
+  }
+
+  template <class Clock, class Duration>
+  chrono::steady_clock::time_point
+  convert_to_steady_clock_timepoint(chrono::time_point<Clock,Duration> const& tp)
+  {
+    // Clock != chrono::steady_clock
+    // The system time may jump while wait_until() is waiting. To compensate for this and time out near
+    // the correct time, we limit how long wait_until() can wait before going around the loop again.
+    const chrono::steady_clock::duration dura(chrono::duration_cast<chrono::steady_clock::duration>(tp - Clock::now()));
+    const chrono::steady_clock::duration duramax(chrono::milliseconds(BOOST_THREAD_POLL_INTERVAL_MILLISECONDS));
+    return chrono::steady_clock::now() + (std::min)(dura, duramax);
+  }
 
 } //end detail namespace
 
@@ -123,6 +164,8 @@ namespace detail
 
     bool wait_to_pull(unique_lock<mutex>&);
     queue_op_status wait_to_pull_until(unique_lock<mutex>&, TimePoint const& tp);
+    template <class Rep, class Period>
+    queue_op_status wait_to_pull_for(unique_lock<mutex>& lk, chrono::duration<Rep,Period> const& dura);
 
     T pull(unique_lock<mutex>&);
     T pull(lock_guard<mutex>&);
@@ -227,8 +270,8 @@ namespace detail
       if (not_empty_and_time_reached(lk)) return false; // success
       if (super::closed(lk)) return true; // closed
 
-      const time_point tp(super::data_.top().time);
-      super::cond_.wait_until(lk, tp);
+      const time_point tpmin(detail::limit_timepoint(super::data_.top().time));
+      super::cond_.wait_until(lk, tpmin);
     }
   }
 
@@ -247,7 +290,29 @@ namespace detail
       if (super::closed(lk)) return queue_op_status::closed;
       if (clock::now() >= tp) return super::empty(lk) ? queue_op_status::timeout : queue_op_status::not_ready;
 
-      const time_point tpmin(tp < super::data_.top().time ? tp : super::data_.top().time);
+      const time_point tpmin((std::min)(tp, detail::limit_timepoint(super::data_.top().time)));
+      super::cond_.wait_until(lk, tpmin);
+    }
+  }
+
+  template <class T, class Clock, class TimePoint>
+  template <class Rep, class Period>
+  queue_op_status sync_timed_queue<T, Clock, TimePoint>::wait_to_pull_for(unique_lock<mutex>& lk, chrono::duration<Rep,Period> const& dura)
+  {
+    const chrono::steady_clock::time_point tp(chrono::steady_clock::now() + chrono::duration_cast<chrono::steady_clock::duration>(dura));
+    for (;;)
+    {
+      if (not_empty_and_time_reached(lk)) return queue_op_status::success;
+      if (super::closed(lk)) return queue_op_status::closed;
+      if (chrono::steady_clock::now() >= tp) return super::empty(lk) ? queue_op_status::timeout : queue_op_status::not_ready;
+
+      super::wait_until_not_empty_or_closed_until(lk, tp);
+
+      if (not_empty_and_time_reached(lk)) return queue_op_status::success;
+      if (super::closed(lk)) return queue_op_status::closed;
+      if (chrono::steady_clock::now() >= tp) return super::empty(lk) ? queue_op_status::timeout : queue_op_status::not_ready;
+
+      const chrono::steady_clock::time_point tpmin((std::min)(tp, detail::convert_to_steady_clock_timepoint(super::data_.top().time)));
       super::cond_.wait_until(lk, tpmin);
     }
   }
@@ -329,7 +394,10 @@ namespace detail
   queue_op_status
   sync_timed_queue<T, Clock, TimePoint>::pull_for(chrono::duration<Rep,Period> const& dura, T& elem)
   {
-    return pull_until(clock::now() + dura, elem);
+    unique_lock<mutex> lk(super::mtx_);
+    const queue_op_status rc = wait_to_pull_for(lk, dura);
+    if (rc == queue_op_status::success) pull(lk, elem);
+    return rc;
   }
 
   ///////////////////////////

--- a/test/sync/mutual_exclusion/sync_pq/tq_multi_thread_pass.cpp
+++ b/test/sync/mutual_exclusion/sync_pq/tq_multi_thread_pass.cpp
@@ -24,63 +24,58 @@ using namespace boost::chrono;
 
 typedef boost::concurrent::sync_timed_queue<int> sync_tq;
 
-const int count = 5;
+const int cnt = 5;
 
-void call_push(sync_tq* q)
+void call_push(sync_tq* q, const steady_clock::time_point start)
 {
     // push elements onto the queue every 500 milliseconds but with a decreasing delay each time
-    for (int i = 0; i < count; ++i)
+    for (int i = 0; i < cnt; ++i)
     {
-        q->push(i, sync_tq::clock::now() + seconds(count - i));
-        boost::this_thread::sleep_for(milliseconds(500));
+        boost::this_thread::sleep_until(start + milliseconds(i * 500));
+        const steady_clock::time_point expected = start + milliseconds(i * 500) + seconds(cnt - i);
+        q->push(i, expected);
     }
 }
 
-void call_pull(sync_tq* q)
+void call_pull(sync_tq* q, const steady_clock::time_point start)
 {
     // pull elements off of the queue (earliest element first)
-    steady_clock::time_point start = steady_clock::now();
-    for (int i = count - 1; i >= 0; --i)
+    for (int i = cnt - 1; i >= 0; --i)
     {
         int j;
         q->pull(j);
         BOOST_TEST_EQ(i, j);
-        milliseconds elapsed = duration_cast<milliseconds>(steady_clock::now() - start);
-        milliseconds expected = milliseconds(i * 500) + seconds(count - i);
-        BOOST_TEST_GE(elapsed, expected - milliseconds(BOOST_THREAD_TEST_TIME_MS));
-        BOOST_TEST_LE(elapsed, expected + milliseconds(BOOST_THREAD_TEST_TIME_MS));
+        const steady_clock::time_point expected = start + milliseconds(i * 500) + seconds(cnt - i);
+        BOOST_TEST_GE(steady_clock::now(), expected - milliseconds(BOOST_THREAD_TEST_TIME_MS));
+        BOOST_TEST_LE(steady_clock::now(), expected + milliseconds(BOOST_THREAD_TEST_TIME_MS));
     }
 }
 
-void call_pull_until(sync_tq* q)
+void call_pull_until(sync_tq* q, const steady_clock::time_point start)
 {
     // pull elements off of the queue (earliest element first)
-    steady_clock::time_point start = steady_clock::now();
-    for (int i = count - 1; i >= 0; --i)
+    for (int i = cnt - 1; i >= 0; --i)
     {
         int j;
         q->pull_until(steady_clock::now() + hours(1), j);
         BOOST_TEST_EQ(i, j);
-        milliseconds elapsed = duration_cast<milliseconds>(steady_clock::now() - start);
-        milliseconds expected = milliseconds(i * 500) + seconds(count - i);
-        BOOST_TEST_GE(elapsed, expected - milliseconds(BOOST_THREAD_TEST_TIME_MS));
-        BOOST_TEST_LE(elapsed, expected + milliseconds(BOOST_THREAD_TEST_TIME_MS));
+        const steady_clock::time_point expected = start + milliseconds(i * 500) + seconds(cnt - i);
+        BOOST_TEST_GE(steady_clock::now(), expected - milliseconds(BOOST_THREAD_TEST_TIME_MS));
+        BOOST_TEST_LE(steady_clock::now(), expected + milliseconds(BOOST_THREAD_TEST_TIME_MS));
     }
 }
 
-void call_pull_for(sync_tq* q)
+void call_pull_for(sync_tq* q, const steady_clock::time_point start)
 {
     // pull elements off of the queue (earliest element first)
-    steady_clock::time_point start = steady_clock::now();
-    for (int i = count - 1; i >= 0; --i)
+    for (int i = cnt - 1; i >= 0; --i)
     {
         int j;
         q->pull_for(hours(1), j);
         BOOST_TEST_EQ(i, j);
-        milliseconds elapsed = duration_cast<milliseconds>(steady_clock::now() - start);
-        milliseconds expected = milliseconds(i * 500) + seconds(count - i);
-        BOOST_TEST_GE(elapsed, expected - milliseconds(BOOST_THREAD_TEST_TIME_MS));
-        BOOST_TEST_LE(elapsed, expected + milliseconds(BOOST_THREAD_TEST_TIME_MS));
+        const steady_clock::time_point expected = start + milliseconds(i * 500) + seconds(cnt - i);
+        BOOST_TEST_GE(steady_clock::now(), expected - milliseconds(BOOST_THREAD_TEST_TIME_MS));
+        BOOST_TEST_LE(steady_clock::now(), expected + milliseconds(BOOST_THREAD_TEST_TIME_MS));
     }
 }
 
@@ -89,8 +84,9 @@ void test_push_while_pull()
     sync_tq tq;
     BOOST_TEST(tq.empty());
     boost::thread_group tg;
-    tg.create_thread(boost::bind(call_push, &tq));
-    tg.create_thread(boost::bind(call_pull, &tq));
+    const steady_clock::time_point start = steady_clock::now();
+    tg.create_thread(boost::bind(call_push, &tq, start));
+    tg.create_thread(boost::bind(call_pull, &tq, start));
     tg.join_all();
     BOOST_TEST(tq.empty());
 }
@@ -100,8 +96,9 @@ void test_push_while_pull_until()
     sync_tq tq;
     BOOST_TEST(tq.empty());
     boost::thread_group tg;
-    tg.create_thread(boost::bind(call_push, &tq));
-    tg.create_thread(boost::bind(call_pull_until, &tq));
+    const steady_clock::time_point start = steady_clock::now();
+    tg.create_thread(boost::bind(call_push, &tq, start));
+    tg.create_thread(boost::bind(call_pull_until, &tq, start));
     tg.join_all();
     BOOST_TEST(tq.empty());
 }
@@ -111,8 +108,9 @@ void test_push_while_pull_for()
     sync_tq tq;
     BOOST_TEST(tq.empty());
     boost::thread_group tg;
-    tg.create_thread(boost::bind(call_push, &tq));
-    tg.create_thread(boost::bind(call_pull_for, &tq));
+    const steady_clock::time_point start = steady_clock::now();
+    tg.create_thread(boost::bind(call_push, &tq, start));
+    tg.create_thread(boost::bind(call_pull_for, &tq, start));
     tg.join_all();
     BOOST_TEST(tq.empty());
 }

--- a/test/test_time_jumps.cpp
+++ b/test/test_time_jumps.cpp
@@ -2142,7 +2142,7 @@ void testSyncTimedQueuePullForSucceedsSystem(const long long jumpMs)
     bool succeeded = (q.pull_for(typename Helper::milliseconds(10000), i) == boost::queue_op_status::success);
     typename Helper::steady_time_point after(Helper::steadyNow());
 
-    checkWaitTime<Helper>(Helper::waitDur, after - before, succeeded ? e_succeeded_good : e_failed_bad);
+    checkWaitTime<Helper>(Helper::waitDur - typename Helper::milliseconds(jumpMs), after - before, succeeded ? e_succeeded_good : e_failed_bad);
 }
 
 template <typename Helper>
@@ -2156,7 +2156,7 @@ void testSyncTimedQueuePullForSucceedsCustom(const long long jumpMs)
     bool succeeded = (q.pull_for(typename Helper::milliseconds(10000), i) == boost::queue_op_status::success);
     typename Helper::steady_time_point after(Helper::steadyNow());
 
-    checkWaitTime<Helper>(Helper::waitDur, after - before, succeeded ? e_succeeded_good : e_failed_bad);
+    checkWaitTime<Helper>(Helper::waitDur - typename Helper::milliseconds(jumpMs), after - before, succeeded ? e_succeeded_good : e_failed_bad);
 }
 
 template <typename Helper>

--- a/test/test_time_jumps.cpp
+++ b/test/test_time_jumps.cpp
@@ -1952,9 +1952,35 @@ void testSyncPriorityQueueBoost(const std::string& name)
 // Test Sync Timed Queue
 
 template <typename Helper>
-void testSyncTimedQueuePullForEmpty(const long long jumpMs)
+void testSyncTimedQueuePullForEmptySteady(const long long jumpMs)
 {
     boost::sync_timed_queue<int, typename Helper::steady_clock> q;
+    int i;
+
+    typename Helper::steady_time_point before(Helper::steadyNow());
+    bool timeout = (q.pull_for(Helper::waitDur, i) == boost::queue_op_status::timeout);
+    typename Helper::steady_time_point after(Helper::steadyNow());
+
+    checkWaitTime<Helper>(Helper::waitDur, after - before, timeout ? e_timeout : e_no_timeout);
+}
+
+template <typename Helper>
+void testSyncTimedQueuePullForEmptySystem(const long long jumpMs)
+{
+    boost::sync_timed_queue<int, typename Helper::system_clock> q;
+    int i;
+
+    typename Helper::steady_time_point before(Helper::steadyNow());
+    bool timeout = (q.pull_for(Helper::waitDur, i) == boost::queue_op_status::timeout);
+    typename Helper::steady_time_point after(Helper::steadyNow());
+
+    checkWaitTime<Helper>(Helper::waitDur, after - before, timeout ? e_timeout : e_no_timeout);
+}
+
+template <typename Helper>
+void testSyncTimedQueuePullForEmptyCustom(const long long jumpMs)
+{
+    boost::sync_timed_queue<int, typename Helper::custom_clock> q;
     int i;
 
     typename Helper::steady_time_point before(Helper::steadyNow());
@@ -2006,9 +2032,37 @@ void testSyncTimedQueuePullUntilEmptyCustom(const long long jumpMs)
 //--------------------------------------
 
 template <typename Helper>
-void testSyncTimedQueuePullForNotReady(const long long jumpMs)
+void testSyncTimedQueuePullForNotReadySteady(const long long jumpMs)
 {
     boost::sync_timed_queue<int, typename Helper::steady_clock> q;
+    q.push(0, typename Helper::milliseconds(10000)); // a long time
+    int i;
+
+    typename Helper::steady_time_point before(Helper::steadyNow());
+    bool notReady = (q.pull_for(Helper::waitDur, i) == boost::queue_op_status::not_ready);
+    typename Helper::steady_time_point after(Helper::steadyNow());
+
+    checkWaitTime<Helper>(Helper::waitDur, after - before, notReady ? e_not_ready_good : e_ready_bad);
+}
+
+template <typename Helper>
+void testSyncTimedQueuePullForNotReadySystem(const long long jumpMs)
+{
+    boost::sync_timed_queue<int, typename Helper::system_clock> q;
+    q.push(0, typename Helper::milliseconds(10000)); // a long time
+    int i;
+
+    typename Helper::steady_time_point before(Helper::steadyNow());
+    bool notReady = (q.pull_for(Helper::waitDur, i) == boost::queue_op_status::not_ready);
+    typename Helper::steady_time_point after(Helper::steadyNow());
+
+    checkWaitTime<Helper>(Helper::waitDur, after - before, notReady ? e_not_ready_good : e_ready_bad);
+}
+
+template <typename Helper>
+void testSyncTimedQueuePullForNotReadyCustom(const long long jumpMs)
+{
+    boost::sync_timed_queue<int, typename Helper::custom_clock> q;
     q.push(0, typename Helper::milliseconds(10000)); // a long time
     int i;
 
@@ -2064,9 +2118,37 @@ void testSyncTimedQueuePullUntilNotReadyCustom(const long long jumpMs)
 //--------------------------------------
 
 template <typename Helper>
-void testSyncTimedQueuePullForSucceeds(const long long jumpMs)
+void testSyncTimedQueuePullForSucceedsSteady(const long long jumpMs)
 {
     boost::sync_timed_queue<int, typename Helper::steady_clock> q;
+    q.push(0, Helper::waitDur);
+    int i;
+
+    typename Helper::steady_time_point before(Helper::steadyNow());
+    bool succeeded = (q.pull_for(typename Helper::milliseconds(10000), i) == boost::queue_op_status::success);
+    typename Helper::steady_time_point after(Helper::steadyNow());
+
+    checkWaitTime<Helper>(Helper::waitDur, after - before, succeeded ? e_succeeded_good : e_failed_bad);
+}
+
+template <typename Helper>
+void testSyncTimedQueuePullForSucceedsSystem(const long long jumpMs)
+{
+    boost::sync_timed_queue<int, typename Helper::system_clock> q;
+    q.push(0, Helper::waitDur);
+    int i;
+
+    typename Helper::steady_time_point before(Helper::steadyNow());
+    bool succeeded = (q.pull_for(typename Helper::milliseconds(10000), i) == boost::queue_op_status::success);
+    typename Helper::steady_time_point after(Helper::steadyNow());
+
+    checkWaitTime<Helper>(Helper::waitDur, after - before, succeeded ? e_succeeded_good : e_failed_bad);
+}
+
+template <typename Helper>
+void testSyncTimedQueuePullForSucceedsCustom(const long long jumpMs)
+{
+    boost::sync_timed_queue<int, typename Helper::custom_clock> q;
     q.push(0, Helper::waitDur);
     int i;
 
@@ -2171,19 +2253,25 @@ template <typename Helper>
 void testSyncTimedQueueBoost(const std::string& name)
 {
     std::cout << std::endl;
-    runTestWithNone<Helper>(testSyncTimedQueuePullForEmpty        <Helper>, name + "::pull_for(), empty");
+    runTestWithNone<Helper>(testSyncTimedQueuePullForEmptySteady  <Helper>, name + "::pull_for(), empty, steady time");
+    runTestWithNone<Helper>(testSyncTimedQueuePullForEmptySystem  <Helper>, name + "::pull_for(), empty, system time");
+    runTestWithNone<Helper>(testSyncTimedQueuePullForEmptyCustom  <Helper>, name + "::pull_for(), empty, custom time");
     runTestWithNone<Helper>(testSyncTimedQueuePullUntilEmptySteady<Helper>, name + "::pull_until(), empty, steady time");
     runTestWithNone<Helper>(testSyncTimedQueuePullUntilEmptySystem<Helper>, name + "::pull_until(), empty, system time");
     runTestWithNone<Helper>(testSyncTimedQueuePullUntilEmptyCustom<Helper>, name + "::pull_until(), empty, custom time");
 
     std::cout << std::endl;
-    runTestWithNone<Helper>(testSyncTimedQueuePullForNotReady        <Helper>, name + "::pull_for(), not ready");
+    runTestWithNone<Helper>(testSyncTimedQueuePullForNotReadySteady  <Helper>, name + "::pull_for(), not ready, steady time");
+    runTestWithNone<Helper>(testSyncTimedQueuePullForNotReadySystem  <Helper>, name + "::pull_for(), not ready, system time");
+    runTestWithNone<Helper>(testSyncTimedQueuePullForNotReadyCustom  <Helper>, name + "::pull_for(), not ready, custom time");
     runTestWithNone<Helper>(testSyncTimedQueuePullUntilNotReadySteady<Helper>, name + "::pull_until(), not ready, steady time");
     runTestWithNone<Helper>(testSyncTimedQueuePullUntilNotReadySystem<Helper>, name + "::pull_until(), not ready, system time");
     runTestWithNone<Helper>(testSyncTimedQueuePullUntilNotReadyCustom<Helper>, name + "::pull_until(), not ready, custom time");
 
     std::cout << std::endl;
-    runTestWithNone<Helper>(testSyncTimedQueuePullForSucceeds        <Helper>, name + "::pull_for(), succeeds");
+    runTestWithNone<Helper>(testSyncTimedQueuePullForSucceedsSteady  <Helper>, name + "::pull_for(), succeeds, steady time");
+    runTestWithNone<Helper>(testSyncTimedQueuePullForSucceedsSystem  <Helper>, name + "::pull_for(), succeeds, system time");
+    runTestWithNone<Helper>(testSyncTimedQueuePullForSucceedsCustom  <Helper>, name + "::pull_for(), succeeds, custom time");
     runTestWithNone<Helper>(testSyncTimedQueuePullUntilSucceedsSteady<Helper>, name + "::pull_until(), succeeds, steady time");
     runTestWithNone<Helper>(testSyncTimedQueuePullUntilSucceedsSystem<Helper>, name + "::pull_until(), succeeds, system time");
     runTestWithNone<Helper>(testSyncTimedQueuePullUntilSucceedsCustom<Helper>, name + "::pull_until(), succeeds, custom time");


### PR DESCRIPTION
* Added missing sync_timed_queue::pull_for() time jump tests.
* Added pull_until() and pull_for() to the test for #271.
* Fixed time jump issues that were re-introduced while fixing #271.
* Fixed time jump issues with sync_timed_queue::pull_for().