### PR TITLE
Fix linker error with clang-cl #286

### DIFF
--- a/include/boost/thread/detail/config.hpp
+++ b/include/boost/thread/detail/config.hpp
@@ -470,7 +470,8 @@
 #else //Use default
 #   if defined(BOOST_THREAD_PLATFORM_WIN32)
 #       if defined(BOOST_MSVC) || defined(BOOST_INTEL_WIN) \
-      || defined(__MINGW32__) || defined(MINGW32) || defined(BOOST_MINGW32)
+      || defined(__MINGW32__) || defined(MINGW32) || defined(BOOST_MINGW32) \
+      || (defined(_MSC_VER) && defined(__clang__))
       //For compilers supporting auto-tss cleanup
             //with Boost.Threads lib, use Boost.Threads lib
 #           define BOOST_THREAD_USE_LIB


### PR DESCRIPTION
Fix issue #286

Analog to this [patch for boost.type_index](https://github.com/boostorg/type_index/pull/25/commits), I check for clang-win by testing if both `__clang__` and `_MSC_VER` are set.