### PR TITLE
Revert change to elide a warning that caused Solaris builds to fail.

### DIFF
--- a/include/boost/thread/pthread/thread_data.hpp
+++ b/include/boost/thread/pthread/thread_data.hpp
@@ -57,7 +57,7 @@ namespace boost
 #else
           std::size_t page_size = ::sysconf( _SC_PAGESIZE);
 #endif
-#if PTHREAD_STACK_MIN > 0
+#ifdef PTHREAD_STACK_MIN
           if (size<PTHREAD_STACK_MIN) size=PTHREAD_STACK_MIN;
 #endif
           size = ((size+page_size-1)/page_size)*page_size;


### PR DESCRIPTION
Revert a minor change to elide a warning regarding comparison of unsigned to zero that caused solaris platforms to fail to build.

https://github.com/boostorg/thread/issues/283
