### PR TITLE
Fixed optimized away hooks. Fixes #316

### DIFF
--- a/src/win32/tss_pe.cpp
+++ b/src/win32/tss_pe.cpp
@@ -152,19 +152,25 @@ extern BOOL (WINAPI * const _pDefaultRawDllMainOrig)(HINSTANCE, DWORD, LPVOID) =
         static PVAPI_V on_process_init();
         static PVAPI_V on_process_term();
         static void NTAPI on_tls_callback(HINSTANCE, DWORD, PVOID);
+    }
 
+    namespace boost
+    {
         //The .CRT$Xxx information is taken from Codeguru:
         //http://www.codeguru.com/Cpp/misc/misc/threadsprocesses/article.php/c6945__2/
+
+        // Variables below are not referenced anywhere and
+        // to not be optimized away has to have external linkage
 
 #if (_MSC_VER >= 1400)
 #pragma section(".CRT$XIU",long,read)
 #pragma section(".CRT$XCU",long,read)
 #pragma section(".CRT$XTU",long,read)
 #pragma section(".CRT$XLC",long,read)
-        __declspec(allocate(".CRT$XLC")) _TLSCB __xl_ca=on_tls_callback;
-        __declspec(allocate(".CRT$XIU"))_PIFV_ p_tls_prepare = on_tls_prepare;
-        __declspec(allocate(".CRT$XCU"))_PVFV_ p_process_init = on_process_init;
-        __declspec(allocate(".CRT$XTU"))_PVFV_ p_process_term = on_process_term;
+        extern const __declspec(allocate(".CRT$XLC")) _TLSCB p_tls_callback = on_tls_callback;
+        extern const __declspec(allocate(".CRT$XIU")) _PIFV_ p_tls_prepare = on_tls_prepare;
+        extern const __declspec(allocate(".CRT$XCU")) _PVFV_ p_process_init = on_process_init;
+        extern const __declspec(allocate(".CRT$XTU")) _PVFV_ p_process_term = on_process_term;
 #else
         #if (_MSC_VER >= 1300) // 1300 == VC++ 7.0
         #   pragma data_seg(push, old_seg)
@@ -176,30 +182,33 @@ extern BOOL (WINAPI * const _pDefaultRawDllMainOrig)(HINSTANCE, DWORD, LPVOID) =
             //this could be changed easily if required.
 
             #pragma data_seg(".CRT$XIU")
-            static _PIFV_ p_tls_prepare = on_tls_prepare;
+            extern const _PIFV_ p_tls_prepare = on_tls_prepare;
             #pragma data_seg()
 
             //Callback after all global ctors.
 
             #pragma data_seg(".CRT$XCU")
-            static _PVFV_ p_process_init = on_process_init;
+            extern const _PVFV_ p_process_init = on_process_init;
             #pragma data_seg()
 
             //Callback for tls notifications.
 
             #pragma data_seg(".CRT$XLB")
-            _TLSCB p_thread_callback = on_tls_callback;
+            extern const _TLSCB p_thread_callback = on_tls_callback;
             #pragma data_seg()
             //Callback for termination.
 
             #pragma data_seg(".CRT$XTU")
-            static _PVFV_ p_process_term = on_process_term;
+            extern const _PVFV_ p_process_term = on_process_term;
             #pragma data_seg()
         #if (_MSC_VER >= 1300) // 1300 == VC++ 7.0
         #   pragma data_seg(pop, old_seg)
         #endif
 #endif
+    } // namespace boost
 
+    namespace
+    {
 #ifdef BOOST_MSVC
 #pragma warning(push)
 #pragma warning(disable:4189)


### PR DESCRIPTION
MSVC learned to not emit unreferenced symbols with internal linkage and the
hooks were defined in unnamed namespace which forces internal linkage, even if
you mark a variable `extern`.

Since Boost does not have a stable ABI, does not mangle the namespace with
the version, and the hooks are in `boost` namespace (`boost::on_*`) -- there is
no point in trying to hide some symbols because mixing different versions of
boost static libraries will not work already.

I also renamed the `__xl_ca` variable for consistency and because using double
underscored identifiers is forbidden. (`[lex.name]/3`)

The `extern const` is for verbosity and because they are indeed const (it is
done via pragma already).