### PR TITLE
A fix for issue #326 - https://github.com/boostorg/thread/issues/326

### DIFF
--- a/include/boost/thread/future.hpp
+++ b/include/boost/thread/future.hpp
@@ -5085,7 +5085,7 @@ namespace detail {
                   lock, boost::move(*this), boost::forward<F>(func)
               )));
     } else {
-      return BOOST_THREAD_MAKE_RV_REF((boost::detail::make_future_async_continuation_shared_state<BOOST_THREAD_FUTURE<R>, future_type>(
+      return BOOST_THREAD_MAKE_RV_REF((boost::detail::make_future_sync_continuation_shared_state<BOOST_THREAD_FUTURE<R>, future_type>(
                   lock, boost::move(*this), boost::forward<F>(func)
               )));
     }


### PR DESCRIPTION
Fixing a typo when BOOST_THREAD_CONTINUATION_SYNC is defined.