### PR TITLE
fix possible crash when running a boost::thread within a boost::thread

### DIFF
--- a/include/boost/thread/thread_functors.hpp
+++ b/include/boost/thread/thread_functors.hpp
@@ -53,6 +53,19 @@ namespace boost
   };
 
 #if defined BOOST_THREAD_PROVIDES_INTERRUPTIONS
+  struct non_interruptable_join_if_joinable
+  {
+    template <class Thread>
+    void operator()(Thread& t)
+    {
+      if (t.joinable())
+      {
+        this_thread::disable_interruption di;
+        t.join();
+      }
+    }
+  };
+
   struct interrupt_and_join_if_joinable
   {
     template <class Thread>
@@ -60,6 +73,20 @@ namespace boost
     {
       if (t.joinable())
       {
+        t.interrupt();
+        t.join();
+      }
+    }
+  };
+
+  struct non_interruptable_interrupt_and_join_if_joinable
+  {
+    template <class Thread>
+    void operator()(Thread& t)
+    {
+      if (t.joinable())
+      {
+        this_thread::disable_interruption di;
         t.interrupt();
         t.join();
       }

--- a/src/pthread/thread.cpp
+++ b/src/pthread/thread.cpp
@@ -321,7 +321,6 @@ namespace boost
 
             {
                 unique_lock<mutex> lock(local_thread_info->data_mutex);
-                this_thread::disable_interruption di;
                 while(!local_thread_info->done)
                 {
                     local_thread_info->done_condition.wait(lock);
@@ -370,7 +369,6 @@ namespace boost
 
             {
                 unique_lock<mutex> lock(local_thread_info->data_mutex);
-                this_thread::disable_interruption di;
                 while(!local_thread_info->done)
                 {
                     if(!local_thread_info->done_condition.do_wait_until(lock,timeout)) break; // timeout occurred

--- a/src/pthread/thread.cpp
+++ b/src/pthread/thread.cpp
@@ -321,6 +321,7 @@ namespace boost
 
             {
                 unique_lock<mutex> lock(local_thread_info->data_mutex);
+                this_thread::disable_interruption di;
                 while(!local_thread_info->done)
                 {
                     local_thread_info->done_condition.wait(lock);
@@ -369,6 +370,7 @@ namespace boost
 
             {
                 unique_lock<mutex> lock(local_thread_info->data_mutex);
+                this_thread::disable_interruption di;
                 while(!local_thread_info->done)
                 {
                     if(!local_thread_info->done_condition.do_wait_until(lock,timeout)) break; // timeout occurred


### PR DESCRIPTION
When running a boost::thread within a boost::thread, the inner thread can crash when calling join, when it's joined itself.
See:
https://github.com/boostorg/thread/issues/366
https://stackoverflow.com/q/71482828