### PR TITLE
Add support for move constructor/assignment to thread::id

### DIFF
--- a/include/boost/thread/detail/thread.hpp
+++ b/include/boost/thread/detail/thread.hpp
@@ -641,6 +641,25 @@ namespace boost
             thread_data(other.thread_data)
         {}
 
+#if !defined(BOOST_NO_CXX11_RVALUE_REFERENCES)
+        id(id&& other) BOOST_NOEXCEPT :
+            thread_data(static_cast< data&& >(other.thread_data))
+        {
+#if defined(BOOST_THREAD_PROVIDES_BASIC_THREAD_ID)
+            other.thread_data = 0;
+#endif
+        }
+
+        id& operator=(id&& other) BOOST_NOEXCEPT
+        {
+            thread_data = static_cast< data&& >(other.thread_data);
+#if defined(BOOST_THREAD_PROVIDES_BASIC_THREAD_ID)
+            other.thread_data = 0;
+#endif
+            return *this;
+        }
+#endif // !defined(BOOST_NO_CXX11_RVALUE_REFERENCES)
+
         bool operator==(const id& y) const BOOST_NOEXCEPT
         {
             return thread_data==y.thread_data;


### PR DESCRIPTION
Move is more efficient than copy in case if `thread::id` uses a smart pointer internally.

This PR was extracted from https://github.com/boostorg/thread/pull/310.