### PR TITLE
Use BOOST_OVERRIDE

### DIFF
--- a/include/boost/thread/detail/nullary_function.hpp
+++ b/include/boost/thread/detail/nullary_function.hpp
@@ -48,7 +48,7 @@ namespace boost
           : f(boost::move(f_))
         {}
 
-        void call()
+        void call() BOOST_OVERRIDE
         {
           f();
         }
@@ -59,7 +59,7 @@ namespace boost
         impl_type_ptr(void (*f_)())
           : f(f_)
         {}
-        void call()
+        void call() BOOST_OVERRIDE
         {
           f();
         }
@@ -155,7 +155,7 @@ namespace boost
           : f(boost::move(f_))
         {}
 
-        R call()
+        R call() BOOST_OVERRIDE
         {
           return f();
         }

--- a/include/boost/thread/detail/thread.hpp
+++ b/include/boost/thread/detail/thread.hpp
@@ -10,9 +10,6 @@
 #include <boost/predef/platform.h>
 
 #include <boost/thread/exceptions.hpp>
-#ifndef BOOST_NO_IOSTREAM
-#include <ostream>
-#endif
 #include <boost/thread/detail/move.hpp>
 #include <boost/thread/mutex.hpp>
 #if defined BOOST_THREAD_USES_DATETIME
@@ -26,13 +23,9 @@
 #include <boost/thread/detail/invoke.hpp>
 #include <boost/thread/detail/is_convertible.hpp>
 #include <boost/assert.hpp>
-#include <list>
-#include <algorithm>
 #include <boost/core/ref.hpp>
 #include <boost/cstdint.hpp>
 #include <boost/bind/bind.hpp>
-#include <stdlib.h>
-#include <memory>
 #include <boost/core/enable_if.hpp>
 #include <boost/type_traits/remove_reference.hpp>
 #include <boost/io/ios_state.hpp>
@@ -45,6 +38,13 @@
 #include <boost/chrono/ceil.hpp>
 #endif
 
+#include <algorithm>
+#include <cstdlib>
+#include <list>
+#include <memory>
+#ifndef BOOST_NO_IOSTREAM
+#include <ostream>
+#endif
 #if defined(BOOST_THREAD_PROVIDES_VARIADIC_THREAD)
 #include <tuple>
 #endif
@@ -115,7 +115,7 @@ namespace boost
 #endif
             //thread_data() {}
 
-            void run()
+            void run() BOOST_OVERRIDE
             {
                 f();
             }
@@ -135,7 +135,7 @@ namespace boost
             thread_data(boost::reference_wrapper<F> f_):
                 f(f_)
             {}
-            void run()
+            void run() BOOST_OVERRIDE
             {
                 f();
             }
@@ -152,7 +152,7 @@ namespace boost
             thread_data(const boost::reference_wrapper<F> f_):
                 f(f_)
             {}
-            void run()
+            void run() BOOST_OVERRIDE
             {
                 f();
             }
@@ -797,7 +797,7 @@ namespace boost
                 f(f_)
             {}
 
-            void operator()()
+            void operator()() BOOST_OVERRIDE
             {
                 f();
             }

--- a/include/boost/thread/exceptions.hpp
+++ b/include/boost/thread/exceptions.hpp
@@ -15,10 +15,10 @@
 //       with recursive headers if I don't separate it
 //  wek: Not sure why recursive headers would cause compilation problems
 //       given the include guards, but regardless it makes sense to
-//       seperate this out any way.
+//       separate this out any way.
 
-#include <string>
 #include <stdexcept>
+#include <string>
 #include <boost/system/system_error.hpp>
 #include <boost/system/error_code.hpp>
 
@@ -56,7 +56,7 @@ namespace boost
         {
         }
 
-        ~thread_exception() BOOST_NOEXCEPT_OR_NOTHROW
+        ~thread_exception() BOOST_NOEXCEPT_OR_NOTHROW BOOST_OVERRIDE
         {}
 
 
@@ -113,7 +113,7 @@ namespace boost
         {
         }
 
-        ~lock_error() BOOST_NOEXCEPT_OR_NOTHROW
+        ~lock_error() BOOST_NOEXCEPT_OR_NOTHROW BOOST_OVERRIDE
         {}
 
     };
@@ -141,7 +141,7 @@ namespace boost
           }
 
 
-        ~thread_resource_error() BOOST_NOEXCEPT_OR_NOTHROW
+        ~thread_resource_error() BOOST_NOEXCEPT_OR_NOTHROW BOOST_OVERRIDE
         {}
 
     };

--- a/include/boost/thread/future.hpp
+++ b/include/boost/thread/future.hpp
@@ -934,7 +934,7 @@ namespace boost
             this->set_async();
           }
 
-          ~future_async_shared_state_base()
+          ~future_async_shared_state_base() BOOST_OVERRIDE
           {
 #ifdef BOOST_THREAD_FUTURE_BLOCKING
             join();
@@ -944,7 +944,7 @@ namespace boost
 #endif
           }
 
-          virtual void wait(boost::unique_lock<boost::mutex>& lk, bool rethrow)
+          void wait(boost::unique_lock<boost::mutex>& lk, bool rethrow) BOOST_OVERRIDE
           {
 #ifdef BOOST_THREAD_FUTURE_BLOCKING
               {
@@ -1102,7 +1102,7 @@ namespace boost
             this->set_deferred();
           }
 
-          virtual void execute(boost::unique_lock<boost::mutex>& lck) {
+          void execute(boost::unique_lock<boost::mutex>& lck) BOOST_OVERRIDE {
             try
             {
               Fp local_fuct=boost::move(func_);
@@ -2970,7 +2970,7 @@ namespace boost
 
             void reset()
             {
-              // todo The packaged_task::reset must be as if an assignemnt froma new packaged_task with the same function
+              // todo The packaged_task::reset must be as if an assignment from a new packaged_task with the same function
               // the reset function is an optimization that avoids reallocating a new task.
               started=false;
               this->validate();
@@ -3387,7 +3387,7 @@ namespace boost
               {
                 f(boost::move(args)...);
 #else
-            void do_apply()
+            void do_apply() BOOST_OVERRIDE
             {
                 try
                 {
@@ -3408,7 +3408,7 @@ namespace boost
                 {
                     f(boost::move(args)...);
 #else
-            void do_run()
+            void do_run() BOOST_OVERRIDE
             {
                 try
                 {
@@ -3462,7 +3462,7 @@ namespace boost
                 {
                     f(boost::move(args)...);
 #else
-            void do_apply()
+            void do_apply() BOOST_OVERRIDE
             {
                 try
                 {
@@ -3483,7 +3483,7 @@ namespace boost
                 {
                     f(boost::move(args)...);
 #else
-            void do_run()
+            void do_run() BOOST_OVERRIDE
             {
                 try
                 {

--- a/src/future.cpp
+++ b/src/future.cpp
@@ -20,8 +20,8 @@ namespace boost
       public boost::system::error_category
     {
     public:
-        virtual const char* name() const BOOST_NOEXCEPT;
-        virtual std::string message(int ev) const;
+        const char* name() const BOOST_NOEXCEPT BOOST_OVERRIDE;
+        std::string message(int ev) const BOOST_OVERRIDE;
     };
 
     const char*
@@ -61,4 +61,3 @@ namespace boost
 
 }
 #endif
-

--- a/src/pthread/thread.cpp
+++ b/src/pthread/thread.cpp
@@ -37,11 +37,13 @@
 #include <boost/algorithm/string/trim.hpp>
 #include <boost/lexical_cast.hpp>
 
+#include <cstring> // memcmp.
 #include <fstream>
-#include <string>
+#include <map>
 #include <set>
+#include <string>
+#include <utility>
 #include <vector>
-#include <string.h> // memcmp.
 
 namespace boost
 {
@@ -214,7 +216,7 @@ namespace boost
                 interrupt_enabled=false;
 #endif
             }
-            ~externally_launched_thread() {
+            ~externally_launched_thread() BOOST_OVERRIDE {
               BOOST_ASSERT(notify.empty());
               notify.clear();
 //#ifndef BOOST_NO_EXCEPTIONS
@@ -222,9 +224,9 @@ namespace boost
               async_states_.clear();
 //#endif
             }
-            void run()
+            void run() BOOST_OVERRIDE
             {}
-            void notify_all_at_thread_exit(condition_variable*, mutex*)
+            void notify_all_at_thread_exit(condition_variable*, mutex*) BOOST_OVERRIDE
             {}
 
         private:
@@ -559,7 +561,7 @@ namespace boost
             }
             // Fall back to hardware_concurrency() in case
             // /proc/cpuinfo is formatted differently than we expect.
-            return cores.size() != 0 ? cores.size() : hardware_concurrency();
+            return cores.empty() ? hardware_concurrency() : cores.size();
         } catch(...) {
           return hardware_concurrency();
         }


### PR DESCRIPTION
Use BOOST_OVERRIDE to fix GCC -Wsuggest-override and Clang-tidy modernize-use-override warnings.
Alphabetical order of STL headers. Fix misspellings.