### PR TITLE
By default #define BOOST_THREAD_USE_LIB in Windows for clang

### DIFF
--- a/include/boost/thread/detail/config.hpp
+++ b/include/boost/thread/detail/config.hpp
@@ -469,7 +469,7 @@
 #elif defined(BOOST_THREAD_USE_LIB)   //Use lib
 #else //Use default
 #   if defined(BOOST_THREAD_PLATFORM_WIN32)
-#       if defined(BOOST_MSVC) || defined(BOOST_INTEL_WIN) \
+#       if defined(BOOST_MSVC) || defined(BOOST_INTEL_WIN) || defined(BOOST_CLANG) \
       || defined(__MINGW32__) || defined(MINGW32) || defined(BOOST_MINGW32) \
       || (defined(_MSC_VER) && defined(__clang__))
       //For compilers supporting auto-tss cleanup


### PR DESCRIPTION
I was trying to compile my code in Windows with clang-cl and BOOST_ALL_NO_LIB and I was getting weird linker errors about missing *imported* symbols:  undefined symbol: __declspec(dllimport) public: void __thiscall boost::thread::join(void)

This led me to find out that clang-cl was a second class citizen wrt the definition of BOOST_THREAD_USE_LIB by default in Windows.

I propose to add clang to the compilers that get BOOST_THREAD_USE_LIB defined by default in Windows.