### PR TITLE
Cleanup header includes

### DIFF
--- a/include/boost/thread/concurrent_queues/detail/sync_deque_base.hpp
+++ b/include/boost/thread/concurrent_queues/detail/sync_deque_base.hpp
@@ -12,6 +12,7 @@
 //////////////////////////////////////////////////////////////////////////////
 
 #include <boost/bind/bind.hpp>
+#include <boost/core/ref.hpp>
 
 #include <boost/thread/detail/config.hpp>
 #include <boost/thread/condition_variable.hpp>
@@ -187,7 +188,7 @@ namespace detail
   template <class ValueType, class Queue>
   bool sync_deque_base<ValueType, Queue>::wait_until_not_empty_or_closed(unique_lock<mutex>& lk)
   {
-    cond_.wait(lk, boost::bind(&sync_deque_base<ValueType, Queue>::not_empty_or_closed, boost::ref(*this), boost::ref(lk)));
+    cond_.wait(lk, boost::bind(&sync_deque_base<ValueType, Queue>::not_empty_or_closed, this, boost::ref(lk)));
     if (! empty(lk)) return false; // success
     return true; // closed
   }
@@ -196,7 +197,7 @@ namespace detail
   template <class WClock, class Duration>
   queue_op_status sync_deque_base<ValueType, Queue>::wait_until_not_empty_or_closed_until(unique_lock<mutex>& lk, chrono::time_point<WClock,Duration> const&tp)
   {
-    if (! cond_.wait_until(lk, tp, boost::bind(&sync_deque_base<ValueType, Queue>::not_empty_or_closed, boost::ref(*this), boost::ref(lk))))
+    if (! cond_.wait_until(lk, tp, boost::bind(&sync_deque_base<ValueType, Queue>::not_empty_or_closed, this, boost::ref(lk))))
       return queue_op_status::timeout;
     if (! empty(lk)) return queue_op_status::success;
     return queue_op_status::closed;

--- a/include/boost/thread/concurrent_queues/detail/sync_queue_base.hpp
+++ b/include/boost/thread/concurrent_queues/detail/sync_queue_base.hpp
@@ -12,6 +12,7 @@
 //////////////////////////////////////////////////////////////////////////////
 
 #include <boost/bind/bind.hpp>
+#include <boost/core/ref.hpp>
 
 #include <boost/thread/detail/config.hpp>
 #include <boost/thread/condition_variable.hpp>
@@ -187,7 +188,7 @@ namespace detail
   template <class ValueType, class Queue>
   bool sync_queue_base<ValueType, Queue>::wait_until_not_empty_or_closed(unique_lock<mutex>& lk)
   {
-    cond_.wait(lk, boost::bind(&sync_queue_base<ValueType, Queue>::not_empty_or_closed, boost::ref(*this), boost::ref(lk)));
+    cond_.wait(lk, boost::bind(&sync_queue_base<ValueType, Queue>::not_empty_or_closed, this, boost::ref(lk)));
     if (! empty(lk)) return false; // success
     return true; // closed
   }
@@ -196,7 +197,7 @@ namespace detail
   template <class WClock, class Duration>
   queue_op_status sync_queue_base<ValueType, Queue>::wait_until_not_empty_or_closed_until(unique_lock<mutex>& lk, chrono::time_point<WClock,Duration> const&tp)
   {
-    if (! cond_.wait_until(lk, tp, boost::bind(&sync_queue_base<ValueType, Queue>::not_empty_or_closed, boost::ref(*this), boost::ref(lk))))
+    if (! cond_.wait_until(lk, tp, boost::bind(&sync_queue_base<ValueType, Queue>::not_empty_or_closed, this, boost::ref(lk))))
       return queue_op_status::timeout;
     if (! empty(lk)) return queue_op_status::success;
     return queue_op_status::closed;

--- a/include/boost/thread/detail/thread.hpp
+++ b/include/boost/thread/detail/thread.hpp
@@ -30,7 +30,6 @@
 #include <algorithm>
 #include <boost/core/ref.hpp>
 #include <boost/cstdint.hpp>
-#include <boost/bind/bind.hpp>
 #include <stdlib.h>
 #include <memory>
 #include <boost/core/enable_if.hpp>
@@ -47,6 +46,8 @@
 
 #if defined(BOOST_THREAD_PROVIDES_VARIADIC_THREAD)
 #include <tuple>
+#else
+#include <boost/bind/bind.hpp>
 #endif
 #include <boost/config/abi_prefix.hpp>
 

--- a/include/boost/thread/future.hpp
+++ b/include/boost/thread/future.hpp
@@ -393,7 +393,7 @@ namespace boost
                 is_deferred_=false;
                 execute(lk);
               }
-              waiters.wait(lk, boost::bind(&shared_state_base::is_done, boost::ref(*this)));
+              waiters.wait(lk, boost::bind(&shared_state_base::is_done, this));
               if(rethrow && exception)
               {
                   boost::rethrow_exception(exception);
@@ -420,7 +420,7 @@ namespace boost
                     return false;
 
                 do_callback(lock);
-                return waiters.timed_wait(lock, rel_time, boost::bind(&shared_state_base::is_done, boost::ref(*this)));
+                return waiters.timed_wait(lock, rel_time, boost::bind(&shared_state_base::is_done, this));
             }
 
             bool timed_wait_until(boost::system_time const& target_time)
@@ -430,7 +430,7 @@ namespace boost
                     return false;
 
                 do_callback(lock);
-                return waiters.timed_wait(lock, target_time, boost::bind(&shared_state_base::is_done, boost::ref(*this)));
+                return waiters.timed_wait(lock, target_time, boost::bind(&shared_state_base::is_done, this));
             }
 #endif
 #ifdef BOOST_THREAD_USES_CHRONO
@@ -443,7 +443,7 @@ namespace boost
               if (is_deferred_)
                   return future_status::deferred;
               do_callback(lock);
-              if(!waiters.wait_until(lock, abs_time, boost::bind(&shared_state_base::is_done, boost::ref(*this))))
+              if(!waiters.wait_until(lock, abs_time, boost::bind(&shared_state_base::is_done, this)))
               {
                   return future_status::timeout;
               }
@@ -940,7 +940,7 @@ namespace boost
             join();
 #elif defined BOOST_THREAD_ASYNC_FUTURE_WAITS
             unique_lock<boost::mutex> lk(this->mutex);
-            this->waiters.wait(lk, boost::bind(&shared_state_base::is_done, boost::ref(*this)));
+            this->waiters.wait(lk, boost::bind(&shared_state_base::is_done, this));
 #endif
           }
 

--- a/include/boost/thread/pthread/once.hpp
+++ b/include/boost/thread/pthread/once.hpp
@@ -19,13 +19,16 @@
 #include <boost/thread/detail/delete.hpp>
 #include <boost/core/no_exceptions_support.hpp>
 
-#include <boost/bind/bind.hpp>
 #include <boost/assert.hpp>
-#include <boost/config/abi_prefix.hpp>
-
 #include <boost/cstdint.hpp>
 #include <pthread.h>
 #include <csignal>
+
+#if !defined(BOOST_THREAD_PROVIDES_INVOKE) && !defined(BOOST_THREAD_PROVIDES_INVOKE_RET)
+#include <boost/bind/bind.hpp>
+#endif
+
+#include <boost/config/abi_prefix.hpp>
 
 namespace boost
 {

--- a/include/boost/thread/pthread/once_atomic.hpp
+++ b/include/boost/thread/pthread/once_atomic.hpp
@@ -16,8 +16,12 @@
 #include <boost/thread/detail/move.hpp>
 #include <boost/thread/detail/invoke.hpp>
 #include <boost/core/no_exceptions_support.hpp>
+#include <boost/atomic/capabilities.hpp>
+#include <boost/atomic/atomic.hpp>
+
+#if !defined(BOOST_THREAD_PROVIDES_INVOKE) && !defined(BOOST_THREAD_PROVIDES_INVOKE_RET)
 #include <boost/bind/bind.hpp>
-#include <boost/atomic.hpp>
+#endif
 
 #include <boost/config/abi_prefix.hpp>
 

--- a/include/boost/thread/pthread/shared_mutex.hpp
+++ b/include/boost/thread/pthread/shared_mutex.hpp
@@ -171,7 +171,7 @@ namespace boost
             boost::this_thread::disable_interruption do_not_disturb;
 #endif
             boost::unique_lock<boost::mutex> lk(state_change);
-            shared_cond.wait(lk, boost::bind(&state_data::can_lock_shared, boost::ref(state)));
+            shared_cond.wait(lk, boost::bind(&state_data::can_lock_shared, &state));
             state.lock_shared();
         }
 
@@ -194,7 +194,7 @@ namespace boost
             boost::this_thread::disable_interruption do_not_disturb;
 #endif
             boost::unique_lock<boost::mutex> lk(state_change);
-            if(!shared_cond.timed_wait(lk, timeout, boost::bind(&state_data::can_lock_shared, boost::ref(state))))
+            if(!shared_cond.timed_wait(lk, timeout, boost::bind(&state_data::can_lock_shared, &state)))
             {
                 return false;
             }
@@ -209,7 +209,7 @@ namespace boost
             boost::this_thread::disable_interruption do_not_disturb;
 #endif
             boost::unique_lock<boost::mutex> lk(state_change);
-            if(!shared_cond.timed_wait(lk, relative_time, boost::bind(&state_data::can_lock_shared, boost::ref(state))))
+            if(!shared_cond.timed_wait(lk, relative_time, boost::bind(&state_data::can_lock_shared, &state)))
             {
                 return false;
             }
@@ -230,7 +230,7 @@ namespace boost
           boost::this_thread::disable_interruption do_not_disturb;
 #endif
           boost::unique_lock<boost::mutex> lk(state_change);
-          if(!shared_cond.wait_until(lk, abs_time, boost::bind(&state_data::can_lock_shared, boost::ref(state))))
+          if(!shared_cond.wait_until(lk, abs_time, boost::bind(&state_data::can_lock_shared, &state)))
           {
               return false;
           }
@@ -270,7 +270,7 @@ namespace boost
 #endif
             boost::unique_lock<boost::mutex> lk(state_change);
             state.exclusive_waiting_blocked=true;
-            exclusive_cond.wait(lk, boost::bind(&state_data::can_lock, boost::ref(state)));
+            exclusive_cond.wait(lk, boost::bind(&state_data::can_lock, &state));
             state.exclusive=true;
         }
 
@@ -282,7 +282,7 @@ namespace boost
 #endif
             boost::unique_lock<boost::mutex> lk(state_change);
             state.exclusive_waiting_blocked=true;
-            if(!exclusive_cond.timed_wait(lk, timeout, boost::bind(&state_data::can_lock, boost::ref(state))))
+            if(!exclusive_cond.timed_wait(lk, timeout, boost::bind(&state_data::can_lock, &state)))
             {
                 state.exclusive_waiting_blocked=false;
                 release_waiters();
@@ -300,7 +300,7 @@ namespace boost
 #endif
             boost::unique_lock<boost::mutex> lk(state_change);
             state.exclusive_waiting_blocked=true;
-            if(!exclusive_cond.timed_wait(lk, relative_time, boost::bind(&state_data::can_lock, boost::ref(state))))
+            if(!exclusive_cond.timed_wait(lk, relative_time, boost::bind(&state_data::can_lock, &state)))
             {
                 state.exclusive_waiting_blocked=false;
                 release_waiters();
@@ -324,7 +324,7 @@ namespace boost
 #endif
           boost::unique_lock<boost::mutex> lk(state_change);
           state.exclusive_waiting_blocked=true;
-          if(!exclusive_cond.wait_until(lk, abs_time, boost::bind(&state_data::can_lock, boost::ref(state))))
+          if(!exclusive_cond.wait_until(lk, abs_time, boost::bind(&state_data::can_lock, &state)))
           {
               state.exclusive_waiting_blocked=false;
               release_waiters();
@@ -362,7 +362,7 @@ namespace boost
             boost::this_thread::disable_interruption do_not_disturb;
 #endif
             boost::unique_lock<boost::mutex> lk(state_change);
-            shared_cond.wait(lk, boost::bind(&state_data::can_lock_upgrade, boost::ref(state)));
+            shared_cond.wait(lk, boost::bind(&state_data::can_lock_upgrade, &state));
             state.lock_shared();
             state.upgrade=true;
         }
@@ -374,7 +374,7 @@ namespace boost
             boost::this_thread::disable_interruption do_not_disturb;
 #endif
             boost::unique_lock<boost::mutex> lk(state_change);
-            if(!shared_cond.timed_wait(lk, timeout, boost::bind(&state_data::can_lock_upgrade, boost::ref(state))))
+            if(!shared_cond.timed_wait(lk, timeout, boost::bind(&state_data::can_lock_upgrade, &state)))
             {
                 return false;
             }
@@ -390,7 +390,7 @@ namespace boost
             boost::this_thread::disable_interruption do_not_disturb;
 #endif
             boost::unique_lock<boost::mutex> lk(state_change);
-            if(!shared_cond.timed_wait(lk, relative_time, boost::bind(&state_data::can_lock_upgrade, boost::ref(state))))
+            if(!shared_cond.timed_wait(lk, relative_time, boost::bind(&state_data::can_lock_upgrade, &state)))
             {
                 return false;
             }
@@ -412,7 +412,7 @@ namespace boost
           boost::this_thread::disable_interruption do_not_disturb;
 #endif
           boost::unique_lock<boost::mutex> lk(state_change);
-          if(!shared_cond.wait_until(lk, abs_time, boost::bind(&state_data::can_lock_upgrade, boost::ref(state))))
+          if(!shared_cond.wait_until(lk, abs_time, boost::bind(&state_data::can_lock_upgrade, &state)))
           {
               return false;
           }
@@ -457,7 +457,7 @@ namespace boost
             boost::unique_lock<boost::mutex> lk(state_change);
             state.assert_lock_upgraded();
             state.unlock_shared();
-            upgrade_cond.wait(lk, boost::bind(&state_data::no_shared, boost::ref(state)));
+            upgrade_cond.wait(lk, boost::bind(&state_data::no_shared, &state));
             state.upgrade=false;
             state.exclusive=true;
             state.assert_locked();
@@ -511,7 +511,7 @@ namespace boost
 #endif
           boost::unique_lock<boost::mutex> lk(state_change);
           state.assert_lock_upgraded();
-          if(!shared_cond.wait_until(lk, abs_time, boost::bind(&state_data::one_shared, boost::ref(state))))
+          if(!shared_cond.wait_until(lk, abs_time, boost::bind(&state_data::one_shared, &state)))
           {
               return false;
           }
@@ -569,7 +569,7 @@ namespace boost
 #endif
           boost::unique_lock<boost::mutex> lk(state_change);
           state.assert_lock_shared();
-          if(!shared_cond.wait_until(lk, abs_time, boost::bind(&state_data::one_shared, boost::ref(state))))
+          if(!shared_cond.wait_until(lk, abs_time, boost::bind(&state_data::one_shared, &state)))
           {
               return false;
           }
@@ -623,7 +623,7 @@ namespace boost
 #endif
           boost::unique_lock<boost::mutex> lk(state_change);
           state.assert_lock_shared();
-          if(!exclusive_cond.wait_until(lk, abs_time, boost::bind(&state_data::can_lock_upgrade, boost::ref(state))))
+          if(!exclusive_cond.wait_until(lk, abs_time, boost::bind(&state_data::can_lock_upgrade, &state)))
           {
               return false;
           }

--- a/include/boost/thread/v2/shared_mutex.hpp
+++ b/include/boost/thread/v2/shared_mutex.hpp
@@ -275,9 +275,9 @@ namespace boost {
     inline void shared_mutex::lock()
     {
       boost::unique_lock<mutex_t> lk(mut_);
-      gate1_.wait(lk, boost::bind(&shared_mutex::no_writer, boost::ref(*this)));
+      gate1_.wait(lk, boost::bind(&shared_mutex::no_writer, this));
       state_ |= write_entered_;
-      gate2_.wait(lk, boost::bind(&shared_mutex::no_readers, boost::ref(*this)));
+      gate2_.wait(lk, boost::bind(&shared_mutex::no_readers, this));
     }
 
     inline bool shared_mutex::try_lock()
@@ -298,13 +298,13 @@ namespace boost {
     {
       boost::unique_lock<mutex_t> lk(mut_);
       if (!gate1_.wait_until(lk, abs_time, boost::bind(
-            &shared_mutex::no_writer, boost::ref(*this))))
+            &shared_mutex::no_writer, this)))
       {
         return false;
       }
       state_ |= write_entered_;
       if (!gate2_.wait_until(lk, abs_time, boost::bind(
-            &shared_mutex::no_readers, boost::ref(*this))))
+            &shared_mutex::no_readers, this)))
       {
         state_ &= ~write_entered_;
         return false;
@@ -319,13 +319,13 @@ namespace boost {
     {
       boost::unique_lock<mutex_t> lk(mut_);
       if (!gate1_.timed_wait(lk, abs_or_rel_time, boost::bind(
-            &shared_mutex::no_writer, boost::ref(*this))))
+            &shared_mutex::no_writer, this)))
       {
         return false;
       }
       state_ |= write_entered_;
       if (!gate2_.timed_wait(lk, abs_or_rel_time, boost::bind(
-            &shared_mutex::no_readers, boost::ref(*this))))
+            &shared_mutex::no_readers, this)))
       {
         state_ &= ~write_entered_;
         return false;
@@ -350,7 +350,7 @@ namespace boost {
     inline void shared_mutex::lock_shared()
     {
       boost::unique_lock<mutex_t> lk(mut_);
-      gate1_.wait(lk, boost::bind(&shared_mutex::no_writer_no_max_readers, boost::ref(*this)));
+      gate1_.wait(lk, boost::bind(&shared_mutex::no_writer_no_max_readers, this));
       count_t num_readers = (state_ & n_readers_) + 1;
       state_ &= ~n_readers_;
       state_ |= num_readers;
@@ -376,7 +376,7 @@ namespace boost {
     {
       boost::unique_lock<mutex_t> lk(mut_);
       if (!gate1_.wait_until(lk, abs_time, boost::bind(
-            &shared_mutex::no_writer_no_max_readers, boost::ref(*this))))
+            &shared_mutex::no_writer_no_max_readers, this)))
       {
         return false;
       }
@@ -393,7 +393,7 @@ namespace boost {
     {
       boost::unique_lock<mutex_t> lk(mut_);
       if (!gate1_.timed_wait(lk, abs_or_rel_time, boost::bind(
-            &shared_mutex::no_writer_no_max_readers, boost::ref(*this))))
+            &shared_mutex::no_writer_no_max_readers, this)))
       {
         return false;
       }
@@ -653,9 +653,9 @@ namespace boost {
     inline void upgrade_mutex::lock()
     {
       boost::unique_lock<mutex_t> lk(mut_);
-      gate1_.wait(lk, boost::bind(&upgrade_mutex::no_writer_no_upgrader, boost::ref(*this)));
+      gate1_.wait(lk, boost::bind(&upgrade_mutex::no_writer_no_upgrader, this));
       state_ |= write_entered_;
-      gate2_.wait(lk, boost::bind(&upgrade_mutex::no_readers, boost::ref(*this)));
+      gate2_.wait(lk, boost::bind(&upgrade_mutex::no_readers, this));
     }
 
     inline bool upgrade_mutex::try_lock()
@@ -676,13 +676,13 @@ namespace boost {
     {
       boost::unique_lock<mutex_t> lk(mut_);
       if (!gate1_.wait_until(lk, abs_time, boost::bind(
-            &upgrade_mutex::no_writer_no_upgrader, boost::ref(*this))))
+            &upgrade_mutex::no_writer_no_upgrader, this)))
       {
         return false;
       }
       state_ |= write_entered_;
       if (!gate2_.wait_until(lk, abs_time, boost::bind(
-            &upgrade_mutex::no_readers, boost::ref(*this))))
+            &upgrade_mutex::no_readers, this)))
       {
         state_ &= ~write_entered_;
         return false;
@@ -697,13 +697,13 @@ namespace boost {
     {
       boost::unique_lock<mutex_t> lk(mut_);
       if (!gate1_.timed_wait(lk, abs_or_rel_time, boost::bind(
-            &upgrade_mutex::no_writer_no_upgrader, boost::ref(*this))))
+            &upgrade_mutex::no_writer_no_upgrader, this)))
       {
         return false;
       }
       state_ |= write_entered_;
       if (!gate2_.timed_wait(lk, abs_or_rel_time, boost::bind(
-            &upgrade_mutex::no_readers, boost::ref(*this))))
+            &upgrade_mutex::no_readers, this)))
       {
         state_ &= ~write_entered_;
         return false;
@@ -729,7 +729,7 @@ namespace boost {
     inline void upgrade_mutex::lock_shared()
     {
       boost::unique_lock<mutex_t> lk(mut_);
-      gate1_.wait(lk, boost::bind(&upgrade_mutex::no_writer_no_max_readers, boost::ref(*this)));
+      gate1_.wait(lk, boost::bind(&upgrade_mutex::no_writer_no_max_readers, this));
       count_t num_readers = (state_ & n_readers_) + 1;
       state_ &= ~n_readers_;
       state_ |= num_readers;
@@ -755,7 +755,7 @@ namespace boost {
     {
       boost::unique_lock<mutex_t> lk(mut_);
       if (!gate1_.wait_until(lk, abs_time, boost::bind(
-            &upgrade_mutex::no_writer_no_max_readers, boost::ref(*this))))
+            &upgrade_mutex::no_writer_no_max_readers, this)))
       {
         return false;
       }
@@ -772,7 +772,7 @@ namespace boost {
     {
       boost::unique_lock<mutex_t> lk(mut_);
       if (!gate1_.timed_wait(lk, abs_or_rel_time, boost::bind(
-            &upgrade_mutex::no_writer_no_max_readers, boost::ref(*this))))
+            &upgrade_mutex::no_writer_no_max_readers, this)))
       {
         return false;
       }
@@ -807,7 +807,7 @@ namespace boost {
     inline void upgrade_mutex::lock_upgrade()
     {
       boost::unique_lock<mutex_t> lk(mut_);
-      gate1_.wait(lk, boost::bind(&upgrade_mutex::no_writer_no_upgrader_no_max_readers, boost::ref(*this)));
+      gate1_.wait(lk, boost::bind(&upgrade_mutex::no_writer_no_upgrader_no_max_readers, this));
       count_t num_readers = (state_ & n_readers_) + 1;
       state_ &= ~n_readers_;
       state_ |= upgradable_entered_ | num_readers;
@@ -833,7 +833,7 @@ namespace boost {
     {
       boost::unique_lock<mutex_t> lk(mut_);
       if (!gate1_.wait_until(lk, abs_time, boost::bind(
-            &upgrade_mutex::no_writer_no_upgrader_no_max_readers, boost::ref(*this))))
+            &upgrade_mutex::no_writer_no_upgrader_no_max_readers, this)))
       {
         return false;
       }
@@ -850,7 +850,7 @@ namespace boost {
     {
       boost::unique_lock<mutex_t> lk(mut_);
       if (!gate1_.timed_wait(lk, abs_or_rel_time, boost::bind(
-            &upgrade_mutex::no_writer_no_upgrader_no_max_readers, boost::ref(*this))))
+            &upgrade_mutex::no_writer_no_upgrader_no_max_readers, this)))
       {
         return false;
       }
@@ -898,7 +898,7 @@ namespace boost {
       boost::unique_lock<mutex_t> lk(mut_);
       BOOST_ASSERT(one_or_more_readers());
       if (!gate1_.wait_until(lk, abs_time, boost::bind(
-            &upgrade_mutex::no_writer_no_upgrader, boost::ref(*this))))
+            &upgrade_mutex::no_writer_no_upgrader, this)))
       {
         return false;
       }
@@ -906,7 +906,7 @@ namespace boost {
       state_ &= ~n_readers_;
       state_ |= (write_entered_ | num_readers);
       if (!gate2_.wait_until(lk, abs_time, boost::bind(
-            &upgrade_mutex::no_readers, boost::ref(*this))))
+            &upgrade_mutex::no_readers, this)))
       {
         ++num_readers;
         state_ &= ~(write_entered_ | n_readers_);
@@ -953,7 +953,7 @@ namespace boost {
       boost::unique_lock<mutex_t> lk(mut_);
       BOOST_ASSERT(one_or_more_readers());
       if (!gate1_.wait_until(lk, abs_time, boost::bind(
-            &upgrade_mutex::no_writer_no_upgrader, boost::ref(*this))))
+            &upgrade_mutex::no_writer_no_upgrader, this)))
       {
         return false;
       }
@@ -987,7 +987,7 @@ namespace boost {
       count_t num_readers = (state_ & n_readers_) - 1;
       state_ &= ~(upgradable_entered_ | n_readers_);
       state_ |= write_entered_ | num_readers;
-      gate2_.wait(lk, boost::bind(&upgrade_mutex::no_readers, boost::ref(*this)));
+      gate2_.wait(lk, boost::bind(&upgrade_mutex::no_readers, this));
     }
 
     inline bool upgrade_mutex::try_unlock_upgrade_and_lock()
@@ -1017,7 +1017,7 @@ namespace boost {
       state_ &= ~(upgradable_entered_ | n_readers_);
       state_ |= (write_entered_ | num_readers);
       if (!gate2_.wait_until(lk, abs_time, boost::bind(
-            &upgrade_mutex::no_readers, boost::ref(*this))))
+            &upgrade_mutex::no_readers, this)))
       {
         ++num_readers;
         state_ &= ~(write_entered_ | n_readers_);

--- a/include/boost/thread/win32/once.hpp
+++ b/include/boost/thread/win32/once.hpp
@@ -22,7 +22,9 @@
 #include <boost/thread/detail/move.hpp>
 #include <boost/thread/detail/invoke.hpp>
 
+#if !defined(BOOST_THREAD_PROVIDES_INVOKE) && !defined(BOOST_THREAD_PROVIDES_INVOKE_RET)
 #include <boost/bind/bind.hpp>
+#endif
 
 #include <boost/config/abi_prefix.hpp>
 
@@ -152,7 +154,7 @@ namespace boost
             {
                 name_once_mutex(mutex_name,flag_address);
             }
-            
+
             return ::boost::detail::win32::create_event(
                 mutex_name, 
                 ::boost::detail::win32::manual_reset_event,

--- a/src/pthread/once_atomic.cpp
+++ b/src/pthread/once_atomic.cpp
@@ -11,8 +11,8 @@
 #include <boost/thread/pthread/pthread_mutex_scoped_lock.hpp>
 #include <boost/assert.hpp>
 #include <boost/static_assert.hpp>
-#include <boost/atomic.hpp>
 #include <boost/memory_order.hpp>
+#include <boost/atomic/atomic.hpp>
 #include <pthread.h>
 
 namespace boost

--- a/test/experimental/parallel/v1/exception_list_pass.cpp
+++ b/test/experimental/parallel/v1/exception_list_pass.cpp
@@ -14,7 +14,7 @@
 
 #include <boost/thread/experimental/parallel/v1/exception_list.hpp>
 
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 
 int main()

--- a/test/experimental/parallel/v2/task_region_pass.cpp
+++ b/test/experimental/parallel/v2/task_region_pass.cpp
@@ -16,7 +16,7 @@
 #include <boost/thread/experimental/parallel/v2/task_region.hpp>
 #include <string>
 
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 #if ! defined BOOST_NO_CXX11_LAMBDAS  && defined(BOOST_THREAD_PROVIDES_INVOKE)
 using boost::experimental::parallel::v2::task_region;

--- a/test/functional/invoke/invoke_int_0_pass.cpp
+++ b/test/functional/invoke/invoke_int_0_pass.cpp
@@ -15,7 +15,7 @@
 // <boost/thread/detail/invoke.hpp>
 
 #include <boost/thread/detail/invoke.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 int f()
 {

--- a/test/functional/invoke/invoke_lvalue_pass.cpp
+++ b/test/functional/invoke/invoke_lvalue_pass.cpp
@@ -16,7 +16,7 @@
 // <boost/thread/detail/invoke.hpp>
 
 #include <boost/thread/detail/invoke.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 int count = 0;
 

--- a/test/functional/invoke/invoke_rvalue_pass.cpp
+++ b/test/functional/invoke/invoke_rvalue_pass.cpp
@@ -15,7 +15,7 @@
 // <boost/thread/detail/invoke.hpp>
 
 #include <boost/thread/detail/invoke.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 int count = 0;
 

--- a/test/functional/invoker/invoker_int_0_pass.cpp
+++ b/test/functional/invoker/invoker_int_0_pass.cpp
@@ -15,7 +15,7 @@
 // <boost/thread/detail/invoker.hpp>
 
 #include <boost/thread/detail/invoker.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 int f()
 {

--- a/test/functional/invoker/invoker_lvalue_pass.cpp
+++ b/test/functional/invoker/invoker_lvalue_pass.cpp
@@ -15,7 +15,7 @@
 // <boost/thread/detail/invoker.hpp>
 
 #include <boost/thread/detail/invoker.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 int count = 0;
 

--- a/test/functional/invoker/invoker_rvalue_pass.cpp
+++ b/test/functional/invoker/invoker_rvalue_pass.cpp
@@ -19,7 +19,7 @@
 #endif
 
 #include <boost/thread/detail/invoker.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 int count = 0;
 

--- a/test/sync/conditions/condition_variable/copy_fail.cpp
+++ b/test/sync/conditions/condition_variable/copy_fail.cpp
@@ -18,7 +18,7 @@
 // condition_variable(const condition_variable&) = delete;
 
 #include <boost/thread/condition_variable.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 void fail()
 {

--- a/test/sync/conditions/condition_variable/default_pass.cpp
+++ b/test/sync/conditions/condition_variable/default_pass.cpp
@@ -18,7 +18,7 @@
 // condition_variable(const condition_variable&) = delete;
 
 #include <boost/thread/condition_variable.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 int main()
 {

--- a/test/sync/conditions/condition_variable/dtor_pass.cpp
+++ b/test/sync/conditions/condition_variable/dtor_pass.cpp
@@ -21,7 +21,7 @@
 #include <boost/thread/mutex.hpp>
 #include <boost/thread/thread.hpp>
 #include <boost/thread/locks.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 boost::condition_variable* cv;
 boost::mutex m;

--- a/test/sync/conditions/condition_variable/lost_notif_pass.cpp
+++ b/test/sync/conditions/condition_variable/lost_notif_pass.cpp
@@ -21,7 +21,7 @@
 #include <boost/thread/condition_variable.hpp>
 #include <boost/thread/mutex.hpp>
 #include <boost/thread/thread.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 #include <cassert>
 
 // Summary of each test:

--- a/test/sync/conditions/condition_variable/native_handle_pass.cpp
+++ b/test/sync/conditions/condition_variable/native_handle_pass.cpp
@@ -20,7 +20,8 @@
 #include <boost/thread/condition_variable.hpp>
 
 #include <boost/static_assert.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/type_traits/is_same.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 int main()
 {

--- a/test/sync/conditions/condition_variable/wait_for_pass.cpp
+++ b/test/sync/conditions/condition_variable/wait_for_pass.cpp
@@ -21,7 +21,7 @@
 #include <boost/thread/condition_variable.hpp>
 #include <boost/thread/mutex.hpp>
 #include <boost/thread/thread.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 #include <cassert>
 #include "../../../timming.hpp"
 

--- a/test/sync/conditions/condition_variable/wait_for_pred_pass.cpp
+++ b/test/sync/conditions/condition_variable/wait_for_pred_pass.cpp
@@ -20,7 +20,7 @@
 #include <boost/thread/condition_variable.hpp>
 #include <boost/thread/mutex.hpp>
 #include <boost/thread/thread.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 #include <cassert>
 #include <iostream>
 #include "../../../timming.hpp"

--- a/test/sync/conditions/condition_variable/wait_pass.cpp
+++ b/test/sync/conditions/condition_variable/wait_pass.cpp
@@ -21,7 +21,7 @@
 #include <boost/thread/condition_variable.hpp>
 #include <boost/thread/mutex.hpp>
 #include <boost/thread/thread.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 #include <cassert>
 #include <iostream>
 

--- a/test/sync/conditions/condition_variable/wait_until_pass.cpp
+++ b/test/sync/conditions/condition_variable/wait_until_pass.cpp
@@ -20,7 +20,7 @@
 #include <boost/thread/condition_variable.hpp>
 #include <boost/thread/mutex.hpp>
 #include <boost/thread/thread.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 #include <iostream>
 #include <cassert>
 #include "../../../timming.hpp"

--- a/test/sync/conditions/condition_variable/wait_until_pred_pass.cpp
+++ b/test/sync/conditions/condition_variable/wait_until_pred_pass.cpp
@@ -20,7 +20,7 @@
 #include <boost/thread/condition_variable.hpp>
 #include <boost/thread/mutex.hpp>
 #include <boost/thread/thread.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 #include <cassert>
 #include <iostream>
 #include "../../../timming.hpp"

--- a/test/sync/conditions/condition_variable_any/copy_fail.cpp
+++ b/test/sync/conditions/condition_variable_any/copy_fail.cpp
@@ -18,7 +18,7 @@
 // condition_variable_any(const condition_variable_any&) = delete;
 
 #include <boost/thread/condition_variable.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 void fail()
 {

--- a/test/sync/conditions/condition_variable_any/default_pass.cpp
+++ b/test/sync/conditions/condition_variable_any/default_pass.cpp
@@ -18,7 +18,7 @@
 // condition_variable_any(const condition_variable_any&) = delete;
 
 #include <boost/thread/condition_variable.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 int main()
 {

--- a/test/sync/conditions/condition_variable_any/dtor_pass.cpp
+++ b/test/sync/conditions/condition_variable_any/dtor_pass.cpp
@@ -21,7 +21,7 @@
 #include <boost/thread/mutex.hpp>
 #include <boost/thread/thread.hpp>
 #include <boost/thread/locks.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 boost::condition_variable_any* cv;
 boost::timed_mutex m;

--- a/test/sync/conditions/condition_variable_any/lost_notif_pass.cpp
+++ b/test/sync/conditions/condition_variable_any/lost_notif_pass.cpp
@@ -21,7 +21,7 @@
 #include <boost/thread/condition_variable.hpp>
 #include <boost/thread/mutex.hpp>
 #include <boost/thread/thread.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 #include <cassert>
 
 // Summary of each test:

--- a/test/sync/conditions/condition_variable_any/wait_for_pass.cpp
+++ b/test/sync/conditions/condition_variable_any/wait_for_pass.cpp
@@ -20,7 +20,7 @@
 #include <boost/thread/condition_variable.hpp>
 #include <boost/thread/mutex.hpp>
 #include <boost/thread/thread.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 #include "../../../timming.hpp"
 
 #if defined BOOST_THREAD_USES_CHRONO

--- a/test/sync/conditions/condition_variable_any/wait_for_pred_pass.cpp
+++ b/test/sync/conditions/condition_variable_any/wait_for_pred_pass.cpp
@@ -20,7 +20,7 @@
 #include <boost/thread/condition_variable.hpp>
 #include <boost/thread/mutex.hpp>
 #include <boost/thread/thread.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 #include "../../../timming.hpp"
 
 #if defined BOOST_THREAD_USES_CHRONO

--- a/test/sync/conditions/condition_variable_any/wait_until_pass.cpp
+++ b/test/sync/conditions/condition_variable_any/wait_until_pass.cpp
@@ -20,7 +20,7 @@
 #include <boost/thread/condition_variable.hpp>
 #include <boost/thread/mutex.hpp>
 #include <boost/thread/thread.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 #include "../../../timming.hpp"
 
 #if defined BOOST_THREAD_USES_CHRONO

--- a/test/sync/conditions/condition_variable_any/wait_until_pred_pass.cpp
+++ b/test/sync/conditions/condition_variable_any/wait_until_pred_pass.cpp
@@ -20,7 +20,7 @@
 #include <boost/thread/condition_variable.hpp>
 #include <boost/thread/mutex.hpp>
 #include <boost/thread/thread.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 #include "../../../timming.hpp"
 
 #if defined BOOST_THREAD_USES_CHRONO

--- a/test/sync/conditions/cv_status/cv_status_pass.cpp
+++ b/test/sync/conditions/cv_status/cv_status_pass.cpp
@@ -18,7 +18,7 @@
 // static unsigned hardware_concurrency();
 
 #include <boost/thread/condition_variable.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 int main()
 {

--- a/test/sync/conditions/notify_all_at_thread_exit_pass.cpp
+++ b/test/sync/conditions/notify_all_at_thread_exit_pass.cpp
@@ -23,7 +23,7 @@
 #include <boost/thread/locks.hpp>
 #include <boost/thread/thread.hpp>
 #include <boost/chrono/chrono.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 boost::condition_variable cv;
 boost::mutex mut;

--- a/test/sync/futures/async/async_executor_pass.cpp
+++ b/test/sync/futures/async/async_executor_pass.cpp
@@ -29,7 +29,7 @@
 #include <boost/thread/detail/memory.hpp>
 #include <boost/thread/csbl/memory/unique_ptr.hpp>
 #include <memory>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 #include <boost/thread/executors/basic_thread_pool.hpp>
 #include <boost/thread/executor.hpp>
 

--- a/test/sync/futures/async/async_pass.cpp
+++ b/test/sync/futures/async/async_pass.cpp
@@ -34,7 +34,7 @@
 #include <boost/thread/detail/memory.hpp>
 #include <boost/thread/csbl/memory/unique_ptr.hpp>
 #include <memory>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 typedef boost::chrono::high_resolution_clock Clock;
 typedef boost::chrono::milliseconds ms;

--- a/test/sync/futures/future/async_deferred_then_pass.cpp
+++ b/test/sync/futures/future/async_deferred_then_pass.cpp
@@ -16,7 +16,7 @@
 #include <boost/thread/detail/log.hpp>
 
 #include <boost/thread/future.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 #if defined BOOST_THREAD_PROVIDES_FUTURE_CONTINUATION && defined(BOOST_THREAD_PROVIDES_VARIADIC_THREAD)
 

--- a/test/sync/futures/future/copy_assign_fail.cpp
+++ b/test/sync/futures/future/copy_assign_fail.cpp
@@ -21,7 +21,7 @@
 
 #define BOOST_THREAD_VERSION 3
 #include <boost/thread/future.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 int main()
 {

--- a/test/sync/futures/future/copy_ctor_fail.cpp
+++ b/test/sync/futures/future/copy_ctor_fail.cpp
@@ -20,7 +20,7 @@
 
 #define BOOST_THREAD_VERSION 3
 #include <boost/thread/future.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 int main()
 {

--- a/test/sync/futures/future/default_pass.cpp
+++ b/test/sync/futures/future/default_pass.cpp
@@ -21,7 +21,7 @@
 #define BOOST_THREAD_VERSION 3
 
 #include <boost/thread/future.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 int main()
 {

--- a/test/sync/futures/future/dtor_pass.cpp
+++ b/test/sync/futures/future/dtor_pass.cpp
@@ -22,7 +22,7 @@
 #include <boost/exception/exception.hpp>
 
 #include <boost/thread/future.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 #if defined BOOST_THREAD_PROVIDES_FUTURE_CTOR_ALLOCATORS
 #include "../test_allocator.hpp"
 #endif

--- a/test/sync/futures/future/get_or_pass.cpp
+++ b/test/sync/futures/future/get_or_pass.cpp
@@ -18,7 +18,7 @@
 #include <boost/thread/future.hpp>
 #include <boost/thread/thread.hpp>
 #include <boost/core/ref.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 #if defined BOOST_THREAD_USES_CHRONO
 

--- a/test/sync/futures/future/get_pass.cpp
+++ b/test/sync/futures/future/get_pass.cpp
@@ -28,7 +28,7 @@
 
 #include <boost/thread/future.hpp>
 #include <boost/thread/thread.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 #if defined BOOST_THREAD_USES_CHRONO
 

--- a/test/sync/futures/future/move_assign_pass.cpp
+++ b/test/sync/futures/future/move_assign_pass.cpp
@@ -21,7 +21,7 @@
 #define BOOST_THREAD_VERSION 3
 
 #include <boost/thread/future.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 boost::mutex m0;
 boost::mutex m1;

--- a/test/sync/futures/future/move_ctor_pass.cpp
+++ b/test/sync/futures/future/move_ctor_pass.cpp
@@ -21,7 +21,7 @@
 #define BOOST_THREAD_VERSION 3
 
 #include <boost/thread/future.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 boost::mutex m;
 

--- a/test/sync/futures/future/share_pass.cpp
+++ b/test/sync/futures/future/share_pass.cpp
@@ -21,7 +21,7 @@
 #define BOOST_THREAD_VERSION 3
 
 #include <boost/thread/future.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 int main()
 {

--- a/test/sync/futures/future/then_deferred_pass.cpp
+++ b/test/sync/futures/future/then_deferred_pass.cpp
@@ -16,7 +16,7 @@
 #include <boost/thread/detail/log.hpp>
 
 #include <boost/thread/future.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 #include <cassert>
 
 #if defined BOOST_THREAD_PROVIDES_FUTURE_CONTINUATION

--- a/test/sync/futures/future/then_executor_pass.cpp
+++ b/test/sync/futures/future/then_executor_pass.cpp
@@ -18,7 +18,7 @@
 #include <boost/thread/future.hpp>
 #include <boost/thread/executors/basic_thread_pool.hpp>
 #include <boost/thread/executor.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 #include <cassert>
 
 #if defined BOOST_THREAD_PROVIDES_FUTURE_CONTINUATION

--- a/test/sync/futures/future/then_pass.cpp
+++ b/test/sync/futures/future/then_pass.cpp
@@ -16,7 +16,7 @@
 #include <boost/thread/detail/log.hpp>
 
 #include <boost/thread/future.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 #if defined BOOST_THREAD_PROVIDES_FUTURE_CONTINUATION
 

--- a/test/sync/futures/future/wait_for_pass.cpp
+++ b/test/sync/futures/future/wait_for_pass.cpp
@@ -29,7 +29,7 @@
 #include <boost/thread/future.hpp>
 #include <boost/thread/thread.hpp>
 #include <boost/chrono/chrono_io.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 #if defined BOOST_THREAD_USES_CHRONO
 

--- a/test/sync/futures/future/wait_pass.cpp
+++ b/test/sync/futures/future/wait_pass.cpp
@@ -28,7 +28,7 @@
 #include <boost/thread/future.hpp>
 #include <boost/thread/thread.hpp>
 #include <boost/chrono/chrono_io.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 #if defined BOOST_THREAD_USES_CHRONO
 

--- a/test/sync/futures/future/wait_until_pass.cpp
+++ b/test/sync/futures/future/wait_until_pass.cpp
@@ -29,7 +29,7 @@
 #include <boost/thread/future.hpp>
 #include <boost/thread/thread.hpp>
 #include <boost/chrono/chrono_io.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 #include "../../../timming.hpp"
 
 #if defined BOOST_THREAD_USES_CHRONO

--- a/test/sync/futures/make_ready_future_pass.cpp
+++ b/test/sync/futures/make_ready_future_pass.cpp
@@ -29,7 +29,7 @@
 #define BOOST_THREAD_VERSION 3
 
 #include <boost/thread/future.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 #include <boost/static_assert.hpp>
 
 struct A

--- a/test/sync/futures/packaged_task/alloc_ctor_pass.cpp
+++ b/test/sync/futures/packaged_task/alloc_ctor_pass.cpp
@@ -29,7 +29,7 @@
 
 #include <boost/thread/detail/config.hpp>
 #include <boost/thread/future.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 
 #if defined BOOST_THREAD_PROVIDES_FUTURE_CTOR_ALLOCATORS

--- a/test/sync/futures/packaged_task/copy_assign_fail.cpp
+++ b/test/sync/futures/packaged_task/copy_assign_fail.cpp
@@ -26,7 +26,7 @@
 #endif
 
 #include <boost/thread/future.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 class A
 {

--- a/test/sync/futures/packaged_task/copy_ctor_fail.cpp
+++ b/test/sync/futures/packaged_task/copy_ctor_fail.cpp
@@ -26,7 +26,7 @@
 #endif
 
 #include <boost/thread/future.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 class A
 {

--- a/test/sync/futures/packaged_task/default_ctor_pass.cpp
+++ b/test/sync/futures/packaged_task/default_ctor_pass.cpp
@@ -26,7 +26,7 @@
 #endif
 
 #include <boost/thread/future.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 #include <string>
 
 int main()

--- a/test/sync/futures/packaged_task/dtor_pass.cpp
+++ b/test/sync/futures/packaged_task/dtor_pass.cpp
@@ -24,7 +24,7 @@
 
 #include <boost/thread/future.hpp>
 #include <boost/thread/thread.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 #if BOOST_THREAD_VERSION == 4
 #define BOOST_THREAD_DETAIL_SIGNATURE double()

--- a/test/sync/futures/packaged_task/func_ctor_pass.cpp
+++ b/test/sync/futures/packaged_task/func_ctor_pass.cpp
@@ -22,7 +22,7 @@
 #define BOOST_THREAD_VERSION 4
 
 #include <boost/thread/future.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 #if BOOST_THREAD_VERSION == 4
 #define BOOST_THREAD_DETAIL_SIGNATURE double()

--- a/test/sync/futures/packaged_task/get_future_pass.cpp
+++ b/test/sync/futures/packaged_task/get_future_pass.cpp
@@ -27,7 +27,7 @@
 #endif
 
 #include <boost/thread/future.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 class A
 {

--- a/test/sync/futures/packaged_task/make_ready_at_thread_exit_pass.cpp
+++ b/test/sync/futures/packaged_task/make_ready_at_thread_exit_pass.cpp
@@ -21,7 +21,7 @@
 #define BOOST_THREAD_VERSION 4
 
 #include <boost/thread/future.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 #if defined BOOST_THREAD_USES_CHRONO && \
     defined BOOST_THREAD_PROVIDES_SIGNATURE_PACKAGED_TASK && \

--- a/test/sync/futures/packaged_task/member_swap_pass.cpp
+++ b/test/sync/futures/packaged_task/member_swap_pass.cpp
@@ -26,7 +26,7 @@
 #endif
 
 #include <boost/thread/future.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 class A
 {

--- a/test/sync/futures/packaged_task/move_assign_pass.cpp
+++ b/test/sync/futures/packaged_task/move_assign_pass.cpp
@@ -26,7 +26,7 @@
 #endif
 
 #include <boost/thread/future.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 class A
 {

--- a/test/sync/futures/packaged_task/move_ctor_pass.cpp
+++ b/test/sync/futures/packaged_task/move_ctor_pass.cpp
@@ -26,7 +26,7 @@
 #endif
 
 #include <boost/thread/future.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 class A
 {

--- a/test/sync/futures/packaged_task/non_member_swap_pass.cpp
+++ b/test/sync/futures/packaged_task/non_member_swap_pass.cpp
@@ -26,7 +26,7 @@
 #endif
 
 #include <boost/thread/future.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 class A
 {

--- a/test/sync/futures/packaged_task/operator_pass.cpp
+++ b/test/sync/futures/packaged_task/operator_pass.cpp
@@ -22,7 +22,7 @@
 #define BOOST_THREAD_VERSION 4
 
 #include <boost/thread/future.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 #if defined BOOST_THREAD_USES_CHRONO
 

--- a/test/sync/futures/packaged_task/reset_pass.cpp
+++ b/test/sync/futures/packaged_task/reset_pass.cpp
@@ -26,7 +26,7 @@
 #endif
 
 #include <boost/thread/future.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 class A
 {

--- a/test/sync/futures/packaged_task/types_pass.cpp
+++ b/test/sync/futures/packaged_task/types_pass.cpp
@@ -23,7 +23,8 @@
 
 #include <boost/thread/future.hpp>
 #include <boost/static_assert.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/type_traits/is_same.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 struct A {};
 

--- a/test/sync/futures/packaged_task/use_allocator_pass.cpp
+++ b/test/sync/futures/packaged_task/use_allocator_pass.cpp
@@ -29,7 +29,7 @@
 #endif
 
 #include <boost/thread/future.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 #include <boost/static_assert.hpp>
 
 #if defined BOOST_THREAD_PROVIDES_FUTURE_CTOR_ALLOCATORS

--- a/test/sync/futures/promise/alloc_ctor_pass.cpp
+++ b/test/sync/futures/promise/alloc_ctor_pass.cpp
@@ -21,7 +21,7 @@
 #define BOOST_THREAD_VERSION 3
 
 #include <boost/thread/future.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 #if defined BOOST_THREAD_PROVIDES_FUTURE_CTOR_ALLOCATORS
 #include "../test_allocator.hpp"
 

--- a/test/sync/futures/promise/copy_assign_fail.cpp
+++ b/test/sync/futures/promise/copy_assign_fail.cpp
@@ -18,7 +18,7 @@
 
 #define BOOST_THREAD_VERSION 3
 #include <boost/thread/future.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 int main()
 {

--- a/test/sync/futures/promise/copy_ctor_fail.cpp
+++ b/test/sync/futures/promise/copy_ctor_fail.cpp
@@ -18,7 +18,7 @@
 
 #define BOOST_THREAD_VERSION 3
 #include <boost/thread/future.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 int main()
 {

--- a/test/sync/futures/promise/default_pass.cpp
+++ b/test/sync/futures/promise/default_pass.cpp
@@ -21,7 +21,7 @@
 #define BOOST_THREAD_VERSION 3
 
 #include <boost/thread/future.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 int main()
 {

--- a/test/sync/futures/promise/dtor_pass.cpp
+++ b/test/sync/futures/promise/dtor_pass.cpp
@@ -21,7 +21,7 @@
 #define BOOST_THREAD_VERSION 3
 
 #include <boost/thread/future.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 int main()
 {

--- a/test/sync/futures/promise/emplace_pass.cpp
+++ b/test/sync/futures/promise/emplace_pass.cpp
@@ -22,7 +22,7 @@
 #define BOOST_THREAD_VERSION 3
 
 #include <boost/thread/future.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 #include <boost/static_assert.hpp>
 
 struct A

--- a/test/sync/futures/promise/get_future_pass.cpp
+++ b/test/sync/futures/promise/get_future_pass.cpp
@@ -21,7 +21,7 @@
 #define BOOST_THREAD_VERSION 3
 
 #include <boost/thread/future.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 int main()
 {

--- a/test/sync/futures/promise/move_assign_pass.cpp
+++ b/test/sync/futures/promise/move_assign_pass.cpp
@@ -21,7 +21,7 @@
 #define BOOST_THREAD_VERSION 3
 
 #include <boost/thread/future.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 #if defined BOOST_THREAD_PROVIDES_FUTURE_CTOR_ALLOCATORS
 #include "../test_allocator.hpp"
 #endif

--- a/test/sync/futures/promise/move_ctor_pass.cpp
+++ b/test/sync/futures/promise/move_ctor_pass.cpp
@@ -21,7 +21,7 @@
 #define BOOST_THREAD_VERSION 3
 
 #include <boost/thread/future.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 #if defined BOOST_THREAD_PROVIDES_FUTURE_CTOR_ALLOCATORS
 #include "../test_allocator.hpp"
 #endif

--- a/test/sync/futures/promise/set_exception_at_thread_exit_pass.cpp
+++ b/test/sync/futures/promise/set_exception_at_thread_exit_pass.cpp
@@ -21,7 +21,7 @@
 #define BOOST_THREAD_VERSION 4
 
 #include <boost/thread/future.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 #include <boost/static_assert.hpp>
 
 namespace boost

--- a/test/sync/futures/promise/set_exception_pass.cpp
+++ b/test/sync/futures/promise/set_exception_pass.cpp
@@ -21,7 +21,7 @@
 #define BOOST_THREAD_VERSION 3
 
 #include <boost/thread/future.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 #include <boost/static_assert.hpp>
 
 namespace boost

--- a/test/sync/futures/promise/set_lvalue_at_thread_exit_pass.cpp
+++ b/test/sync/futures/promise/set_lvalue_at_thread_exit_pass.cpp
@@ -21,7 +21,7 @@
 #define BOOST_THREAD_VERSION 4
 
 #include <boost/thread/future.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 #include <memory>
 
 int i = 0;

--- a/test/sync/futures/promise/set_lvalue_pass.cpp
+++ b/test/sync/futures/promise/set_lvalue_pass.cpp
@@ -21,7 +21,7 @@
 #define BOOST_THREAD_VERSION 3
 
 #include <boost/thread/future.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 #include <boost/static_assert.hpp>
 
 int main()

--- a/test/sync/futures/promise/set_rvalue_at_thread_exit_pass.cpp
+++ b/test/sync/futures/promise/set_rvalue_at_thread_exit_pass.cpp
@@ -21,7 +21,7 @@
 #define BOOST_THREAD_VERSION 3
 
 #include <boost/thread/future.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 #include <boost/thread/detail/memory.hpp>
 #include <boost/thread/csbl/memory/unique_ptr.hpp>
 

--- a/test/sync/futures/promise/set_rvalue_pass.cpp
+++ b/test/sync/futures/promise/set_rvalue_pass.cpp
@@ -21,7 +21,7 @@
 #define BOOST_THREAD_VERSION 3
 
 #include <boost/thread/future.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 #include <boost/static_assert.hpp>
 
 struct A

--- a/test/sync/futures/promise/set_value_at_thread_exit_const_pass.cpp
+++ b/test/sync/futures/promise/set_value_at_thread_exit_const_pass.cpp
@@ -21,7 +21,7 @@
 #define BOOST_THREAD_VERSION 4
 
 #include <boost/thread/future.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 #if defined BOOST_THREAD_PROVIDES_SIGNATURE_PACKAGED_TASK && defined(BOOST_THREAD_PROVIDES_VARIADIC_THREAD)
 void func(boost::promise<int> p)

--- a/test/sync/futures/promise/set_value_at_thread_exit_void_pass.cpp
+++ b/test/sync/futures/promise/set_value_at_thread_exit_void_pass.cpp
@@ -21,7 +21,7 @@
 #define BOOST_THREAD_VERSION 4
 
 #include <boost/thread/future.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 int i = 0;
 

--- a/test/sync/futures/promise/set_value_const_pass.cpp
+++ b/test/sync/futures/promise/set_value_const_pass.cpp
@@ -21,7 +21,7 @@
 #define BOOST_THREAD_VERSION 3
 
 #include <boost/thread/future.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 #include <boost/static_assert.hpp>
 
 #ifdef BOOST_MSVC

--- a/test/sync/futures/promise/set_value_void_pass.cpp
+++ b/test/sync/futures/promise/set_value_void_pass.cpp
@@ -21,7 +21,7 @@
 #define BOOST_THREAD_VERSION 3
 
 #include <boost/thread/future.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 #include <boost/static_assert.hpp>
 
 struct A

--- a/test/sync/futures/promise/use_allocator_pass.cpp
+++ b/test/sync/futures/promise/use_allocator_pass.cpp
@@ -21,7 +21,7 @@
 #define BOOST_THREAD_VERSION 3
 
 #include <boost/thread/future.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 #include <boost/static_assert.hpp>
 
 #if defined BOOST_THREAD_PROVIDES_FUTURE_CTOR_ALLOCATORS

--- a/test/sync/futures/shared_future/copy_assign_pass.cpp
+++ b/test/sync/futures/shared_future/copy_assign_pass.cpp
@@ -21,7 +21,7 @@
 
 #define BOOST_THREAD_VERSION 3
 #include <boost/thread/future.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 int main()
 {

--- a/test/sync/futures/shared_future/copy_ctor_pass.cpp
+++ b/test/sync/futures/shared_future/copy_ctor_pass.cpp
@@ -20,7 +20,7 @@
 
 #define BOOST_THREAD_VERSION 3
 #include <boost/thread/future.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 int main()
 {

--- a/test/sync/futures/shared_future/default_pass.cpp
+++ b/test/sync/futures/shared_future/default_pass.cpp
@@ -21,7 +21,7 @@
 #define BOOST_THREAD_VERSION 3
 
 #include <boost/thread/future.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 int main()
 {

--- a/test/sync/futures/shared_future/dtor_pass.cpp
+++ b/test/sync/futures/shared_future/dtor_pass.cpp
@@ -22,7 +22,7 @@
 #include <boost/exception/exception.hpp>
 
 #include <boost/thread/future.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 #if defined BOOST_THREAD_PROVIDES_FUTURE_CTOR_ALLOCATORS
 #include "../test_allocator.hpp"
 #endif

--- a/test/sync/futures/shared_future/get_pass.cpp
+++ b/test/sync/futures/shared_future/get_pass.cpp
@@ -24,7 +24,7 @@
 
 #include <boost/thread/future.hpp>
 #include <boost/thread/thread.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 #if defined BOOST_THREAD_USES_CHRONO
 

--- a/test/sync/futures/shared_future/move_assign_pass.cpp
+++ b/test/sync/futures/shared_future/move_assign_pass.cpp
@@ -21,7 +21,7 @@
 #define BOOST_THREAD_VERSION 3
 
 #include <boost/thread/future.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 boost::mutex m0;
 boost::mutex m1;

--- a/test/sync/futures/shared_future/move_ctor_pass.cpp
+++ b/test/sync/futures/shared_future/move_ctor_pass.cpp
@@ -21,7 +21,7 @@
 #define BOOST_THREAD_VERSION 3
 
 #include <boost/thread/future.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 boost::mutex m;
 

--- a/test/sync/futures/shared_future/then_executor_pass.cpp
+++ b/test/sync/futures/shared_future/then_executor_pass.cpp
@@ -19,7 +19,7 @@
 #include <boost/thread/future.hpp>
 #include <boost/thread/executors/basic_thread_pool.hpp>
 #include <boost/thread/executor.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 #if defined BOOST_THREAD_PROVIDES_FUTURE_CONTINUATION
 

--- a/test/sync/futures/shared_future/then_pass.cpp
+++ b/test/sync/futures/shared_future/then_pass.cpp
@@ -16,7 +16,7 @@
 #include <boost/thread/detail/log.hpp>
 
 #include <boost/thread/future.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 #if defined BOOST_THREAD_PROVIDES_FUTURE_CONTINUATION
 

--- a/test/sync/futures/shared_future/wait_for_pass.cpp
+++ b/test/sync/futures/shared_future/wait_for_pass.cpp
@@ -28,7 +28,7 @@
 #include <boost/thread/future.hpp>
 #include <boost/thread/thread.hpp>
 #include <boost/chrono/chrono_io.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 #include "../../../timming.hpp"
 
 #if defined BOOST_THREAD_USES_CHRONO

--- a/test/sync/futures/shared_future/wait_pass.cpp
+++ b/test/sync/futures/shared_future/wait_pass.cpp
@@ -28,7 +28,7 @@
 #include <boost/thread/future.hpp>
 #include <boost/thread/thread.hpp>
 #include <boost/chrono/chrono_io.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 #if defined BOOST_THREAD_USES_CHRONO
 

--- a/test/sync/futures/shared_future/wait_until_pass.cpp
+++ b/test/sync/futures/shared_future/wait_until_pass.cpp
@@ -29,7 +29,7 @@
 #include <boost/thread/future.hpp>
 #include <boost/thread/thread.hpp>
 #include <boost/chrono/chrono_io.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 #include "../../../timming.hpp"
 
 #if defined BOOST_THREAD_USES_CHRONO

--- a/test/sync/futures/when_all/iterators_pass.cpp
+++ b/test/sync/futures/when_all/iterators_pass.cpp
@@ -28,7 +28,7 @@
 #define BOOST_THREAD_VERSION 4
 
 #include <boost/thread/future.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 #include <stdexcept>
 
 #ifdef BOOST_MSVC

--- a/test/sync/futures/when_all/none_pass.cpp
+++ b/test/sync/futures/when_all/none_pass.cpp
@@ -26,7 +26,7 @@
 #define BOOST_THREAD_VERSION 4
 
 #include <boost/thread/future.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 int main()
 {

--- a/test/sync/futures/when_all/one_pass.cpp
+++ b/test/sync/futures/when_all/one_pass.cpp
@@ -27,7 +27,7 @@
 #define BOOST_THREAD_VERSION 4
 
 #include <boost/thread/future.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 #include <stdexcept>
 
 #ifdef BOOST_MSVC

--- a/test/sync/futures/when_all/variadic_pass.cpp
+++ b/test/sync/futures/when_all/variadic_pass.cpp
@@ -27,7 +27,7 @@
 #define BOOST_THREAD_VERSION 4
 
 #include <boost/thread/future.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 #include <stdexcept>
 
 #ifdef BOOST_MSVC

--- a/test/sync/futures/when_any/iterators_pass.cpp
+++ b/test/sync/futures/when_any/iterators_pass.cpp
@@ -28,7 +28,7 @@
 #define BOOST_THREAD_VERSION 4
 
 #include <boost/thread/future.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 #include <stdexcept>
 
 #ifdef BOOST_MSVC

--- a/test/sync/futures/when_any/none_pass.cpp
+++ b/test/sync/futures/when_any/none_pass.cpp
@@ -26,7 +26,7 @@
 #define BOOST_THREAD_VERSION 4
 
 #include <boost/thread/future.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 int main()
 {

--- a/test/sync/futures/when_any/one_pass.cpp
+++ b/test/sync/futures/when_any/one_pass.cpp
@@ -26,7 +26,7 @@
 #define BOOST_THREAD_VERSION 4
 
 #include <boost/thread/future.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 #ifdef BOOST_MSVC
 #pragma warning(disable: 4127) // conditional expression is constant

--- a/test/sync/futures/when_any/variadic_pass.cpp
+++ b/test/sync/futures/when_any/variadic_pass.cpp
@@ -26,7 +26,7 @@
 #define BOOST_THREAD_VERSION 4
 
 #include <boost/thread/future.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 #include <stdexcept>
 
 #ifdef BOOST_MSVC

--- a/test/sync/mutual_exclusion/deque_views/single_thread_pass.cpp
+++ b/test/sync/mutual_exclusion/deque_views/single_thread_pass.cpp
@@ -16,7 +16,7 @@
 #include <boost/thread/concurrent_queues/deque_adaptor.hpp>
 #include <boost/thread/concurrent_queues/deque_views.hpp>
 
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 #include <boost/static_assert.hpp>
 
 class non_copyable

--- a/test/sync/mutual_exclusion/locks/lock_guard/adopt_lock_pass.cpp
+++ b/test/sync/mutual_exclusion/locks/lock_guard/adopt_lock_pass.cpp
@@ -21,7 +21,7 @@
 #include <boost/thread/lock_guard.hpp>
 #include <boost/thread/mutex.hpp>
 #include <boost/thread/thread.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 #include "../../../../timming.hpp"
 
 #ifdef BOOST_THREAD_USES_CHRONO

--- a/test/sync/mutual_exclusion/locks/lock_guard/copy_assign_fail.cpp
+++ b/test/sync/mutual_exclusion/locks/lock_guard/copy_assign_fail.cpp
@@ -20,7 +20,7 @@
 
 #include <boost/thread/lock_guard.hpp>
 #include <boost/thread/mutex.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 boost::mutex m0;
 boost::mutex m1;

--- a/test/sync/mutual_exclusion/locks/lock_guard/copy_ctor_fail.cpp
+++ b/test/sync/mutual_exclusion/locks/lock_guard/copy_ctor_fail.cpp
@@ -21,7 +21,7 @@
 
 #include <boost/thread/lock_guard.hpp>
 #include <boost/thread/mutex.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 boost::mutex m0;
 boost::mutex m1;

--- a/test/sync/mutual_exclusion/locks/lock_guard/default_pass.cpp
+++ b/test/sync/mutual_exclusion/locks/lock_guard/default_pass.cpp
@@ -21,7 +21,7 @@
 #include <boost/thread/lock_guard.hpp>
 #include <boost/thread/mutex.hpp>
 #include <boost/thread/thread.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 #include "../../../../timming.hpp"
 
 #ifdef BOOST_THREAD_USES_CHRONO

--- a/test/sync/mutual_exclusion/locks/lock_guard/lock_guard_adopt_lock_compile_fail.cpp
+++ b/test/sync/mutual_exclusion/locks/lock_guard/lock_guard_adopt_lock_compile_fail.cpp
@@ -11,7 +11,7 @@
 
 #include <boost/thread/lock_guard.hpp>
 #include <boost/thread/mutex.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 boost::mutex m;
 

--- a/test/sync/mutual_exclusion/locks/lock_guard/lock_guard_adopt_lock_compile_pass.cpp
+++ b/test/sync/mutual_exclusion/locks/lock_guard/lock_guard_adopt_lock_compile_pass.cpp
@@ -11,7 +11,7 @@
 
 #include <boost/thread/lock_guard.hpp>
 #include <boost/thread/mutex.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 boost::mutex m;
 

--- a/test/sync/mutual_exclusion/locks/lock_guard/lock_guard_compile_fail.cpp
+++ b/test/sync/mutual_exclusion/locks/lock_guard/lock_guard_compile_fail.cpp
@@ -11,7 +11,7 @@
 
 #include <boost/thread/lock_guard.hpp>
 #include <boost/thread/mutex.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 boost::mutex m;
 

--- a/test/sync/mutual_exclusion/locks/lock_guard/lock_guard_compile_pass.cpp
+++ b/test/sync/mutual_exclusion/locks/lock_guard/lock_guard_compile_pass.cpp
@@ -11,7 +11,7 @@
 
 #include <boost/thread/lock_guard.hpp>
 #include <boost/thread/mutex.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 boost::mutex m;
 

--- a/test/sync/mutual_exclusion/locks/lock_guard/make_lock_guard_adopt_lock_pass.cpp
+++ b/test/sync/mutual_exclusion/locks/lock_guard/make_lock_guard_adopt_lock_pass.cpp
@@ -22,7 +22,7 @@
 #include <boost/thread/lock_guard.hpp>
 #include <boost/thread/mutex.hpp>
 #include <boost/thread/thread.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 #include "../../../../timming.hpp"
 
 

--- a/test/sync/mutual_exclusion/locks/lock_guard/make_lock_guard_pass.cpp
+++ b/test/sync/mutual_exclusion/locks/lock_guard/make_lock_guard_pass.cpp
@@ -23,7 +23,7 @@
 #include <boost/thread/mutex.hpp>
 #include <boost/thread/thread.hpp>
 
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 #include "../../../../timming.hpp"
 
 #ifdef BOOST_THREAD_USES_CHRONO

--- a/test/sync/mutual_exclusion/locks/lock_guard/types_pass.cpp
+++ b/test/sync/mutual_exclusion/locks/lock_guard/types_pass.cpp
@@ -29,7 +29,7 @@
 #include <boost/thread/mutex.hpp>
 #include <boost/static_assert.hpp>
 #include <boost/type_traits/is_same.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 int main()
 {

--- a/test/sync/mutual_exclusion/locks/nested_strict_lock/copy_assign_fail.cpp
+++ b/test/sync/mutual_exclusion/locks/nested_strict_lock/copy_assign_fail.cpp
@@ -12,7 +12,7 @@
 #include <boost/thread/lock_types.hpp>
 #include <boost/thread/strict_lock.hpp>
 #include <boost/thread/mutex.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 boost::mutex m0;
 boost::mutex m1;

--- a/test/sync/mutual_exclusion/locks/nested_strict_lock/copy_ctor_fail.cpp
+++ b/test/sync/mutual_exclusion/locks/nested_strict_lock/copy_ctor_fail.cpp
@@ -13,7 +13,7 @@
 #include <boost/thread/lock_types.hpp>
 #include <boost/thread/strict_lock.hpp>
 #include <boost/thread/mutex.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 boost::mutex m0;
 boost::mutex m1;

--- a/test/sync/mutual_exclusion/locks/nested_strict_lock/default_pass.cpp
+++ b/test/sync/mutual_exclusion/locks/nested_strict_lock/default_pass.cpp
@@ -13,7 +13,7 @@
 #include <boost/thread/strict_lock.hpp>
 #include <boost/thread/mutex.hpp>
 #include <boost/thread/thread.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 #include "../../../../timming.hpp"
 
 #ifdef BOOST_THREAD_USES_CHRONO

--- a/test/sync/mutual_exclusion/locks/nested_strict_lock/make_nested_strict_lock_pass.cpp
+++ b/test/sync/mutual_exclusion/locks/nested_strict_lock/make_nested_strict_lock_pass.cpp
@@ -15,7 +15,7 @@
 #include <boost/thread/mutex.hpp>
 #include <boost/thread/thread.hpp>
 
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 #include "../../../../timming.hpp"
 
 #ifdef BOOST_THREAD_USES_CHRONO

--- a/test/sync/mutual_exclusion/locks/nested_strict_lock/owns_lock_pass.cpp
+++ b/test/sync/mutual_exclusion/locks/nested_strict_lock/owns_lock_pass.cpp
@@ -12,7 +12,7 @@
 #include <boost/thread/lock_types.hpp>
 #include <boost/thread/strict_lock.hpp>
 #include <boost/thread/mutex.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 int main()
 {

--- a/test/sync/mutual_exclusion/locks/nested_strict_lock/types_pass.cpp
+++ b/test/sync/mutual_exclusion/locks/nested_strict_lock/types_pass.cpp
@@ -21,7 +21,7 @@
 #include <boost/thread/mutex.hpp>
 #include <boost/static_assert.hpp>
 #include <boost/type_traits/is_same.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 int main()
 {

--- a/test/sync/mutual_exclusion/locks/reverse_lock/types_pass.cpp
+++ b/test/sync/mutual_exclusion/locks/reverse_lock/types_pass.cpp
@@ -22,7 +22,7 @@
 #include <boost/thread/mutex.hpp>
 #include <boost/static_assert.hpp>
 #include <boost/type_traits/is_same.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 int main()
 {

--- a/test/sync/mutual_exclusion/locks/reverse_lock/unique_lock_ctor_pass.cpp
+++ b/test/sync/mutual_exclusion/locks/reverse_lock/unique_lock_ctor_pass.cpp
@@ -13,7 +13,7 @@
 #include <boost/thread/lock_types.hpp>
 #include <boost/thread/mutex.hpp>
 #include <boost/thread/thread.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 
 int main()

--- a/test/sync/mutual_exclusion/locks/shared_lock/cons/adopt_lock_pass.cpp
+++ b/test/sync/mutual_exclusion/locks/shared_lock/cons/adopt_lock_pass.cpp
@@ -21,7 +21,7 @@
 
 #include <boost/thread/lock_types.hpp>
 #include <boost/thread/shared_mutex.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 
 int main()

--- a/test/sync/mutual_exclusion/locks/shared_lock/cons/copy_assign_fail.cpp
+++ b/test/sync/mutual_exclusion/locks/shared_lock/cons/copy_assign_fail.cpp
@@ -20,7 +20,7 @@
 
 #include <boost/thread/lock_types.hpp>
 #include <boost/thread/shared_mutex.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 boost::shared_mutex m0;
 boost::shared_mutex m1;

--- a/test/sync/mutual_exclusion/locks/shared_lock/cons/copy_ctor_fail.cpp
+++ b/test/sync/mutual_exclusion/locks/shared_lock/cons/copy_ctor_fail.cpp
@@ -21,7 +21,7 @@
 
 #include <boost/thread/lock_types.hpp>
 #include <boost/thread/shared_mutex.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 boost::shared_mutex m0;
 boost::shared_mutex m1;

--- a/test/sync/mutual_exclusion/locks/shared_lock/cons/default_pass.cpp
+++ b/test/sync/mutual_exclusion/locks/shared_lock/cons/default_pass.cpp
@@ -20,7 +20,7 @@
 
 #include <boost/thread/lock_types.hpp>
 #include <boost/thread/shared_mutex.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 int main()
 {

--- a/test/sync/mutual_exclusion/locks/shared_lock/cons/defer_lock_pass.cpp
+++ b/test/sync/mutual_exclusion/locks/shared_lock/cons/defer_lock_pass.cpp
@@ -20,7 +20,7 @@
 
 #include <boost/thread/lock_types.hpp>
 #include <boost/thread/shared_mutex.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 int main()
 {

--- a/test/sync/mutual_exclusion/locks/shared_lock/cons/duration_pass.cpp
+++ b/test/sync/mutual_exclusion/locks/shared_lock/cons/duration_pass.cpp
@@ -22,7 +22,7 @@
 #include <boost/thread/lock_types.hpp>
 #include <boost/thread/shared_mutex.hpp>
 #include <boost/thread/thread.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 #include <boost/chrono/chrono_io.hpp>
 #include "../../../../../timming.hpp"
 

--- a/test/sync/mutual_exclusion/locks/shared_lock/cons/move_assign_pass.cpp
+++ b/test/sync/mutual_exclusion/locks/shared_lock/cons/move_assign_pass.cpp
@@ -21,7 +21,7 @@
 
 #include <boost/thread/lock_types.hpp>
 #include <boost/thread/shared_mutex.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 boost::shared_mutex m0;
 boost::shared_mutex m1;

--- a/test/sync/mutual_exclusion/locks/shared_lock/cons/move_ctor_pass.cpp
+++ b/test/sync/mutual_exclusion/locks/shared_lock/cons/move_ctor_pass.cpp
@@ -21,7 +21,7 @@
 
 #include <boost/thread/lock_types.hpp>
 #include <boost/thread/shared_mutex.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 boost::shared_mutex m;
 

--- a/test/sync/mutual_exclusion/locks/shared_lock/cons/move_ctor_unique_lock_pass.cpp
+++ b/test/sync/mutual_exclusion/locks/shared_lock/cons/move_ctor_unique_lock_pass.cpp
@@ -21,7 +21,7 @@
 
 #include <boost/thread/lock_types.hpp>
 #include <boost/thread/shared_mutex.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 boost::shared_mutex m;
 

--- a/test/sync/mutual_exclusion/locks/shared_lock/cons/move_ctor_upgrade_lock_pass.cpp
+++ b/test/sync/mutual_exclusion/locks/shared_lock/cons/move_ctor_upgrade_lock_pass.cpp
@@ -21,7 +21,7 @@
 
 #include <boost/thread/lock_types.hpp>
 #include <boost/thread/shared_mutex.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 boost::shared_mutex m;
 

--- a/test/sync/mutual_exclusion/locks/shared_lock/cons/mutex_pass.cpp
+++ b/test/sync/mutual_exclusion/locks/shared_lock/cons/mutex_pass.cpp
@@ -21,7 +21,7 @@
 #include <boost/thread/lock_types.hpp>
 #include <boost/thread/shared_mutex.hpp>
 #include <boost/thread/thread.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 #include "../../../../../timming.hpp"
 
 boost::shared_mutex m;

--- a/test/sync/mutual_exclusion/locks/shared_lock/cons/time_point_pass.cpp
+++ b/test/sync/mutual_exclusion/locks/shared_lock/cons/time_point_pass.cpp
@@ -22,7 +22,7 @@
 #include <boost/thread/lock_types.hpp>
 #include <boost/thread/shared_mutex.hpp>
 #include <boost/thread/thread.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 #include "../../../../../timming.hpp"
 
 boost::shared_mutex m;

--- a/test/sync/mutual_exclusion/locks/shared_lock/cons/try_to_lock_pass.cpp
+++ b/test/sync/mutual_exclusion/locks/shared_lock/cons/try_to_lock_pass.cpp
@@ -21,7 +21,7 @@
 #include <boost/thread/lock_types.hpp>
 #include <boost/thread/shared_mutex.hpp>
 #include <boost/thread/thread.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 #include "../../../../../timming.hpp"
 
 boost::shared_mutex m;

--- a/test/sync/mutual_exclusion/locks/shared_lock/locking/lock_pass.cpp
+++ b/test/sync/mutual_exclusion/locks/shared_lock/locking/lock_pass.cpp
@@ -21,7 +21,7 @@
 #include <boost/thread/lock_types.hpp>
 #include <boost/thread/shared_mutex.hpp>
 #include <boost/thread/thread.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 #include <iostream>
 #include "../../../../../timming.hpp"
 

--- a/test/sync/mutual_exclusion/locks/shared_lock/locking/try_lock_for_pass.cpp
+++ b/test/sync/mutual_exclusion/locks/shared_lock/locking/try_lock_for_pass.cpp
@@ -21,7 +21,7 @@
 
 #include <boost/thread/lock_types.hpp>
 //#include <boost/thread/shared_mutex.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 bool try_lock_for_called = false;
 

--- a/test/sync/mutual_exclusion/locks/shared_lock/locking/try_lock_pass.cpp
+++ b/test/sync/mutual_exclusion/locks/shared_lock/locking/try_lock_pass.cpp
@@ -21,7 +21,7 @@
 
 #include <boost/thread/lock_types.hpp>
 //#include <boost/thread/shared_mutex.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 bool try_lock_called = false;
 

--- a/test/sync/mutual_exclusion/locks/shared_lock/locking/try_lock_until_pass.cpp
+++ b/test/sync/mutual_exclusion/locks/shared_lock/locking/try_lock_until_pass.cpp
@@ -21,7 +21,7 @@
 
 #include <boost/thread/lock_types.hpp>
 #include <boost/thread/shared_mutex.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 bool try_lock_until_called = false;
 

--- a/test/sync/mutual_exclusion/locks/shared_lock/locking/unlock_pass.cpp
+++ b/test/sync/mutual_exclusion/locks/shared_lock/locking/unlock_pass.cpp
@@ -21,7 +21,7 @@
 
 #include <boost/thread/lock_types.hpp>
 //#include <boost/thread/shared_mutex.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 bool unlock_called = false;
 

--- a/test/sync/mutual_exclusion/locks/shared_lock/mod/member_swap_pass.cpp
+++ b/test/sync/mutual_exclusion/locks/shared_lock/mod/member_swap_pass.cpp
@@ -19,7 +19,7 @@
 // void swap(shared_lock& u);
 
 #include <boost/thread/lock_types.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 struct shared_mutex
 {

--- a/test/sync/mutual_exclusion/locks/shared_lock/mod/non_member_swap_pass.cpp
+++ b/test/sync/mutual_exclusion/locks/shared_lock/mod/non_member_swap_pass.cpp
@@ -18,7 +18,7 @@
 //   void swap(shared_lock<Mutex>& x, shared_lock<Mutex>& y);
 
 #include <boost/thread/lock_types.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 struct shared_mutex
 {

--- a/test/sync/mutual_exclusion/locks/shared_lock/mod/release_pass.cpp
+++ b/test/sync/mutual_exclusion/locks/shared_lock/mod/release_pass.cpp
@@ -19,7 +19,7 @@
 // void Mutex* release();
 
 #include <boost/thread/lock_types.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 struct shared_mutex
 {

--- a/test/sync/mutual_exclusion/locks/shared_lock/obs/mutex_pass.cpp
+++ b/test/sync/mutual_exclusion/locks/shared_lock/obs/mutex_pass.cpp
@@ -20,7 +20,7 @@
 
 #include <boost/thread/lock_types.hpp>
 #include <boost/thread/shared_mutex.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 boost::shared_mutex m;
 

--- a/test/sync/mutual_exclusion/locks/shared_lock/obs/op_bool_pass.cpp
+++ b/test/sync/mutual_exclusion/locks/shared_lock/obs/op_bool_pass.cpp
@@ -20,7 +20,7 @@
 
 #include <boost/thread/lock_types.hpp>
 #include <boost/thread/shared_mutex.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 boost::shared_mutex m;
 

--- a/test/sync/mutual_exclusion/locks/shared_lock/obs/owns_lock_pass.cpp
+++ b/test/sync/mutual_exclusion/locks/shared_lock/obs/owns_lock_pass.cpp
@@ -20,7 +20,7 @@
 
 #include <boost/thread/lock_types.hpp>
 #include <boost/thread/shared_mutex.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 boost::shared_mutex m;
 

--- a/test/sync/mutual_exclusion/locks/shared_lock/types_pass.cpp
+++ b/test/sync/mutual_exclusion/locks/shared_lock/types_pass.cpp
@@ -28,7 +28,8 @@
 #include <boost/thread/lock_types.hpp>
 #include <boost/thread/shared_mutex.hpp>
 #include <boost/static_assert.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/type_traits/is_same.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 int main()
 {

--- a/test/sync/mutual_exclusion/locks/shared_lock_guard/adopt_lock_pass.cpp
+++ b/test/sync/mutual_exclusion/locks/shared_lock_guard/adopt_lock_pass.cpp
@@ -21,7 +21,7 @@
 #include <boost/thread/shared_lock_guard.hpp>
 #include <boost/thread/shared_mutex.hpp>
 #include <boost/thread/thread.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 #include "../../../../timming.hpp"
 
 #if defined BOOST_THREAD_USES_CHRONO

--- a/test/sync/mutual_exclusion/locks/shared_lock_guard/copy_assign_fail.cpp
+++ b/test/sync/mutual_exclusion/locks/shared_lock_guard/copy_assign_fail.cpp
@@ -20,7 +20,7 @@
 
 #include <boost/thread/shared_lock_guard.hpp>
 #include <boost/thread/shared_mutex.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 boost::shared_mutex m0;
 boost::shared_mutex m1;

--- a/test/sync/mutual_exclusion/locks/shared_lock_guard/copy_ctor_fail.cpp
+++ b/test/sync/mutual_exclusion/locks/shared_lock_guard/copy_ctor_fail.cpp
@@ -21,7 +21,7 @@
 
 #include <boost/thread/shared_lock_guard.hpp>
 #include <boost/thread/shared_mutex.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 boost::shared_mutex m0;
 boost::shared_mutex m1;

--- a/test/sync/mutual_exclusion/locks/shared_lock_guard/default_pass.cpp
+++ b/test/sync/mutual_exclusion/locks/shared_lock_guard/default_pass.cpp
@@ -21,7 +21,7 @@
 #include <boost/thread/shared_lock_guard.hpp>
 #include <boost/thread/shared_mutex.hpp>
 #include <boost/thread/thread.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 #include  <iostream>
 #include "../../../../timming.hpp"
 

--- a/test/sync/mutual_exclusion/locks/shared_lock_guard/types_pass.cpp
+++ b/test/sync/mutual_exclusion/locks/shared_lock_guard/types_pass.cpp
@@ -29,7 +29,7 @@
 #include <boost/thread/shared_lock_guard.hpp>
 #include <boost/static_assert.hpp>
 #include <boost/type_traits/is_same.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 int main()
 {

--- a/test/sync/mutual_exclusion/locks/strict_lock/copy_assign_fail.cpp
+++ b/test/sync/mutual_exclusion/locks/strict_lock/copy_assign_fail.cpp
@@ -11,7 +11,7 @@
 
 #include <boost/thread/strict_lock.hpp>
 #include <boost/thread/mutex.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 boost::mutex m0;
 boost::mutex m1;

--- a/test/sync/mutual_exclusion/locks/strict_lock/copy_ctor_fail.cpp
+++ b/test/sync/mutual_exclusion/locks/strict_lock/copy_ctor_fail.cpp
@@ -12,7 +12,7 @@
 
 #include <boost/thread/strict_lock.hpp>
 #include <boost/thread/mutex.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 boost::mutex m0;
 boost::mutex m1;

--- a/test/sync/mutual_exclusion/locks/strict_lock/default_pass.cpp
+++ b/test/sync/mutual_exclusion/locks/strict_lock/default_pass.cpp
@@ -12,7 +12,7 @@
 #include <boost/thread/strict_lock.hpp>
 #include <boost/thread/mutex.hpp>
 #include <boost/thread/thread.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 #include "../../../../timming.hpp"
 
 #ifdef BOOST_THREAD_USES_CHRONO

--- a/test/sync/mutual_exclusion/locks/strict_lock/make_strict_lock_pass.cpp
+++ b/test/sync/mutual_exclusion/locks/strict_lock/make_strict_lock_pass.cpp
@@ -14,7 +14,7 @@
 #include <boost/thread/mutex.hpp>
 #include <boost/thread/thread.hpp>
 
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 #include "../../../../timming.hpp"
 
 #ifdef BOOST_THREAD_USES_CHRONO

--- a/test/sync/mutual_exclusion/locks/strict_lock/owns_lock_pass.cpp
+++ b/test/sync/mutual_exclusion/locks/strict_lock/owns_lock_pass.cpp
@@ -12,7 +12,7 @@
 #include <boost/thread/strict_lock.hpp>
 #include <boost/thread/mutex.hpp>
 #include <boost/thread/thread.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 #ifdef BOOST_THREAD_USES_CHRONO
 typedef boost::chrono::high_resolution_clock Clock;

--- a/test/sync/mutual_exclusion/locks/strict_lock/types_pass.cpp
+++ b/test/sync/mutual_exclusion/locks/strict_lock/types_pass.cpp
@@ -20,7 +20,7 @@
 #include <boost/thread/mutex.hpp>
 #include <boost/static_assert.hpp>
 #include <boost/type_traits/is_same.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 int main()
 {

--- a/test/sync/mutual_exclusion/locks/unique_lock/cons/adopt_lock_pass.cpp
+++ b/test/sync/mutual_exclusion/locks/unique_lock/cons/adopt_lock_pass.cpp
@@ -20,7 +20,7 @@
 
 #include <boost/thread/lock_types.hpp>
 #include <boost/thread/mutex.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 
 int main()

--- a/test/sync/mutual_exclusion/locks/unique_lock/cons/copy_assign_fail.cpp
+++ b/test/sync/mutual_exclusion/locks/unique_lock/cons/copy_assign_fail.cpp
@@ -20,7 +20,7 @@
 
 #include <boost/thread/lock_types.hpp>
 #include <boost/thread/mutex.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 boost::mutex m0;
 boost::mutex m1;

--- a/test/sync/mutual_exclusion/locks/unique_lock/cons/copy_ctor_fail.cpp
+++ b/test/sync/mutual_exclusion/locks/unique_lock/cons/copy_ctor_fail.cpp
@@ -21,7 +21,7 @@
 
 #include <boost/thread/lock_types.hpp>
 #include <boost/thread/mutex.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 boost::mutex m0;
 boost::mutex m1;

--- a/test/sync/mutual_exclusion/locks/unique_lock/cons/default_pass.cpp
+++ b/test/sync/mutual_exclusion/locks/unique_lock/cons/default_pass.cpp
@@ -20,7 +20,7 @@
 
 #include <boost/thread/lock_types.hpp>
 #include <boost/thread/mutex.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 int main()
 {

--- a/test/sync/mutual_exclusion/locks/unique_lock/cons/defer_lock_pass.cpp
+++ b/test/sync/mutual_exclusion/locks/unique_lock/cons/defer_lock_pass.cpp
@@ -20,7 +20,7 @@
 
 #include <boost/thread/lock_types.hpp>
 #include <boost/thread/mutex.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 int main()
 {

--- a/test/sync/mutual_exclusion/locks/unique_lock/cons/duration_pass.cpp
+++ b/test/sync/mutual_exclusion/locks/unique_lock/cons/duration_pass.cpp
@@ -24,7 +24,7 @@
 #include <boost/thread/lock_types.hpp>
 #include <boost/thread/mutex.hpp>
 #include <boost/thread/thread.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 #include <boost/chrono/chrono_io.hpp>
 #include "../../../../../timming.hpp"
 

--- a/test/sync/mutual_exclusion/locks/unique_lock/cons/make_unique_lock_adopt_lock_pass.cpp
+++ b/test/sync/mutual_exclusion/locks/unique_lock/cons/make_unique_lock_adopt_lock_pass.cpp
@@ -12,7 +12,7 @@
 
 #include <boost/thread/lock_factories.hpp>
 #include <boost/thread/mutex.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 int main()
 {

--- a/test/sync/mutual_exclusion/locks/unique_lock/cons/make_unique_lock_defer_lock_pass.cpp
+++ b/test/sync/mutual_exclusion/locks/unique_lock/cons/make_unique_lock_defer_lock_pass.cpp
@@ -14,7 +14,7 @@
 
 #include <boost/thread/lock_factories.hpp>
 #include <boost/thread/mutex.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 int main()
 {

--- a/test/sync/mutual_exclusion/locks/unique_lock/cons/make_unique_lock_mutex_pass.cpp
+++ b/test/sync/mutual_exclusion/locks/unique_lock/cons/make_unique_lock_mutex_pass.cpp
@@ -14,7 +14,7 @@
 #include <boost/thread/lock_factories.hpp>
 #include <boost/thread/mutex.hpp>
 #include <boost/thread/thread.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 #include "../../../../../timming.hpp"
 
 //#if ! defined(BOOST_NO_CXX11_RVALUE_REFERENCES)

--- a/test/sync/mutual_exclusion/locks/unique_lock/cons/make_unique_lock_try_to_lock_pass.cpp
+++ b/test/sync/mutual_exclusion/locks/unique_lock/cons/make_unique_lock_try_to_lock_pass.cpp
@@ -14,7 +14,7 @@
 #include <boost/thread/lock_factories.hpp>
 #include <boost/thread/mutex.hpp>
 #include <boost/thread/thread.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 #include "../../../../../timming.hpp"
 
 boost::mutex m;

--- a/test/sync/mutual_exclusion/locks/unique_lock/cons/make_unique_locks_mutex_pass.cpp
+++ b/test/sync/mutual_exclusion/locks/unique_lock/cons/make_unique_locks_mutex_pass.cpp
@@ -13,7 +13,7 @@
 #include <boost/thread/lock_factories.hpp>
 #include <boost/thread/mutex.hpp>
 #include <boost/thread/thread.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 #include "../../../../../timming.hpp"
 
 #if ! defined(BOOST_NO_CXX11_AUTO_DECLARATIONS) && ! defined BOOST_THREAD_NO_MAKE_UNIQUE_LOCKS && ! defined BOOST_NO_CXX11_RVALUE_REFERENCES

--- a/test/sync/mutual_exclusion/locks/unique_lock/cons/move_assign_pass.cpp
+++ b/test/sync/mutual_exclusion/locks/unique_lock/cons/move_assign_pass.cpp
@@ -21,7 +21,7 @@
 
 #include <boost/thread/lock_types.hpp>
 #include <boost/thread/mutex.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 boost::mutex m0;
 boost::mutex m1;

--- a/test/sync/mutual_exclusion/locks/unique_lock/cons/move_ctor_pass.cpp
+++ b/test/sync/mutual_exclusion/locks/unique_lock/cons/move_ctor_pass.cpp
@@ -21,7 +21,7 @@
 
 #include <boost/thread/lock_types.hpp>
 #include <boost/thread/mutex.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 boost::mutex m;
 

--- a/test/sync/mutual_exclusion/locks/unique_lock/cons/move_ctor_shared_lock_for_pass.cpp
+++ b/test/sync/mutual_exclusion/locks/unique_lock/cons/move_ctor_shared_lock_for_pass.cpp
@@ -26,7 +26,7 @@
 
 #include <boost/thread/lock_types.hpp>
 #include <boost/thread/shared_mutex.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 boost::shared_mutex m;
 

--- a/test/sync/mutual_exclusion/locks/unique_lock/cons/move_ctor_shared_lock_try_pass.cpp
+++ b/test/sync/mutual_exclusion/locks/unique_lock/cons/move_ctor_shared_lock_try_pass.cpp
@@ -24,7 +24,7 @@
 
 #include <boost/thread/lock_types.hpp>
 #include <boost/thread/shared_mutex.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 boost::shared_mutex m;
 

--- a/test/sync/mutual_exclusion/locks/unique_lock/cons/move_ctor_shared_lock_until_pass.cpp
+++ b/test/sync/mutual_exclusion/locks/unique_lock/cons/move_ctor_shared_lock_until_pass.cpp
@@ -26,7 +26,7 @@
 
 #include <boost/thread/lock_types.hpp>
 #include <boost/thread/shared_mutex.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 boost::shared_mutex m;
 

--- a/test/sync/mutual_exclusion/locks/unique_lock/cons/move_ctor_upgrade_lock_for_pass.cpp
+++ b/test/sync/mutual_exclusion/locks/unique_lock/cons/move_ctor_upgrade_lock_for_pass.cpp
@@ -24,7 +24,7 @@
 
 #include <boost/thread/lock_types.hpp>
 #include <boost/thread/shared_mutex.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 boost::upgrade_mutex m;
 

--- a/test/sync/mutual_exclusion/locks/unique_lock/cons/move_ctor_upgrade_lock_pass.cpp
+++ b/test/sync/mutual_exclusion/locks/unique_lock/cons/move_ctor_upgrade_lock_pass.cpp
@@ -21,7 +21,7 @@
 
 #include <boost/thread/lock_types.hpp>
 #include <boost/thread/shared_mutex.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 boost::upgrade_mutex m;
 

--- a/test/sync/mutual_exclusion/locks/unique_lock/cons/move_ctor_upgrade_lock_try_pass.cpp
+++ b/test/sync/mutual_exclusion/locks/unique_lock/cons/move_ctor_upgrade_lock_try_pass.cpp
@@ -22,7 +22,7 @@
 
 #include <boost/thread/lock_types.hpp>
 #include <boost/thread/shared_mutex.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 boost::upgrade_mutex m;
 

--- a/test/sync/mutual_exclusion/locks/unique_lock/cons/move_ctor_upgrade_lock_until_pass.cpp
+++ b/test/sync/mutual_exclusion/locks/unique_lock/cons/move_ctor_upgrade_lock_until_pass.cpp
@@ -24,7 +24,7 @@
 
 #include <boost/thread/lock_types.hpp>
 #include <boost/thread/shared_mutex.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 boost::upgrade_mutex m;
 

--- a/test/sync/mutual_exclusion/locks/unique_lock/cons/mutex_pass.cpp
+++ b/test/sync/mutual_exclusion/locks/unique_lock/cons/mutex_pass.cpp
@@ -22,7 +22,7 @@
 #include <boost/thread/lock_types.hpp>
 #include <boost/thread/mutex.hpp>
 #include <boost/thread/thread.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 #include <iostream>
 #include "../../../../../timming.hpp"
 

--- a/test/sync/mutual_exclusion/locks/unique_lock/cons/time_point_pass.cpp
+++ b/test/sync/mutual_exclusion/locks/unique_lock/cons/time_point_pass.cpp
@@ -24,7 +24,7 @@
 #include <boost/thread/lock_types.hpp>
 #include <boost/thread/mutex.hpp>
 #include <boost/thread/thread.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 #include "../../../../../timming.hpp"
 
 #if defined BOOST_THREAD_USES_CHRONO

--- a/test/sync/mutual_exclusion/locks/unique_lock/cons/try_to_lock_pass.cpp
+++ b/test/sync/mutual_exclusion/locks/unique_lock/cons/try_to_lock_pass.cpp
@@ -22,7 +22,7 @@
 #include <boost/thread/lock_types.hpp>
 #include <boost/thread/mutex.hpp>
 #include <boost/thread/thread.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 #include "../../../../../timming.hpp"
 
 

--- a/test/sync/mutual_exclusion/locks/unique_lock/locking/lock_pass.cpp
+++ b/test/sync/mutual_exclusion/locks/unique_lock/locking/lock_pass.cpp
@@ -21,7 +21,7 @@
 #include <boost/thread/lock_types.hpp>
 #include <boost/thread/mutex.hpp>
 #include <boost/thread/thread.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 #include <iostream>
 #include "../../../../../timming.hpp"
 

--- a/test/sync/mutual_exclusion/locks/unique_lock/locking/try_lock_for_pass.cpp
+++ b/test/sync/mutual_exclusion/locks/unique_lock/locking/try_lock_for_pass.cpp
@@ -21,7 +21,7 @@
 
 #include <boost/thread/lock_types.hpp>
 //#include <boost/thread/mutex.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 #if defined BOOST_THREAD_USES_CHRONO
 

--- a/test/sync/mutual_exclusion/locks/unique_lock/locking/try_lock_pass.cpp
+++ b/test/sync/mutual_exclusion/locks/unique_lock/locking/try_lock_pass.cpp
@@ -21,7 +21,7 @@
 
 #include <boost/thread/lock_types.hpp>
 //#include <boost/thread/mutex.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 bool try_lock_called = false;
 

--- a/test/sync/mutual_exclusion/locks/unique_lock/locking/try_lock_until_pass.cpp
+++ b/test/sync/mutual_exclusion/locks/unique_lock/locking/try_lock_until_pass.cpp
@@ -21,7 +21,7 @@
 
 #include <boost/thread/lock_types.hpp>
 #include <boost/thread/mutex.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 #if defined BOOST_THREAD_USES_CHRONO
 

--- a/test/sync/mutual_exclusion/locks/unique_lock/locking/unlock_pass.cpp
+++ b/test/sync/mutual_exclusion/locks/unique_lock/locking/unlock_pass.cpp
@@ -20,7 +20,7 @@
 
 #include <boost/thread/lock_types.hpp>
 //#include <boost/thread/mutex.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 
 bool unlock_called = false;

--- a/test/sync/mutual_exclusion/locks/unique_lock/mod/member_swap_pass.cpp
+++ b/test/sync/mutual_exclusion/locks/unique_lock/mod/member_swap_pass.cpp
@@ -19,7 +19,7 @@
 // void swap(unique_lock& u);
 
 #include <boost/thread/lock_types.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 struct mutex
 {

--- a/test/sync/mutual_exclusion/locks/unique_lock/mod/non_member_swap_pass.cpp
+++ b/test/sync/mutual_exclusion/locks/unique_lock/mod/non_member_swap_pass.cpp
@@ -18,7 +18,7 @@
 //   void swap(unique_lock<Mutex>& x, unique_lock<Mutex>& y);
 
 #include <boost/thread/lock_types.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 struct mutex
 {

--- a/test/sync/mutual_exclusion/locks/unique_lock/mod/release_pass.cpp
+++ b/test/sync/mutual_exclusion/locks/unique_lock/mod/release_pass.cpp
@@ -19,7 +19,7 @@
 // void Mutex* release();
 
 #include <boost/thread/lock_types.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 struct mutex
 {

--- a/test/sync/mutual_exclusion/locks/unique_lock/obs/mutex_pass.cpp
+++ b/test/sync/mutual_exclusion/locks/unique_lock/obs/mutex_pass.cpp
@@ -20,7 +20,7 @@
 
 #include <boost/thread/lock_types.hpp>
 #include <boost/thread/mutex.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 boost::mutex m;
 

--- a/test/sync/mutual_exclusion/locks/unique_lock/obs/op_bool_pass.cpp
+++ b/test/sync/mutual_exclusion/locks/unique_lock/obs/op_bool_pass.cpp
@@ -20,7 +20,7 @@
 
 #include <boost/thread/lock_types.hpp>
 #include <boost/thread/mutex.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 boost::mutex m;
 

--- a/test/sync/mutual_exclusion/locks/unique_lock/obs/op_int_fail.cpp
+++ b/test/sync/mutual_exclusion/locks/unique_lock/obs/op_int_fail.cpp
@@ -20,7 +20,7 @@
 
 #include <boost/thread/lock_types.hpp>
 #include <boost/thread/mutex.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 boost::mutex m;
 

--- a/test/sync/mutual_exclusion/locks/unique_lock/obs/owns_lock_pass.cpp
+++ b/test/sync/mutual_exclusion/locks/unique_lock/obs/owns_lock_pass.cpp
@@ -20,7 +20,7 @@
 
 #include <boost/thread/lock_types.hpp>
 #include <boost/thread/mutex.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 
 int main()

--- a/test/sync/mutual_exclusion/locks/unique_lock/types_pass.cpp
+++ b/test/sync/mutual_exclusion/locks/unique_lock/types_pass.cpp
@@ -28,7 +28,8 @@
 #include <boost/thread/lock_types.hpp>
 #include <boost/thread/mutex.hpp>
 #include <boost/static_assert.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/type_traits/is_same.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 int main()
 {

--- a/test/sync/mutual_exclusion/locks/upgrade_lock/cons/adopt_lock_pass.cpp
+++ b/test/sync/mutual_exclusion/locks/upgrade_lock/cons/adopt_lock_pass.cpp
@@ -21,7 +21,7 @@
 
 #include <boost/thread/lock_types.hpp>
 #include <boost/thread/shared_mutex.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 
 int main()

--- a/test/sync/mutual_exclusion/locks/upgrade_lock/cons/copy_assign_fail.cpp
+++ b/test/sync/mutual_exclusion/locks/upgrade_lock/cons/copy_assign_fail.cpp
@@ -20,7 +20,7 @@
 
 #include <boost/thread/lock_types.hpp>
 #include <boost/thread/shared_mutex.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 boost::shared_mutex m0;
 boost::shared_mutex m1;

--- a/test/sync/mutual_exclusion/locks/upgrade_lock/cons/copy_ctor_fail.cpp
+++ b/test/sync/mutual_exclusion/locks/upgrade_lock/cons/copy_ctor_fail.cpp
@@ -21,7 +21,7 @@
 
 #include <boost/thread/lock_types.hpp>
 #include <boost/thread/shared_mutex.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 boost::shared_mutex m0;
 boost::shared_mutex m1;

--- a/test/sync/mutual_exclusion/locks/upgrade_lock/cons/default_pass.cpp
+++ b/test/sync/mutual_exclusion/locks/upgrade_lock/cons/default_pass.cpp
@@ -20,7 +20,7 @@
 
 #include <boost/thread/lock_types.hpp>
 #include <boost/thread/shared_mutex.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 int main()
 {

--- a/test/sync/mutual_exclusion/locks/upgrade_lock/cons/defer_lock_pass.cpp
+++ b/test/sync/mutual_exclusion/locks/upgrade_lock/cons/defer_lock_pass.cpp
@@ -20,7 +20,7 @@
 
 #include <boost/thread/lock_types.hpp>
 #include <boost/thread/shared_mutex.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 int main()
 {

--- a/test/sync/mutual_exclusion/locks/upgrade_lock/cons/duration_pass.cpp
+++ b/test/sync/mutual_exclusion/locks/upgrade_lock/cons/duration_pass.cpp
@@ -24,7 +24,7 @@
 #include <boost/thread/lock_types.hpp>
 #include <boost/thread/shared_mutex.hpp>
 #include <boost/thread/thread.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 #include <boost/chrono/chrono_io.hpp>
 #include "../../../../../timming.hpp"
 

--- a/test/sync/mutual_exclusion/locks/upgrade_lock/cons/move_assign_pass.cpp
+++ b/test/sync/mutual_exclusion/locks/upgrade_lock/cons/move_assign_pass.cpp
@@ -21,7 +21,7 @@
 
 #include <boost/thread/lock_types.hpp>
 #include <boost/thread/shared_mutex.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 boost::shared_mutex m0;
 boost::shared_mutex m1;

--- a/test/sync/mutual_exclusion/locks/upgrade_lock/cons/move_ctor_pass.cpp
+++ b/test/sync/mutual_exclusion/locks/upgrade_lock/cons/move_ctor_pass.cpp
@@ -21,7 +21,7 @@
 
 #include <boost/thread/lock_types.hpp>
 #include <boost/thread/shared_mutex.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 boost::shared_mutex m;
 

--- a/test/sync/mutual_exclusion/locks/upgrade_lock/cons/move_ctor_shared_lock_for_pass.cpp
+++ b/test/sync/mutual_exclusion/locks/upgrade_lock/cons/move_ctor_shared_lock_for_pass.cpp
@@ -26,7 +26,7 @@
 
 #include <boost/thread/lock_types.hpp>
 #include <boost/thread/shared_mutex.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 boost::shared_mutex m;
 

--- a/test/sync/mutual_exclusion/locks/upgrade_lock/cons/move_ctor_shared_lock_try_pass.cpp
+++ b/test/sync/mutual_exclusion/locks/upgrade_lock/cons/move_ctor_shared_lock_try_pass.cpp
@@ -24,7 +24,7 @@
 
 #include <boost/thread/lock_types.hpp>
 #include <boost/thread/shared_mutex.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 boost::shared_mutex m;
 

--- a/test/sync/mutual_exclusion/locks/upgrade_lock/cons/move_ctor_shared_lock_until_pass.cpp
+++ b/test/sync/mutual_exclusion/locks/upgrade_lock/cons/move_ctor_shared_lock_until_pass.cpp
@@ -26,7 +26,7 @@
 
 #include <boost/thread/lock_types.hpp>
 #include <boost/thread/shared_mutex.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 boost::shared_mutex m;
 

--- a/test/sync/mutual_exclusion/locks/upgrade_lock/cons/move_ctor_unique_lock_pass.cpp
+++ b/test/sync/mutual_exclusion/locks/upgrade_lock/cons/move_ctor_unique_lock_pass.cpp
@@ -21,7 +21,7 @@
 
 #include <boost/thread/lock_types.hpp>
 #include <boost/thread/shared_mutex.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 boost::shared_mutex m;
 

--- a/test/sync/mutual_exclusion/locks/upgrade_lock/cons/mutex_pass.cpp
+++ b/test/sync/mutual_exclusion/locks/upgrade_lock/cons/mutex_pass.cpp
@@ -22,7 +22,7 @@
 #include <boost/thread/lock_types.hpp>
 #include <boost/thread/shared_mutex.hpp>
 #include <boost/thread/thread.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 #include <iostream>
 #include "../../../../../timming.hpp"
 

--- a/test/sync/mutual_exclusion/locks/upgrade_lock/cons/time_point_pass.cpp
+++ b/test/sync/mutual_exclusion/locks/upgrade_lock/cons/time_point_pass.cpp
@@ -24,7 +24,7 @@
 #include <boost/thread/lock_types.hpp>
 #include <boost/thread/shared_mutex.hpp>
 #include <boost/thread/thread.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 #include "../../../../../timming.hpp"
 
 boost::shared_mutex m;

--- a/test/sync/mutual_exclusion/locks/upgrade_lock/cons/try_to_lock_pass.cpp
+++ b/test/sync/mutual_exclusion/locks/upgrade_lock/cons/try_to_lock_pass.cpp
@@ -22,7 +22,7 @@
 #include <boost/thread/lock_types.hpp>
 #include <boost/thread/shared_mutex.hpp>
 #include <boost/thread/thread.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 #include "../../../../../timming.hpp"
 
 boost::shared_mutex m;

--- a/test/sync/mutual_exclusion/locks/upgrade_lock/locking/lock_pass.cpp
+++ b/test/sync/mutual_exclusion/locks/upgrade_lock/locking/lock_pass.cpp
@@ -21,7 +21,7 @@
 #include <boost/thread/lock_types.hpp>
 #include <boost/thread/shared_mutex.hpp>
 #include <boost/thread/thread.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 #include <iostream>
 #include "../../../../../timming.hpp"
 

--- a/test/sync/mutual_exclusion/locks/upgrade_lock/locking/try_lock_for_pass.cpp
+++ b/test/sync/mutual_exclusion/locks/upgrade_lock/locking/try_lock_for_pass.cpp
@@ -21,7 +21,7 @@
 
 #include <boost/thread/lock_types.hpp>
 //#include <boost/thread/shared_mutex.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 bool try_lock_for_called = false;
 

--- a/test/sync/mutual_exclusion/locks/upgrade_lock/locking/try_lock_pass.cpp
+++ b/test/sync/mutual_exclusion/locks/upgrade_lock/locking/try_lock_pass.cpp
@@ -21,7 +21,7 @@
 
 #include <boost/thread/lock_types.hpp>
 //#include <boost/thread/shared_mutex.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 bool try_lock_called = false;
 

--- a/test/sync/mutual_exclusion/locks/upgrade_lock/locking/try_lock_until_pass.cpp
+++ b/test/sync/mutual_exclusion/locks/upgrade_lock/locking/try_lock_until_pass.cpp
@@ -21,7 +21,7 @@
 
 #include <boost/thread/lock_types.hpp>
 #include <boost/thread/shared_mutex.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 bool try_lock_until_called = false;
 

--- a/test/sync/mutual_exclusion/locks/upgrade_lock/locking/unlock_pass.cpp
+++ b/test/sync/mutual_exclusion/locks/upgrade_lock/locking/unlock_pass.cpp
@@ -21,7 +21,7 @@
 
 #include <boost/thread/lock_types.hpp>
 //#include <boost/thread/shared_mutex.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 bool unlock_called = false;
 

--- a/test/sync/mutual_exclusion/locks/upgrade_lock/mod/member_swap_pass.cpp
+++ b/test/sync/mutual_exclusion/locks/upgrade_lock/mod/member_swap_pass.cpp
@@ -19,7 +19,7 @@
 // void swap(upgrade_lock& u);
 
 #include <boost/thread/lock_types.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 struct shared_mutex
 {

--- a/test/sync/mutual_exclusion/locks/upgrade_lock/mod/non_member_swap_pass.cpp
+++ b/test/sync/mutual_exclusion/locks/upgrade_lock/mod/non_member_swap_pass.cpp
@@ -18,7 +18,7 @@
 //   void swap(upgrade_lock<Mutex>& x, upgrade_lock<Mutex>& y);
 
 #include <boost/thread/lock_types.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 struct shared_mutex
 {

--- a/test/sync/mutual_exclusion/locks/upgrade_lock/mod/release_pass.cpp
+++ b/test/sync/mutual_exclusion/locks/upgrade_lock/mod/release_pass.cpp
@@ -19,7 +19,7 @@
 // void Mutex* release();
 
 #include <boost/thread/lock_types.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 struct shared_mutex
 {

--- a/test/sync/mutual_exclusion/locks/upgrade_lock/obs/mutex_pass.cpp
+++ b/test/sync/mutual_exclusion/locks/upgrade_lock/obs/mutex_pass.cpp
@@ -20,7 +20,7 @@
 
 #include <boost/thread/lock_types.hpp>
 #include <boost/thread/shared_mutex.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 boost::shared_mutex m;
 

--- a/test/sync/mutual_exclusion/locks/upgrade_lock/obs/op_bool_pass.cpp
+++ b/test/sync/mutual_exclusion/locks/upgrade_lock/obs/op_bool_pass.cpp
@@ -20,7 +20,7 @@
 
 #include <boost/thread/lock_types.hpp>
 #include <boost/thread/shared_mutex.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 boost::shared_mutex m;
 

--- a/test/sync/mutual_exclusion/locks/upgrade_lock/obs/owns_lock_pass.cpp
+++ b/test/sync/mutual_exclusion/locks/upgrade_lock/obs/owns_lock_pass.cpp
@@ -20,7 +20,7 @@
 
 #include <boost/thread/lock_types.hpp>
 #include <boost/thread/shared_mutex.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 boost::shared_mutex m;
 

--- a/test/sync/mutual_exclusion/locks/upgrade_lock/types_pass.cpp
+++ b/test/sync/mutual_exclusion/locks/upgrade_lock/types_pass.cpp
@@ -28,7 +28,8 @@
 #include <boost/thread/lock_types.hpp>
 #include <boost/thread/shared_mutex.hpp>
 #include <boost/static_assert.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/type_traits/is_same.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 int main()
 {

--- a/test/sync/mutual_exclusion/mutex/assign_fail.cpp
+++ b/test/sync/mutual_exclusion/mutex/assign_fail.cpp
@@ -19,7 +19,7 @@
 // mutex& operator=(const mutex&) = delete;
 
 #include <boost/thread/mutex.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 int main()
 {

--- a/test/sync/mutual_exclusion/mutex/copy_fail.cpp
+++ b/test/sync/mutual_exclusion/mutex/copy_fail.cpp
@@ -19,7 +19,7 @@
 // mutex(const mutex&) = delete;
 
 #include <boost/thread/mutex.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 int main()
 {

--- a/test/sync/mutual_exclusion/mutex/default_pass.cpp
+++ b/test/sync/mutual_exclusion/mutex/default_pass.cpp
@@ -19,7 +19,7 @@
 // mutex();
 
 #include <boost/thread/mutex.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 int main()
 {

--- a/test/sync/mutual_exclusion/mutex/lock_compile_fail.cpp
+++ b/test/sync/mutual_exclusion/mutex/lock_compile_fail.cpp
@@ -8,7 +8,7 @@
 // class mutex;
 
 #include <boost/thread/mutex.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 void fail()
 {

--- a/test/sync/mutual_exclusion/mutex/lock_compile_pass.cpp
+++ b/test/sync/mutual_exclusion/mutex/lock_compile_pass.cpp
@@ -8,7 +8,7 @@
 // class mutex;
 
 #include <boost/thread/mutex.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 void pass()
 {

--- a/test/sync/mutual_exclusion/mutex/lock_pass.cpp
+++ b/test/sync/mutual_exclusion/mutex/lock_pass.cpp
@@ -20,7 +20,7 @@
 
 #include <boost/thread/mutex.hpp>
 #include <boost/thread/thread.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 #include "../../../timming.hpp"
 
 boost::mutex m;

--- a/test/sync/mutual_exclusion/mutex/native_handle_pass.cpp
+++ b/test/sync/mutual_exclusion/mutex/native_handle_pass.cpp
@@ -20,7 +20,7 @@
 // native_handle_type native_handle();
 
 #include <boost/thread/mutex.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 int main()
 {

--- a/test/sync/mutual_exclusion/mutex/try_lock_compile_fail.cpp
+++ b/test/sync/mutual_exclusion/mutex/try_lock_compile_fail.cpp
@@ -8,7 +8,7 @@
 // class mutex;
 
 #include <boost/thread/mutex.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 void fail()
 {

--- a/test/sync/mutual_exclusion/mutex/try_lock_compile_pass.cpp
+++ b/test/sync/mutual_exclusion/mutex/try_lock_compile_pass.cpp
@@ -8,7 +8,7 @@
 // class mutex;
 
 #include <boost/thread/mutex.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 void pass()
 {

--- a/test/sync/mutual_exclusion/mutex/try_lock_pass.cpp
+++ b/test/sync/mutual_exclusion/mutex/try_lock_pass.cpp
@@ -20,7 +20,7 @@
 
 #include <boost/thread/mutex.hpp>
 #include <boost/thread/thread.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 #include "../../../timming.hpp"
 
 

--- a/test/sync/mutual_exclusion/null_mutex/assign_fail.cpp
+++ b/test/sync/mutual_exclusion/null_mutex/assign_fail.cpp
@@ -19,7 +19,7 @@
 // null_mutex& operator=(const null_mutex&) = delete;
 
 #include <boost/thread/null_mutex.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 int main()
 {

--- a/test/sync/mutual_exclusion/null_mutex/copy_fail.cpp
+++ b/test/sync/mutual_exclusion/null_mutex/copy_fail.cpp
@@ -19,7 +19,7 @@
 // null_mutex(const null_mutex&) = delete;
 
 #include <boost/thread/null_mutex.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 int main()
 {

--- a/test/sync/mutual_exclusion/null_mutex/default_pass.cpp
+++ b/test/sync/mutual_exclusion/null_mutex/default_pass.cpp
@@ -19,7 +19,7 @@
 // null_mutex();
 
 #include <boost/thread/null_mutex.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 int main()
 {

--- a/test/sync/mutual_exclusion/null_mutex/lock_pass.cpp
+++ b/test/sync/mutual_exclusion/null_mutex/lock_pass.cpp
@@ -20,7 +20,7 @@
 
 #include <boost/thread/null_mutex.hpp>
 #include <boost/thread/thread.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 #include "../../../timming.hpp"
 
 boost::null_mutex m;

--- a/test/sync/mutual_exclusion/null_mutex/try_lock_for_pass.cpp
+++ b/test/sync/mutual_exclusion/null_mutex/try_lock_for_pass.cpp
@@ -21,7 +21,7 @@
 
 #include <boost/thread/null_mutex.hpp>
 #include <boost/thread/thread.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 #include "../../../timming.hpp"
 
 #if defined BOOST_THREAD_USES_CHRONO

--- a/test/sync/mutual_exclusion/null_mutex/try_lock_pass.cpp
+++ b/test/sync/mutual_exclusion/null_mutex/try_lock_pass.cpp
@@ -20,7 +20,7 @@
 
 #include <boost/thread/null_mutex.hpp>
 #include <boost/thread/thread.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 #include "../../../timming.hpp"
 
 

--- a/test/sync/mutual_exclusion/null_mutex/try_lock_until_pass.cpp
+++ b/test/sync/mutual_exclusion/null_mutex/try_lock_until_pass.cpp
@@ -21,7 +21,7 @@
 
 #include <boost/thread/null_mutex.hpp>
 #include <boost/thread/thread.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 #include "../../../timming.hpp"
 
 #if defined BOOST_THREAD_USES_CHRONO

--- a/test/sync/mutual_exclusion/once/call_once/call_once_pass.cpp
+++ b/test/sync/mutual_exclusion/once/call_once/call_once_pass.cpp
@@ -25,7 +25,7 @@
 
 #include <boost/thread/once.hpp>
 #include <boost/thread/thread.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 #ifdef BOOST_THREAD_PROVIDES_ONCE_CXX11
 #define BOOST_INIT_ONCE_INIT

--- a/test/sync/mutual_exclusion/queue_views/single_thread_pass.cpp
+++ b/test/sync/mutual_exclusion/queue_views/single_thread_pass.cpp
@@ -16,7 +16,7 @@
 #include <boost/thread/concurrent_queues/queue_adaptor.hpp>
 #include <boost/thread/concurrent_queues/queue_views.hpp>
 
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 #include <boost/static_assert.hpp>
 
 class non_copyable

--- a/test/sync/mutual_exclusion/recursive_mutex/assign_fail.cpp
+++ b/test/sync/mutual_exclusion/recursive_mutex/assign_fail.cpp
@@ -19,7 +19,7 @@
 // recursive_mutex& operator=(const recursive_mutex&) = delete;
 
 #include <boost/thread/recursive_mutex.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 int main()
 {

--- a/test/sync/mutual_exclusion/recursive_mutex/copy_fail.cpp
+++ b/test/sync/mutual_exclusion/recursive_mutex/copy_fail.cpp
@@ -19,7 +19,7 @@
 // recursive_mutex(const recursive_mutex&) = delete;
 
 #include <boost/thread/recursive_mutex.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 int main()
 {

--- a/test/sync/mutual_exclusion/recursive_mutex/default_pass.cpp
+++ b/test/sync/mutual_exclusion/recursive_mutex/default_pass.cpp
@@ -19,7 +19,7 @@
 // recursive_mutex();
 
 #include <boost/thread/recursive_mutex.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 int main()
 {

--- a/test/sync/mutual_exclusion/recursive_mutex/lock_pass.cpp
+++ b/test/sync/mutual_exclusion/recursive_mutex/lock_pass.cpp
@@ -20,7 +20,7 @@
 
 #include <boost/thread/recursive_mutex.hpp>
 #include <boost/thread/thread.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 #include "../../../timming.hpp"
 
 

--- a/test/sync/mutual_exclusion/recursive_mutex/native_handle_pass.cpp
+++ b/test/sync/mutual_exclusion/recursive_mutex/native_handle_pass.cpp
@@ -20,7 +20,7 @@
 // native_handle_type native_handle();
 
 #include <boost/thread/recursive_mutex.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 int main()
 {

--- a/test/sync/mutual_exclusion/recursive_mutex/try_lock_pass.cpp
+++ b/test/sync/mutual_exclusion/recursive_mutex/try_lock_pass.cpp
@@ -20,7 +20,7 @@
 
 #include <boost/thread/recursive_mutex.hpp>
 #include <boost/thread/thread.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 #include <iostream>
 #include "../../../timming.hpp"
 

--- a/test/sync/mutual_exclusion/recursive_timed_mutex/assign_fail.cpp
+++ b/test/sync/mutual_exclusion/recursive_timed_mutex/assign_fail.cpp
@@ -19,7 +19,7 @@
 // recursive_timed_mutex& operator=(const recursive_timed_mutex&) = delete;
 
 #include <boost/thread/recursive_mutex.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 int main()
 {

--- a/test/sync/mutual_exclusion/recursive_timed_mutex/copy_fail.cpp
+++ b/test/sync/mutual_exclusion/recursive_timed_mutex/copy_fail.cpp
@@ -19,7 +19,7 @@
 // recursive_timed_mutex(const recursive_timed_mutex&) = delete;
 
 #include <boost/thread/recursive_mutex.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 int main()
 {

--- a/test/sync/mutual_exclusion/recursive_timed_mutex/default_pass.cpp
+++ b/test/sync/mutual_exclusion/recursive_timed_mutex/default_pass.cpp
@@ -19,7 +19,7 @@
 // recursive_timed_mutex();
 
 #include <boost/thread/recursive_mutex.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 int main()
 {

--- a/test/sync/mutual_exclusion/recursive_timed_mutex/lock_pass.cpp
+++ b/test/sync/mutual_exclusion/recursive_timed_mutex/lock_pass.cpp
@@ -20,7 +20,7 @@
 
 #include <boost/thread/recursive_mutex.hpp>
 #include <boost/thread/thread.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 #include <iostream>
 #include "../../../timming.hpp"
 

--- a/test/sync/mutual_exclusion/recursive_timed_mutex/native_handle_pass.cpp
+++ b/test/sync/mutual_exclusion/recursive_timed_mutex/native_handle_pass.cpp
@@ -20,7 +20,7 @@
 // native_handle_type native_handle();
 
 #include <boost/thread/recursive_mutex.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 int main()
 {

--- a/test/sync/mutual_exclusion/recursive_timed_mutex/try_lock_for_pass.cpp
+++ b/test/sync/mutual_exclusion/recursive_timed_mutex/try_lock_for_pass.cpp
@@ -21,7 +21,7 @@
 
 #include <boost/thread/recursive_mutex.hpp>
 #include <boost/thread/thread.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 #include "../../../timming.hpp"
 
 #if defined BOOST_THREAD_USES_CHRONO

--- a/test/sync/mutual_exclusion/recursive_timed_mutex/try_lock_pass.cpp
+++ b/test/sync/mutual_exclusion/recursive_timed_mutex/try_lock_pass.cpp
@@ -20,7 +20,7 @@
 
 #include <boost/thread/recursive_mutex.hpp>
 #include <boost/thread/thread.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 #include "../../../timming.hpp"
 
 boost::recursive_timed_mutex m;

--- a/test/sync/mutual_exclusion/recursive_timed_mutex/try_lock_until_pass.cpp
+++ b/test/sync/mutual_exclusion/recursive_timed_mutex/try_lock_until_pass.cpp
@@ -21,7 +21,7 @@
 
 #include <boost/thread/recursive_mutex.hpp>
 #include <boost/thread/thread.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 #include "../../../timming.hpp"
 
 #if defined BOOST_THREAD_USES_CHRONO

--- a/test/sync/mutual_exclusion/shared_mutex/assign_fail.cpp
+++ b/test/sync/mutual_exclusion/shared_mutex/assign_fail.cpp
@@ -19,7 +19,7 @@
 // shared_mutex& operator=(const shared_mutex&) = delete;
 
 #include <boost/thread/shared_mutex.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 int main()
 {

--- a/test/sync/mutual_exclusion/shared_mutex/copy_fail.cpp
+++ b/test/sync/mutual_exclusion/shared_mutex/copy_fail.cpp
@@ -19,7 +19,7 @@
 // shared_mutex(const shared_mutex&) = delete;
 
 #include <boost/thread/shared_mutex.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 int main()
 {

--- a/test/sync/mutual_exclusion/shared_mutex/default_pass.cpp
+++ b/test/sync/mutual_exclusion/shared_mutex/default_pass.cpp
@@ -19,7 +19,7 @@
 // shared_mutex();
 
 #include <boost/thread/shared_mutex.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 int main()
 {

--- a/test/sync/mutual_exclusion/shared_mutex/lock_pass.cpp
+++ b/test/sync/mutual_exclusion/shared_mutex/lock_pass.cpp
@@ -20,7 +20,7 @@
 
 #include <boost/thread/shared_mutex.hpp>
 #include <boost/thread/thread.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 #include "../../../timming.hpp"
 
 boost::shared_mutex m;

--- a/test/sync/mutual_exclusion/shared_mutex/try_lock_for_pass.cpp
+++ b/test/sync/mutual_exclusion/shared_mutex/try_lock_for_pass.cpp
@@ -21,7 +21,7 @@
 
 #include <boost/thread/shared_mutex.hpp>
 #include <boost/thread/thread.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 #include "../../../timming.hpp"
 
 boost::shared_mutex m;

--- a/test/sync/mutual_exclusion/shared_mutex/try_lock_pass.cpp
+++ b/test/sync/mutual_exclusion/shared_mutex/try_lock_pass.cpp
@@ -20,7 +20,7 @@
 
 #include <boost/thread/shared_mutex.hpp>
 #include <boost/thread/thread.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 #include "../../../timming.hpp"
 
 boost::shared_mutex m;

--- a/test/sync/mutual_exclusion/shared_mutex/try_lock_until_pass.cpp
+++ b/test/sync/mutual_exclusion/shared_mutex/try_lock_until_pass.cpp
@@ -21,7 +21,7 @@
 
 #include <boost/thread/shared_mutex.hpp>
 #include <boost/thread/thread.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 #include "../../../timming.hpp"
 
 boost::shared_mutex m;

--- a/test/sync/mutual_exclusion/sync_bounded_queue/multi_thread_pass.cpp
+++ b/test/sync/mutual_exclusion/sync_bounded_queue/multi_thread_pass.cpp
@@ -20,7 +20,7 @@
 #include <boost/thread/future.hpp>
 #include <boost/thread/barrier.hpp>
 
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 struct call_push
 {

--- a/test/sync/mutual_exclusion/sync_bounded_queue/single_thread_pass.cpp
+++ b/test/sync/mutual_exclusion/sync_bounded_queue/single_thread_pass.cpp
@@ -14,7 +14,7 @@
 
 #include <boost/thread/sync_bounded_queue.hpp>
 
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 class non_copyable
 {

--- a/test/sync/mutual_exclusion/sync_deque/multi_thread_pass.cpp
+++ b/test/sync/mutual_exclusion/sync_deque/multi_thread_pass.cpp
@@ -20,7 +20,7 @@
 #include <boost/thread/future.hpp>
 #include <boost/thread/barrier.hpp>
 
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 template <typename ValueType>
 struct call_push_back

--- a/test/sync/mutual_exclusion/sync_deque/single_thread_pass.cpp
+++ b/test/sync/mutual_exclusion/sync_deque/single_thread_pass.cpp
@@ -13,7 +13,7 @@
 
 #include <boost/thread/concurrent_queues/sync_deque.hpp>
 
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 class non_copyable
 {

--- a/test/sync/mutual_exclusion/sync_pq/pq_multi_thread_pass.cpp
+++ b/test/sync/mutual_exclusion/sync_pq/pq_multi_thread_pass.cpp
@@ -19,6 +19,7 @@
 #include <boost/thread/barrier.hpp>
 #include <boost/thread/concurrent_queues/sync_priority_queue.hpp>
 
+#include <boost/bind/bind.hpp>
 #include <boost/core/lightweight_test.hpp>
 
 #ifdef BOOST_MSVC

--- a/test/sync/mutual_exclusion/sync_pq/pq_single_thread_pass.cpp
+++ b/test/sync/mutual_exclusion/sync_pq/pq_single_thread_pass.cpp
@@ -19,7 +19,7 @@
 #include <boost/chrono.hpp>
 #include <boost/thread/concurrent_queues/sync_priority_queue.hpp>
 
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 #include "../../../timming.hpp"
 
 using namespace boost::chrono;

--- a/test/sync/mutual_exclusion/sync_pq/tq_multi_thread_pass.cpp
+++ b/test/sync/mutual_exclusion/sync_pq/tq_multi_thread_pass.cpp
@@ -17,6 +17,7 @@
 #include <boost/chrono.hpp>
 #include <boost/thread/concurrent_queues/sync_timed_queue.hpp>
 
+#include <boost/bind/bind.hpp>
 #include <boost/core/lightweight_test.hpp>
 #include "../../../timming.hpp"
 

--- a/test/sync/mutual_exclusion/sync_pq/tq_single_thread_pass.cpp
+++ b/test/sync/mutual_exclusion/sync_pq/tq_single_thread_pass.cpp
@@ -16,6 +16,7 @@
 #include <boost/thread.hpp>
 #include <boost/chrono.hpp>
 #include <boost/function.hpp>
+#include <boost/bind/bind.hpp>
 #include <boost/thread/concurrent_queues/sync_timed_queue.hpp>
 #include <boost/thread/executors/work.hpp>
 

--- a/test/sync/mutual_exclusion/sync_queue/multi_thread_pass.cpp
+++ b/test/sync/mutual_exclusion/sync_queue/multi_thread_pass.cpp
@@ -20,7 +20,7 @@
 #include <boost/thread/future.hpp>
 #include <boost/thread/barrier.hpp>
 
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 template <typename ValueType>
 struct call_push

--- a/test/sync/mutual_exclusion/sync_queue/single_thread_pass.cpp
+++ b/test/sync/mutual_exclusion/sync_queue/single_thread_pass.cpp
@@ -13,7 +13,7 @@
 
 #include <boost/thread/sync_queue.hpp>
 
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 class non_copyable
 {

--- a/test/sync/mutual_exclusion/synchronized_value/call_pass.cpp
+++ b/test/sync/mutual_exclusion/synchronized_value/call_pass.cpp
@@ -23,7 +23,7 @@
 
 #include <boost/thread/synchronized_value.hpp>
 
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 struct S {
   int f() const {return 1;}

--- a/test/sync/mutual_exclusion/synchronized_value/copy_T_assign_pass.cpp
+++ b/test/sync/mutual_exclusion/synchronized_value/copy_T_assign_pass.cpp
@@ -13,7 +13,7 @@
 
 #include <boost/thread/synchronized_value.hpp>
 
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 int main()
 {

--- a/test/sync/mutual_exclusion/synchronized_value/copy_T_ctor_pass.cpp
+++ b/test/sync/mutual_exclusion/synchronized_value/copy_T_ctor_pass.cpp
@@ -13,7 +13,7 @@
 
 #include <boost/thread/synchronized_value.hpp>
 
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 int main()
 {

--- a/test/sync/mutual_exclusion/synchronized_value/copy_assign_pass.cpp
+++ b/test/sync/mutual_exclusion/synchronized_value/copy_assign_pass.cpp
@@ -13,7 +13,7 @@
 
 #include <boost/thread/synchronized_value.hpp>
 
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 int main()
 {

--- a/test/sync/mutual_exclusion/synchronized_value/copy_ctor_pass.cpp
+++ b/test/sync/mutual_exclusion/synchronized_value/copy_ctor_pass.cpp
@@ -13,7 +13,7 @@
 
 #include <boost/thread/synchronized_value.hpp>
 
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 int main()
 {

--- a/test/sync/mutual_exclusion/synchronized_value/default_ctor_pass.cpp
+++ b/test/sync/mutual_exclusion/synchronized_value/default_ctor_pass.cpp
@@ -13,7 +13,7 @@
 
 #include <boost/thread/synchronized_value.hpp>
 
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 int main()
 {

--- a/test/sync/mutual_exclusion/synchronized_value/indirect_pass.cpp
+++ b/test/sync/mutual_exclusion/synchronized_value/indirect_pass.cpp
@@ -14,7 +14,7 @@
 
 #include <boost/thread/synchronized_value.hpp>
 
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 struct S {
   int f() const {return 1;}

--- a/test/sync/mutual_exclusion/synchronized_value/move_T_assign_pass.cpp
+++ b/test/sync/mutual_exclusion/synchronized_value/move_T_assign_pass.cpp
@@ -13,7 +13,7 @@
 
 #include <boost/thread/synchronized_value.hpp>
 
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 int main()
 {

--- a/test/sync/mutual_exclusion/synchronized_value/move_T_ctor_pass.cpp
+++ b/test/sync/mutual_exclusion/synchronized_value/move_T_ctor_pass.cpp
@@ -13,7 +13,7 @@
 
 #include <boost/thread/synchronized_value.hpp>
 
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 int main()
 {

--- a/test/sync/mutual_exclusion/synchronized_value/move_assign_pass.cpp
+++ b/test/sync/mutual_exclusion/synchronized_value/move_assign_pass.cpp
@@ -13,7 +13,7 @@
 
 #include <boost/thread/synchronized_value.hpp>
 
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 int main()
 {

--- a/test/sync/mutual_exclusion/synchronized_value/move_ctor_pass.cpp
+++ b/test/sync/mutual_exclusion/synchronized_value/move_ctor_pass.cpp
@@ -13,7 +13,7 @@
 
 #include <boost/thread/synchronized_value.hpp>
 
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 int main()
 {

--- a/test/sync/mutual_exclusion/synchronized_value/swap_T_pass.cpp
+++ b/test/sync/mutual_exclusion/synchronized_value/swap_T_pass.cpp
@@ -13,7 +13,7 @@
 
 #include <boost/thread/synchronized_value.hpp>
 
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 int main()
 {

--- a/test/sync/mutual_exclusion/synchronized_value/swap_pass.cpp
+++ b/test/sync/mutual_exclusion/synchronized_value/swap_pass.cpp
@@ -13,7 +13,7 @@
 
 #include <boost/thread/synchronized_value.hpp>
 
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 int main()
 {

--- a/test/sync/mutual_exclusion/synchronized_value/synchronize_pass.cpp
+++ b/test/sync/mutual_exclusion/synchronized_value/synchronize_pass.cpp
@@ -15,7 +15,7 @@
 
 #include <boost/thread/synchronized_value.hpp>
 
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 struct S {
   int f() const {return 1;}

--- a/test/sync/mutual_exclusion/timed_mutex/assign_fail.cpp
+++ b/test/sync/mutual_exclusion/timed_mutex/assign_fail.cpp
@@ -19,7 +19,7 @@
 // timed_mutex& operator=(const timed_mutex&) = delete;
 
 #include <boost/thread/mutex.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 int main()
 {

--- a/test/sync/mutual_exclusion/timed_mutex/copy_fail.cpp
+++ b/test/sync/mutual_exclusion/timed_mutex/copy_fail.cpp
@@ -19,7 +19,7 @@
 // timed_mutex(const timed_mutex&) = delete;
 
 #include <boost/thread/mutex.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 int main()
 {

--- a/test/sync/mutual_exclusion/timed_mutex/default_pass.cpp
+++ b/test/sync/mutual_exclusion/timed_mutex/default_pass.cpp
@@ -19,7 +19,7 @@
 // timed_mutex();
 
 #include <boost/thread/mutex.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 int main()
 {

--- a/test/sync/mutual_exclusion/timed_mutex/lock_pass.cpp
+++ b/test/sync/mutual_exclusion/timed_mutex/lock_pass.cpp
@@ -20,7 +20,7 @@
 
 #include <boost/thread/mutex.hpp>
 #include <boost/thread/thread.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 #include "../../../timming.hpp"
 
 boost::timed_mutex m;

--- a/test/sync/mutual_exclusion/timed_mutex/native_handle_pass.cpp
+++ b/test/sync/mutual_exclusion/timed_mutex/native_handle_pass.cpp
@@ -20,7 +20,7 @@
 // native_handle_type native_handle();
 
 #include <boost/thread/mutex.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 
 int main()

--- a/test/sync/mutual_exclusion/timed_mutex/try_lock_for_pass.cpp
+++ b/test/sync/mutual_exclusion/timed_mutex/try_lock_for_pass.cpp
@@ -21,7 +21,7 @@
 
 #include <boost/thread/mutex.hpp>
 #include <boost/thread/thread.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 #include "../../../timming.hpp"
 
 #if defined BOOST_THREAD_USES_CHRONO

--- a/test/sync/mutual_exclusion/timed_mutex/try_lock_pass.cpp
+++ b/test/sync/mutual_exclusion/timed_mutex/try_lock_pass.cpp
@@ -20,7 +20,7 @@
 
 #include <boost/thread/mutex.hpp>
 #include <boost/thread/thread.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 #include "../../../timming.hpp"
 
 

--- a/test/sync/mutual_exclusion/timed_mutex/try_lock_until_pass.cpp
+++ b/test/sync/mutual_exclusion/timed_mutex/try_lock_until_pass.cpp
@@ -21,7 +21,7 @@
 
 #include <boost/thread/mutex.hpp>
 #include <boost/thread/thread.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 #include "../../../timming.hpp"
 
 #if defined BOOST_THREAD_USES_CHRONO

--- a/test/sync/mutual_exclusion/with_lock_guard/with_lock_guard_bind.cpp
+++ b/test/sync/mutual_exclusion/with_lock_guard/with_lock_guard_bind.cpp
@@ -8,11 +8,12 @@
 
 #define BOOST_THREAD_VERSION 4
 
-#include <boost/detail/lightweight_test.hpp> // BOOST_TEST
+#include <boost/core/lightweight_test.hpp> // BOOST_TEST
 
 #include <boost/thread/mutex.hpp>
 #include <boost/thread/with_lock_guard.hpp>
 #include <boost/bind/bind.hpp>
+#include <boost/core/ref.hpp>
 
 class Foo {
  public:

--- a/test/sync/mutual_exclusion/with_lock_guard/with_lock_guard_lambda.cpp
+++ b/test/sync/mutual_exclusion/with_lock_guard/with_lock_guard_lambda.cpp
@@ -14,7 +14,7 @@
 
 #define BOOST_THREAD_VERSION 4
 
-#include <boost/detail/lightweight_test.hpp> // BOOST_TEST
+#include <boost/core/lightweight_test.hpp> // BOOST_TEST
 
 #include <iostream> // std::cout
 #include <boost/thread/mutex.hpp>

--- a/test/sync/mutual_exclusion/with_lock_guard/with_lock_guard_move.cpp
+++ b/test/sync/mutual_exclusion/with_lock_guard/with_lock_guard_move.cpp
@@ -8,7 +8,7 @@
 
 #define BOOST_THREAD_VERSION 4
 
-#include <boost/detail/lightweight_test.hpp> // BOOST_TEST
+#include <boost/core/lightweight_test.hpp> // BOOST_TEST
 
 #include <boost/thread/mutex.hpp>
 #include <boost/thread/with_lock_guard.hpp>

--- a/test/sync/mutual_exclusion/with_lock_guard/with_lock_guard_simple.cpp
+++ b/test/sync/mutual_exclusion/with_lock_guard/with_lock_guard_simple.cpp
@@ -8,7 +8,7 @@
 
 #define BOOST_THREAD_VERSION 4
 
-#include <boost/detail/lightweight_test.hpp> // BOOST_TEST
+#include <boost/core/lightweight_test.hpp> // BOOST_TEST
 
 #include <boost/thread/mutex.hpp>
 #include <boost/thread/with_lock_guard.hpp>

--- a/test/test_10963.cpp
+++ b/test/test_10963.cpp
@@ -15,6 +15,7 @@
 #include <cassert>
 #include <boost/thread/executors/basic_thread_pool.hpp>
 
+#include <boost/type_traits/is_same.hpp>
 
 struct TestCallback
 {
@@ -42,18 +43,18 @@ int main()
     boost::promise<void> test_promise;
     boost::future<void> test_future(test_promise.get_future());
     auto f1 = test_future.then(TestCallback());
-    BOOST_STATIC_ASSERT(std::is_same<decltype(f1), boost::future<boost::future<void> > >::value);
+    BOOST_STATIC_ASSERT(boost::is_same<decltype(f1), boost::future<boost::future<void> > >::value);
     auto f2 = f1.then(TestCallback());
-    BOOST_STATIC_ASSERT(std::is_same<decltype(f2), boost::future<boost::future<void> > >::value);
+    BOOST_STATIC_ASSERT(boost::is_same<decltype(f2), boost::future<boost::future<void> > >::value);
   }
   {
     boost::basic_thread_pool executor;
     boost::promise<void> test_promise;
     boost::future<void> test_future(test_promise.get_future());
     auto f1 = test_future.then(executor, TestCallback());
-    BOOST_STATIC_ASSERT(std::is_same<decltype(f1), boost::future<boost::future<void> > >::value);
+    BOOST_STATIC_ASSERT(boost::is_same<decltype(f1), boost::future<boost::future<void> > >::value);
     auto f2 = f1.then(executor, TestCallback());
-    BOOST_STATIC_ASSERT(std::is_same<decltype(f2), boost::future<boost::future<void> > >::value);
+    BOOST_STATIC_ASSERT(boost::is_same<decltype(f2), boost::future<boost::future<void> > >::value);
 
   }
 #endif

--- a/test/test_10964.cpp
+++ b/test/test_10964.cpp
@@ -16,6 +16,8 @@
 #include <iostream>
 #include <boost/thread/executors/basic_thread_pool.hpp>
 
+#include <boost/type_traits/is_same.hpp>
+
 struct TestCallback
 {
   typedef boost::future<void> result_type;
@@ -77,7 +79,7 @@ int main()
   std::cout << __FILE__ << "[" << __LINE__ << "]" << std::endl;
   {
     auto f1 = boost::make_ready_future().then(TestCallback());
-    BOOST_STATIC_ASSERT(std::is_same<decltype(f1), boost::future<boost::future<void> > >::value);
+    BOOST_STATIC_ASSERT(boost::is_same<decltype(f1), boost::future<boost::future<void> > >::value);
     f1.wait();
   }
   std::cout << __FILE__ << "[" << __LINE__ << "]" << std::endl;
@@ -85,11 +87,11 @@ int main()
   {
     auto f1 = boost::make_ready_future().then(TestCallback());
     std::cout << __FILE__ << "[" << __LINE__ << "]" << std::endl;
-    BOOST_STATIC_ASSERT(std::is_same<decltype(f1), boost::future<boost::future<void> > >::value);
+    BOOST_STATIC_ASSERT(boost::is_same<decltype(f1), boost::future<boost::future<void> > >::value);
     std::cout << __FILE__ << "[" << __LINE__ << "]" << std::endl;
     auto f2 = f1.unwrap();
     std::cout << __FILE__ << "[" << __LINE__ << "]" << std::endl;
-    BOOST_STATIC_ASSERT(std::is_same<decltype(f2), boost::future<void> >::value);
+    BOOST_STATIC_ASSERT(boost::is_same<decltype(f2), boost::future<void> >::value);
     std::cout << __FILE__ << "[" << __LINE__ << "]" << std::endl;
     f2.wait();
     std::cout << __FILE__ << "[" << __LINE__ << "]" << std::endl;
@@ -98,26 +100,26 @@ int main()
   for (int i=0; i< number_of_tests; i++)
   {
     auto f1 = boost::make_ready_future().then(TestCallback());
-    BOOST_STATIC_ASSERT(std::is_same<decltype(f1), boost::future<boost::future<void> > >::value);
+    BOOST_STATIC_ASSERT(boost::is_same<decltype(f1), boost::future<boost::future<void> > >::value);
     boost::future<void> f2 = f1.get();
   }
   std::cout << __FILE__ << "[" << __LINE__ << "]" << std::endl;
   {
     auto f1 = boost::make_ready_future().then(TestCallback());
-    BOOST_STATIC_ASSERT(std::is_same<decltype(f1), boost::future<boost::future<void> > >::value);
+    BOOST_STATIC_ASSERT(boost::is_same<decltype(f1), boost::future<boost::future<void> > >::value);
     auto f3 = f1.then(TestCallback());
-    BOOST_STATIC_ASSERT(std::is_same<decltype(f3), boost::future<boost::future<void> > >::value);
+    BOOST_STATIC_ASSERT(boost::is_same<decltype(f3), boost::future<boost::future<void> > >::value);
     f3.wait();
   }
   std::cout << __FILE__ << "[" << __LINE__ << "]" << std::endl;
   for (int i=0; i< number_of_tests; i++)
   {
     auto f1 = boost::make_ready_future().then(TestCallback());
-    BOOST_STATIC_ASSERT(std::is_same<decltype(f1), boost::future<boost::future<void> > >::value);
+    BOOST_STATIC_ASSERT(boost::is_same<decltype(f1), boost::future<boost::future<void> > >::value);
     auto f2 = f1.unwrap();
-    BOOST_STATIC_ASSERT(std::is_same<decltype(f2), boost::future<void> >::value);
+    BOOST_STATIC_ASSERT(boost::is_same<decltype(f2), boost::future<void> >::value);
     auto f3 = f2.then(TestCallback());
-    BOOST_STATIC_ASSERT(std::is_same<decltype(f3), boost::future<boost::future<void> > >::value);
+    BOOST_STATIC_ASSERT(boost::is_same<decltype(f3), boost::future<boost::future<void> > >::value);
     f3.wait();
   }
   std::cout << __FILE__ << "[" << __LINE__ << "]" << std::endl;
@@ -137,9 +139,9 @@ int main()
   for (int i=0; i< number_of_tests; i++)
   {
     auto f1 = boost::make_ready_future().then(TestCallback());
-    BOOST_STATIC_ASSERT(std::is_same<decltype(f1), boost::future<boost::future<void> > >::value);
+    BOOST_STATIC_ASSERT(boost::is_same<decltype(f1), boost::future<boost::future<void> > >::value);
     auto f3 = f1.then(TestCallback());
-    BOOST_STATIC_ASSERT(std::is_same<decltype(f3), boost::future<boost::future<void> > >::value);
+    BOOST_STATIC_ASSERT(boost::is_same<decltype(f3), boost::future<boost::future<void> > >::value);
     f3.wait();
   }
   std::cout << __FILE__ << "[" << __LINE__ << "]" << std::endl;
@@ -147,9 +149,9 @@ int main()
   {
     boost::basic_thread_pool executor;
     auto f1 = boost::make_ready_future().then(executor, TestCallback());
-    BOOST_STATIC_ASSERT(std::is_same<decltype(f1), boost::future<boost::future<void> > >::value);
+    BOOST_STATIC_ASSERT(boost::is_same<decltype(f1), boost::future<boost::future<void> > >::value);
     auto f3 = f1.then(executor, TestCallback());
-    BOOST_STATIC_ASSERT(std::is_same<decltype(f3), boost::future<boost::future<void> > >::value);
+    BOOST_STATIC_ASSERT(boost::is_same<decltype(f3), boost::future<boost::future<void> > >::value);
     f3.wait();
   }
 #if 1
@@ -160,14 +162,14 @@ int main()
     boost::basic_thread_pool executor(2);
 
     auto f1 = boost::make_ready_future().then(executor, TestCallback());
-    BOOST_STATIC_ASSERT(std::is_same<decltype(f1), boost::future<boost::future<void> > >::value);
+    BOOST_STATIC_ASSERT(boost::is_same<decltype(f1), boost::future<boost::future<void> > >::value);
     std::cout << __FILE__ << "[" << __LINE__ << "] " << int(f1.valid()) << std::endl;
     auto f2 = f1.unwrap();
     std::cout << __FILE__ << "[" << __LINE__ << "] " << int(f2.valid()) << std::endl;
 
-    BOOST_STATIC_ASSERT(std::is_same<decltype(f2), boost::future<void> >::value);
+    BOOST_STATIC_ASSERT(boost::is_same<decltype(f2), boost::future<void> >::value);
     auto f3 = f2.then(executor, TestCallback());
-    BOOST_STATIC_ASSERT(std::is_same<decltype(f3), boost::future<boost::future<void> > >::value);
+    BOOST_STATIC_ASSERT(boost::is_same<decltype(f3), boost::future<boost::future<void> > >::value);
     f3.wait();
   }
 #endif
@@ -177,11 +179,11 @@ int main()
     boost::basic_thread_pool executor;
 
     auto f1 = boost::make_ready_future().then(executor, TestCallback());
-    BOOST_STATIC_ASSERT(std::is_same<decltype(f1), boost::future<boost::future<void> > >::value);
+    BOOST_STATIC_ASSERT(boost::is_same<decltype(f1), boost::future<boost::future<void> > >::value);
     auto f2 = f1.unwrap();
-    BOOST_STATIC_ASSERT(std::is_same<decltype(f2), boost::future<void> >::value);
+    BOOST_STATIC_ASSERT(boost::is_same<decltype(f2), boost::future<void> >::value);
     auto f3 = f2.then(executor, TestCallback());
-    BOOST_STATIC_ASSERT(std::is_same<decltype(f3), boost::future<boost::future<void> > >::value);
+    BOOST_STATIC_ASSERT(boost::is_same<decltype(f3), boost::future<boost::future<void> > >::value);
     f3.wait();
   }
   std::cout << __FILE__ << "[" << __LINE__ << "]" << std::endl;

--- a/test/test_2309.cpp
+++ b/test/test_2309.cpp
@@ -11,7 +11,7 @@
 #include <iostream>
 
 #include <boost/thread.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
   using namespace std;
 

--- a/test/test_2741.cpp
+++ b/test/test_2741.cpp
@@ -8,9 +8,6 @@
 
 #include <boost/thread/thread_only.hpp>
 #include <boost/thread/xtime.hpp>
-#include <boost/bind/bind.hpp>
-#include <boost/ref.hpp>
-#include <boost/utility.hpp>
 
 #include <iostream>
 #include <boost/test/unit_test.hpp>
@@ -75,5 +72,3 @@ BOOST_AUTO_TEST_CASE(test_creation_with_attrs)
 {
   timed_test(&do_test_creation_with_attrs, 1);
 }
-
-

--- a/test/test_3837.cpp
+++ b/test/test_3837.cpp
@@ -7,7 +7,8 @@
 #include <boost/thread.hpp>
 #include <boost/thread/thread_only.hpp>
 #include <boost/optional.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/bind/bind.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 using namespace boost;
 using namespace boost::chrono;

--- a/test/test_4648.cpp
+++ b/test/test_4648.cpp
@@ -6,6 +6,7 @@
 #include <iostream>
 #include <boost/thread.hpp>
 #include <boost/current_function.hpp>
+#include <boost/bind/bind.hpp>
 
 class boostThreadLocksTest
 {

--- a/test/test_5502.cpp
+++ b/test/test_5502.cpp
@@ -12,12 +12,13 @@
 int XXX = 20;
 int YYY = 10;
 
+#include <boost/bind/bind.hpp>
 #include <boost/thread/thread_only.hpp>
 #include <boost/thread/shared_mutex.hpp>
 
 //#include <unistd.h>
 #include <iostream>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 using namespace std;
 

--- a/test/test_7328.cpp
+++ b/test/test_7328.cpp
@@ -7,7 +7,7 @@
 
 #include <iostream>
 #include <boost/thread/thread_only.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 #if defined BOOST_THREAD_USES_CHRONO
 

--- a/test/test_8557.cpp
+++ b/test/test_8557.cpp
@@ -10,8 +10,6 @@
 
 #include <boost/thread/mutex.hpp>
 
-#include <boost/bind/bind.hpp>
-
 #include <iostream>
 
        static void

--- a/test/test_8943.cpp
+++ b/test/test_8943.cpp
@@ -3,7 +3,7 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 #if defined(WIN32)
 #include <tchar.h>

--- a/test/test_8960.cpp
+++ b/test/test_8960.cpp
@@ -5,14 +5,12 @@
 
 #include <boost/thread/thread.hpp>
 #include <iostream>
-
-#include <iostream>
+#include <stdexcept>
 
 #include <boost/thread.hpp>
 #include <boost/thread/locks.hpp>
 #include <boost/chrono.hpp>
-//#include <boost/bind/bind.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 
 void do_thread()

--- a/test/test_9303.cpp
+++ b/test/test_9303.cpp
@@ -4,6 +4,7 @@
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #define BOOST_THREAD_VERSION 4
+    #include <string>
     #include <iostream>
     #include <fstream>
     #include <stdio.h>
@@ -11,6 +12,7 @@
     #include <boost/make_shared.hpp>
     #include <boost/shared_ptr.hpp>
     #include <boost/bind/bind.hpp>
+    #include <boost/core/ref.hpp>
     #include <boost/asio.hpp>
     #include <boost/thread.hpp>
     #include <boost/thread/future.hpp>
@@ -86,7 +88,7 @@
 
     #if defined EXAMPLE_3
         //! Doesn't compile in C++03.
-        //! error: variable âboost::packaged_task<std::basic_string<char>(std::basic_string<char>&)> exampleâ has initializer but incomplete type
+        //! error: variable "boost::packaged_task<std::basic_string<char>(std::basic_string<char>&)> example" has initializer but incomplete type
 
         {
             boost::packaged_task<std::string(std::string&)> example(string_with_params);

--- a/test/test_barrier.cpp
+++ b/test/test_barrier.cpp
@@ -12,7 +12,7 @@
 #include <boost/thread/thread.hpp>
 #include <boost/thread/barrier.hpp>
 
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 #include <vector>
 
 namespace {

--- a/test/test_barrier_size_fct.cpp
+++ b/test/test_barrier_size_fct.cpp
@@ -10,7 +10,7 @@
 #include <boost/thread/thread.hpp>
 #include <boost/thread/barrier.hpp>
 
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 #include <vector>
 
 namespace {

--- a/test/test_barrier_void_fct.cpp
+++ b/test/test_barrier_void_fct.cpp
@@ -10,7 +10,7 @@
 #include <boost/thread/thread.hpp>
 #include <boost/thread/barrier.hpp>
 
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 #include <vector>
 
 namespace {

--- a/test/test_completion_latch.cpp
+++ b/test/test_completion_latch.cpp
@@ -10,7 +10,7 @@
 #include <boost/thread/thread.hpp>
 #include <boost/thread/completion_latch.hpp>
 
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 #include <vector>
 
 namespace

--- a/test/test_latch.cpp
+++ b/test/test_latch.cpp
@@ -10,7 +10,7 @@
 #include <boost/thread/thread.hpp>
 #include <boost/thread/latch.hpp>
 
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 #include <vector>
 
 namespace

--- a/test/test_lock_concept.cpp
+++ b/test/test_lock_concept.cpp
@@ -9,6 +9,7 @@
 #include <boost/test/unit_test.hpp>
 #include <boost/test/test_case_template.hpp>
 #include <boost/mpl/vector.hpp>
+#include <boost/bind/bind.hpp>
 #include <boost/thread/mutex.hpp>
 #include <boost/thread/lock_types.hpp>
 #include <boost/thread/shared_mutex.hpp>

--- a/test/test_ml.cpp
+++ b/test/test_ml.cpp
@@ -6,7 +6,8 @@
 #include <boost/config.hpp>
 #ifndef BOOST_NO_CXX11_RVALUE_REFERENCES
 
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/bind/bind.hpp>
+#include <boost/core/lightweight_test.hpp>
 #include <boost/thread/future.hpp>
 #include <boost/utility/result_of.hpp>
 #include <functional>

--- a/test/test_mutex.cpp
+++ b/test/test_mutex.cpp
@@ -16,6 +16,8 @@
 #include <boost/thread/thread_time.hpp>
 #include <boost/thread/condition.hpp>
 
+#include <boost/bind/bind.hpp>
+
 #define BOOST_TEST_MODULE Boost.Threads: mutex test suite
 
 #include <boost/test/unit_test.hpp>

--- a/test/test_scheduler.cpp
+++ b/test/test_scheduler.cpp
@@ -16,6 +16,7 @@
 #include <boost/thread/executors/scheduler.hpp>
 #include <boost/thread/executors/basic_thread_pool.hpp>
 #include <boost/chrono/chrono_io.hpp>
+#include <boost/bind/bind.hpp>
 #include <iostream>
 
 #include <boost/core/lightweight_test.hpp>

--- a/test/test_scheduling_adaptor.cpp
+++ b/test/test_scheduling_adaptor.cpp
@@ -14,6 +14,7 @@
 #define BOOST_THREAD_PROVIDES_EXECUTORS
 
 #include <boost/function.hpp>
+#include <boost/bind/bind.hpp>
 #include <boost/thread/executors/executor.hpp>
 #include <boost/thread/executors/basic_thread_pool.hpp>
 #include <boost/thread/executors/scheduling_adaptor.hpp>

--- a/test/test_thread.cpp
+++ b/test/test_thread.cpp
@@ -13,8 +13,8 @@
 #include <boost/thread/thread_only.hpp>
 #include <boost/thread/xtime.hpp>
 #include <boost/bind/bind.hpp>
-#include <boost/ref.hpp>
-#include <boost/utility.hpp>
+#include <boost/core/ref.hpp>
+#include <boost/core/noncopyable.hpp>
 
 #define BOOST_TEST_MODULE Boost.Threads: thread test suite
 

--- a/test/test_thread_launching.cpp
+++ b/test/test_thread_launching.cpp
@@ -8,8 +8,8 @@
 
 #include <boost/thread/thread_only.hpp>
 #include <boost/test/unit_test.hpp>
-#include <boost/ref.hpp>
-#include <boost/utility.hpp>
+#include <boost/core/ref.hpp>
+#include <boost/core/noncopyable.hpp>
 #include <string>
 #include <vector>
 

--- a/test/test_thread_mf.cpp
+++ b/test/test_thread_mf.cpp
@@ -8,7 +8,7 @@
 #define BOOST_THREAD_VERSION 3
 
 #include <boost/thread/thread_only.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 struct X
 {

--- a/test/test_time_jumps.cpp
+++ b/test/test_time_jumps.cpp
@@ -4,18 +4,19 @@
 	#include <sys/time.h>
 #endif
 
-#include "boost/bind/bind.hpp"
-#include "boost/chrono.hpp"
-#include "boost/chrono/ceil.hpp"
-#include "boost/date_time.hpp"
-#include "boost/thread/concurrent_queues/sync_priority_queue.hpp"
-#include "boost/thread/concurrent_queues/sync_timed_queue.hpp"
-#include "boost/thread/future.hpp"
-#include "boost/thread/mutex.hpp"
-#include "boost/thread/recursive_mutex.hpp"
-#include "boost/thread/shared_lock_guard.hpp"
-#include "boost/thread/shared_mutex.hpp"
-#include "boost/thread/thread.hpp"
+#include <boost/bind/bind.hpp>
+#include <boost/core/ref.hpp>
+#include <boost/chrono.hpp>
+#include <boost/chrono/ceil.hpp>
+#include <boost/date_time.hpp>
+#include <boost/thread/concurrent_queues/sync_priority_queue.hpp>
+#include <boost/thread/concurrent_queues/sync_timed_queue.hpp>
+#include <boost/thread/future.hpp>
+#include <boost/thread/mutex.hpp>
+#include <boost/thread/recursive_mutex.hpp>
+#include <boost/thread/shared_lock_guard.hpp>
+#include <boost/thread/shared_mutex.hpp>
+#include <boost/thread/thread.hpp>
 
 #include <iomanip>
 #ifdef TEST_CPP14_FEATURES

--- a/test/threads/container/thread_ptr_list_pass.cpp
+++ b/test/threads/container/thread_ptr_list_pass.cpp
@@ -10,9 +10,9 @@
 #include <boost/thread/mutex.hpp>
 #include <boost/thread/csbl/list.hpp>
 //#include <boost/interprocess/smart_ptr/shared_ptr.hpp>
-#include <boost/smart_ptr.hpp>
+#include <boost/smart_ptr/shared_ptr.hpp>
 #include <iostream>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 
 int count = 0;

--- a/test/threads/container/thread_vector_pass.cpp
+++ b/test/threads/container/thread_vector_pass.cpp
@@ -9,7 +9,7 @@
 #include <boost/thread/mutex.hpp>
 #include <boost/thread/csbl/vector.hpp>
 #include <iostream>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 #include <boost/static_assert.hpp>
 
 int count = 0;

--- a/test/threads/this_thread/get_id/get_id_pass.cpp
+++ b/test/threads/this_thread/get_id/get_id_pass.cpp
@@ -17,7 +17,7 @@
 
 #include <boost/thread/thread_only.hpp>
 
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 int main()
 {

--- a/test/threads/this_thread/sleep_for/sleep_for_pass.cpp
+++ b/test/threads/this_thread/sleep_for/sleep_for_pass.cpp
@@ -19,7 +19,7 @@
 #include <cstdlib>
 #include <algorithm>
 
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 #if defined BOOST_THREAD_USES_CHRONO
 

--- a/test/threads/this_thread/sleep_until/sleep_until_pass.cpp
+++ b/test/threads/this_thread/sleep_until/sleep_until_pass.cpp
@@ -19,7 +19,7 @@
 #include <cstdlib>
 #include <algorithm>
 
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 #if defined BOOST_THREAD_USES_CHRONO
 

--- a/test/threads/thread/assign/copy_fail.cpp
+++ b/test/threads/thread/assign/copy_fail.cpp
@@ -21,7 +21,7 @@
 #include <boost/thread/thread_only.hpp>
 #include <new>
 #include <cstdlib>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 class G
 {

--- a/test/threads/thread/assign/move_pass.cpp
+++ b/test/threads/thread/assign/move_pass.cpp
@@ -24,7 +24,7 @@
 #include <new>
 #include <cstdlib>
 #include <cassert>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 class G
 {

--- a/test/threads/thread/constr/FArgs_pass.cpp
+++ b/test/threads/thread/constr/FArgs_pass.cpp
@@ -21,7 +21,7 @@
 #include <cstdlib>
 #include <cassert>
 #include <boost/thread/thread_only.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 unsigned throw_one = 0xFFFF;
 

--- a/test/threads/thread/constr/F_pass.cpp
+++ b/test/threads/thread/constr/F_pass.cpp
@@ -21,7 +21,7 @@
 #include <cstdlib>
 #include <cassert>
 #include <boost/thread/thread_only.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 unsigned throw_one = 0xFFFF;
 

--- a/test/threads/thread/constr/FrvalueArgs_pass.cpp
+++ b/test/threads/thread/constr/FrvalueArgs_pass.cpp
@@ -23,7 +23,7 @@
 #include <new>
 #include <cstdlib>
 #include <cassert>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 class MoveOnly
 {

--- a/test/threads/thread/constr/Frvalue_pass.cpp
+++ b/test/threads/thread/constr/Frvalue_pass.cpp
@@ -23,7 +23,7 @@
 #include <new>
 #include <cstdlib>
 #include <cassert>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 #include <boost/static_assert.hpp>
 
 class MoveOnly

--- a/test/threads/thread/constr/copy_fail.cpp
+++ b/test/threads/thread/constr/copy_fail.cpp
@@ -21,7 +21,7 @@
 #include <boost/thread/thread_only.hpp>
 #include <new>
 #include <cstdlib>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 class G
 {

--- a/test/threads/thread/constr/default_pass.cpp
+++ b/test/threads/thread/constr/default_pass.cpp
@@ -20,7 +20,7 @@
 
 #include <boost/thread/thread_only.hpp>
 #include <cassert>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 int main()
 {

--- a/test/threads/thread/constr/lambda_pass.cpp
+++ b/test/threads/thread/constr/lambda_pass.cpp
@@ -21,7 +21,7 @@
 #include <cstdlib>
 #include <cassert>
 #include <boost/thread/thread_only.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 #if ! defined BOOST_NO_CXX11_LAMBDAS
 

--- a/test/threads/thread/constr/move_pass.cpp
+++ b/test/threads/thread/constr/move_pass.cpp
@@ -20,7 +20,7 @@
 #include <boost/thread/thread_only.hpp>
 #include <new>
 #include <cstdlib>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 class G
 {

--- a/test/threads/thread/destr/dtor_pass.cpp
+++ b/test/threads/thread/destr/dtor_pass.cpp
@@ -22,7 +22,7 @@
 #include <boost/thread/thread_only.hpp>
 #include <new>
 #include <cstdlib>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 class G
 {

--- a/test/threads/thread/id/hash_pass.cpp
+++ b/test/threads/thread/id/hash_pass.cpp
@@ -24,7 +24,7 @@
 
 
 #include <boost/thread/thread_only.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 int main()
 {

--- a/test/threads/thread/members/detach_pass.cpp
+++ b/test/threads/thread/members/detach_pass.cpp
@@ -21,7 +21,7 @@
 #include <new>
 #include <cstdlib>
 #include <cassert>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 class G
 {

--- a/test/threads/thread/members/get_id_pass.cpp
+++ b/test/threads/thread/members/get_id_pass.cpp
@@ -21,7 +21,7 @@
 #include <new>
 #include <cstdlib>
 #include <cassert>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 class G
 {

--- a/test/threads/thread/members/join_pass.cpp
+++ b/test/threads/thread/members/join_pass.cpp
@@ -24,7 +24,7 @@
 #include <cstdlib>
 #include <cassert>
 #include <iostream>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 class G
 {

--- a/test/threads/thread/members/joinable_pass.cpp
+++ b/test/threads/thread/members/joinable_pass.cpp
@@ -21,7 +21,7 @@
 #include <new>
 #include <cstdlib>
 #include <cassert>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 class G
 {

--- a/test/threads/thread/members/native_handle_pass.cpp
+++ b/test/threads/thread/members/native_handle_pass.cpp
@@ -21,7 +21,7 @@
 #include <new>
 #include <cstdlib>
 #include <cassert>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 class G
 {

--- a/test/threads/thread/members/swap_pass.cpp
+++ b/test/threads/thread/members/swap_pass.cpp
@@ -19,7 +19,7 @@
 
 #include <boost/thread/thread_only.hpp>
 #include <cstdlib>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 class G
 {

--- a/test/threads/thread/members/try_join_for_pass.cpp
+++ b/test/threads/thread/members/try_join_for_pass.cpp
@@ -26,7 +26,7 @@
 #include <cstdlib>
 #include <cassert>
 #include <iostream>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 #if defined BOOST_THREAD_USES_CHRONO
 

--- a/test/threads/thread/members/try_join_until_pass.cpp
+++ b/test/threads/thread/members/try_join_until_pass.cpp
@@ -26,7 +26,7 @@
 #include <cstdlib>
 #include <cassert>
 #include <iostream>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 #if defined BOOST_THREAD_USES_CHRONO
 

--- a/test/threads/thread/non_members/swap_pass.cpp
+++ b/test/threads/thread/non_members/swap_pass.cpp
@@ -19,7 +19,7 @@
 #include <new>
 #include <cstdlib>
 #include <cassert>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 class G
 {

--- a/test/threads/thread/static/hardware_concurrency_pass.cpp
+++ b/test/threads/thread/static/hardware_concurrency_pass.cpp
@@ -18,7 +18,7 @@
 // static unsigned hardware_concurrency();
 
 #include <boost/thread/thread_only.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 int main()
 {

--- a/test/timming.hpp
+++ b/test/timming.hpp
@@ -7,7 +7,7 @@
 #define BOOST_THREAD_TEST_TIMMING_HPP
 
 #include <boost/thread/detail/config.hpp>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 #if ! defined BOOST_THREAD_TEST_TIME_MS
 #ifdef BOOST_THREAD_PLATFORM_WIN32


### PR DESCRIPTION
1. Make inclusion of `boost/bind/bind.hpp` conditional in some cases, when the code actually conditionally uses `boost::bind`. Reduces compile-time overhead and fixes https://github.com/boostorg/thread/issues/307.

2. Remove some unnecessary uses of `boost::ref`. This allows to avoid including `boost/core/ref.hpp` in a few places, and avoids the associated template instantiation overhead in others.

3. Replace deprecated header includes with the more recent alternatives. For example: `boost/detail/lightweight_test.hpp` -> `boost/core/lightweight_test.hpp`, `boost/ref.hpp` -> `boost/core/ref.hpp`.

4. Replace some blanket includes with the more fine-grained ones. For example, `boost/utility.hpp`, `boost/atomic.hpp`. This reduces compile time overhead.

5. Add some missing includes, for example, `boost/core/ref.hpp` and `boost/type_traits/is_same.hpp`.

6. Replace uses of `std::is_same` with `boost::is_same` (with the corresponding included header) since the standard type_traits header presence and validity is not tested by the code. Using `boost::is_same` makes the code more portable.
