### PR TITLE
Add compiler barrier definition for clang-win

### DIFF
--- a/include/boost/thread/win32/interlocked_read.hpp
+++ b/include/boost/thread/win32/interlocked_read.hpp
@@ -19,6 +19,8 @@
 // Define compiler barriers
 #if defined(__INTEL_COMPILER)
 #define BOOST_THREAD_DETAIL_COMPILER_BARRIER() __memory_barrier()
+#elif defined(__clang__)
+#define BOOST_THREAD_DETAIL_COMPILER_BARRIER() __atomic_signal_fence(__ATOMIC_SEQ_CST)
 #elif defined(_MSC_VER) && !defined(_WIN32_WCE)
 extern "C" void _ReadWriteBarrier(void);
 #pragma intrinsic(_ReadWriteBarrier)


### PR DESCRIPTION
This silences warnings about `_ReadWriteBarrier` being deprecated.