### PR TITLE
Avoid relying on implicit copy constructor/operator deprecated in C++11

### DIFF
--- a/example/thread_guard.cpp
+++ b/example/thread_guard.cpp
@@ -20,6 +20,7 @@ struct func
     int& i;
 
     func(int& i_):i(i_){}
+    func(func const& other):i(other.i){}
 
     void operator()()
     {

--- a/include/boost/thread/detail/thread.hpp
+++ b/include/boost/thread/detail/thread.hpp
@@ -637,10 +637,6 @@ namespace boost
 #endif
         {}
 
-        id(const id& other) BOOST_NOEXCEPT :
-            thread_data(other.thread_data)
-        {}
-
         bool operator==(const id& y) const BOOST_NOEXCEPT
         {
             return thread_data==y.thread_data;

--- a/test/shared_mutex_locking_thread.hpp
+++ b/test/shared_mutex_locking_thread.hpp
@@ -7,6 +7,7 @@
 //  accompanying file LICENSE_1_0.txt or copy at
 //  http://www.boost.org/LICENSE_1_0.txt)
 
+#include <boost/config.hpp>
 #include <boost/thread/mutex.hpp>
 #include <boost/thread/condition_variable.hpp>
 #include <boost/thread/shared_mutex.hpp>
@@ -37,6 +38,10 @@ public:
         unblocked_count_mutex(unblocked_count_mutex_),
         finish_mutex(finish_mutex_)
     {}
+
+#if !defined(BOOST_NO_CXX11_DEFAULTED_FUNCTIONS)
+    locking_thread(locking_thread const&) = default;
+#endif
 
     void operator()()
     {
@@ -84,6 +89,10 @@ public:
         unblocked_mutex(unblocked_mutex_),unblocked_count(unblocked_count_)
     {}
 
+#if !defined(BOOST_NO_CXX11_DEFAULTED_FUNCTIONS)
+    simple_writing_thread(simple_writing_thread const&) = default;
+#endif
+
     void operator()()
     {
         boost::unique_lock<boost::shared_mutex>  lk(rwm);
@@ -114,6 +123,10 @@ public:
         rwm(rwm_),finish_mutex(finish_mutex_),
         unblocked_mutex(unblocked_mutex_),unblocked_count(unblocked_count_)
     {}
+
+#if !defined(BOOST_NO_CXX11_DEFAULTED_FUNCTIONS)
+    simple_reading_thread(simple_reading_thread const&) = default;
+#endif
 
     void operator()()
     {

--- a/test/sync/futures/promise/set_value_const_pass.cpp
+++ b/test/sync/futures/promise/set_value_const_pass.cpp
@@ -23,6 +23,7 @@
 #include <boost/thread/future.hpp>
 #include <boost/detail/lightweight_test.hpp>
 #include <boost/static_assert.hpp>
+#include <boost/config.hpp>
 
 #ifdef BOOST_MSVC
 # pragma warning(disable: 4702) // unreachable code
@@ -37,6 +38,9 @@ struct A
   {
     throw 10;
   }
+#if !defined(BOOST_NO_CXX11_DEFAULTED_FUNCTIONS)
+  A& operator= (const A&) = default;
+#endif
 };
 
 int main()

--- a/test/test_condition.cpp
+++ b/test/test_condition.cpp
@@ -14,6 +14,7 @@
 #include <boost/thread/thread_only.hpp>
 #include <boost/thread/xtime.hpp>
 
+#include <boost/config.hpp>
 #include <boost/test/unit_test.hpp>
 
 #include "./util.inl"
@@ -41,14 +42,17 @@ void condition_test_thread(condition_test_data* data)
 struct cond_predicate
 {
     cond_predicate(int& var, int val) : _var(var), _val(val) { }
+#if !defined(BOOST_NO_CXX11_DEFAULTED_FUNCTIONS)
+    cond_predicate(cond_predicate const&) = default;
+#endif
 
     bool operator()() { return _var == _val; }
 
     int& _var;
     int _val;
+
 private:
     void operator=(cond_predicate&);
-
 };
 
 void condition_test_waits(condition_test_data* data)

--- a/test/test_shared_mutex_part_2.cpp
+++ b/test/test_shared_mutex_part_2.cpp
@@ -6,6 +6,7 @@
 #define BOOST_THREAD_VERSION 2
 #define BOOST_TEST_MODULE Boost.Threads: shared_mutex_part2 test suite
 
+#include <boost/config.hpp>
 #include <boost/test/unit_test.hpp>
 #include <boost/thread/thread.hpp>
 #include <boost/thread/xtime.hpp>
@@ -35,6 +36,10 @@ public:
         rwm(rwm_),finish_mutex(finish_mutex_),
         unblocked_mutex(unblocked_mutex_),unblocked_count(unblocked_count_)
     {}
+
+#if !defined(BOOST_NO_CXX11_DEFAULTED_FUNCTIONS)
+    simple_upgrade_thread(simple_upgrade_thread const&) = default;
+#endif
 
     void operator()()
     {

--- a/test/util.inl
+++ b/test/util.inl
@@ -12,6 +12,7 @@
 #include <boost/thread/mutex.hpp>
 #include <boost/thread/condition.hpp>
 #include <boost/thread/thread.hpp>
+#include <boost/config.hpp>
 
 #ifndef DEFAULT_EXECUTION_MONITOR_TYPE
 #   define DEFAULT_EXECUTION_MONITOR_TYPE execution_monitor::use_condition
@@ -133,6 +134,10 @@ class indirect_adapter
 public:
     indirect_adapter(F func, execution_monitor& monitor)
         : func(func), monitor(monitor) { }
+#if !defined(BOOST_NO_CXX11_DEFAULTED_FUNCTIONS)
+    indirect_adapter(indirect_adapter const&) = default;
+#endif
+
     void operator()() const
     {
         try
@@ -210,11 +215,15 @@ class thread_member_binder
 public:
     thread_member_binder(R (T::*func)(), T& param)
         : func(func), param(param) { }
+#if !defined(BOOST_NO_CXX11_DEFAULTED_FUNCTIONS)
+    thread_member_binder(thread_member_binder const&) = default;
+#endif
+
     void operator()() const { (param.*func)(); }
 
 private:
     void operator=(thread_member_binder&);
-    
+
     R (T::*func)();
     T& param;
 };


### PR DESCRIPTION
C++11 deprecates implicit default copy constructors and operators if the class has user-defined destructor or copy constructor/operator. gcc 9 generates warnings when this deprecated language feature is used. This commit fixes that by providing user-defained copy constructors/operators where needed. The added definitions are equivalent to the implicitly generated by the compiler.

Additionally, for `thread::id` added move constructor/operator when rvalue references are available. Move is more efficient when the id uses a smart pointer internally.
