### PR TITLE
Fix search path for relative includes

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -41,7 +41,24 @@ environment:
       VARIANT: release
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
 
-    - ADDPATH: C:\cygwin\bin;
+    - FLAVOR: cygwin (32-bit)
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+      ADDPATH: C:\cygwin\bin;
+      CXXSTD: 03,11,14,1z
+      TOOLSET: gcc
+      VARIANT: release
+
+    - FLAVOR: cygwin (64-bit)
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+      ADDPATH: C:\cygwin64\bin;
+      CXXSTD: 03,11,14,1z
+      TOOLSET: gcc
+      VARIANT: release
+
+    - FLAVOR: cygwin (64-bit, latest)
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2022
+      ADDPATH: C:\cygwin64\bin;
+      CXXSTD: 03,11,14,1z
       TOOLSET: gcc
       VARIANT: release
 

--- a/build/Jamfile.v2
+++ b/build/Jamfile.v2
@@ -303,6 +303,9 @@ alias thread_sources
       future.cpp
     : ## requirements ##
       <threadapi>pthread
+    :
+    :
+      <include>../src/pthread
     ;
 
 explicit thread_sources ;


### PR DESCRIPTION
On recent Cygwins and other systems the source files path may not be added to the include search path leading to:
> libs\thread\src\pthread\once.cpp:8:10: fatal error: ./once_atomic.cpp: No such file or directory
>    8 | #include "./once_atomic.cpp"

Add the path explicitly and add CI jobs for this (order/layout based on Boost.CI)

Required also for downstream libraries, see e.g. https://github.com/boostorg/atomic/pull/57