### PR TITLE
Allow using libpthread with Mingw

### DIFF
--- a/build/Jamfile.v2
+++ b/build/Jamfile.v2
@@ -199,7 +199,7 @@ rule win32_pthread_paths ( properties * )
         }
         if <toolset>gcc in $(properties)
         {
-            libname = lib$(libname)GC2.a ;
+            libname = lib$(libname).a ;
         }
         lib_path = [ path.glob $(lib_path) : $(libname) ] ;
         if ! $(lib_path)

--- a/include/boost/thread/pthread/thread_data.hpp
+++ b/include/boost/thread/pthread/thread_data.hpp
@@ -32,6 +32,10 @@
 # endif
 #endif
 
+#if defined(_WIN32)
+#include <windows.h>
+#endif
+
 #include <pthread.h>
 #include <unistd.h>
 
@@ -54,6 +58,10 @@ namespace boost
           if (size==0) return;
 #ifdef BOOST_THREAD_USES_GETPAGESIZE
           std::size_t page_size = getpagesize();
+#elif _WIN32
+          SYSTEM_INFO system_info;
+          ::GetSystemInfo (&system_info);
+          std::size_t page_size = system_info.dwPageSize;
 #else
           std::size_t page_size = ::sysconf( _SC_PAGESIZE);
 #endif


### PR DESCRIPTION
This pull request provides a few changes required for using libpthread with Mingw:
* updates the library name
* allows retrieving the page size on Windows

Those changes are currently cherry-picked when building Ceph for Windows:
https://github.com/ceph/ceph/blob/master/win32_deps_build.sh#L128-L246
