### PR TITLE
Fix issue #366 (adding testcase)

### DIFF
--- a/include/boost/thread/thread_guard.hpp
+++ b/include/boost/thread/thread_guard.hpp
@@ -34,6 +34,11 @@ namespace boost
     }
     ~thread_guard()
     {
+      // In "nesting" scenarios on_destructor may trigger interruption. Since
+      // we're in a destructor we can't afford that.
+      // See https://github.com/boostorg/thread/issues/366.
+      this_thread::disable_interruption di;
+
       CallableThread on_destructor;
 
       on_destructor(t_);

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -378,7 +378,10 @@ rule generate_self_contained_header_tests
           [ thread-run test_5502.cpp ]
     ;
 
-
+    test-suite issues
+    :
+          [ thread-run test_366.cpp ]
+    ;
 
     #explicit ts_conditions ;
     test-suite ts_conditions

--- a/test/test_366.cpp
+++ b/test/test_366.cpp
@@ -1,0 +1,42 @@
+#include "boost/thread/thread_guard.hpp"
+#include "boost/thread.hpp"
+#include <iostream>
+#include <boost/atomic.hpp>
+
+static boost::atomic_int g_sensor{0};
+struct sensing_joiner : boost::interrupt_and_join_if_joinable {
+  ~sensing_joiner() { ++g_sensor; }
+};
+
+static boost::atomic_int g_count_work{0};
+static void inner_thread_func() {
+  while (true) {
+    boost::this_thread::interruption_point();
+    boost::this_thread::no_interruption_point::sleep_for(
+        boost::chrono::seconds(1));
+    ++g_count_work;
+  }
+}
+
+static void outer_thread_func() {
+    boost::thread inner;
+    boost::thread_guard<sensing_joiner> guard(inner);
+
+    inner = boost::thread(inner_thread_func);
+}
+
+static void double_interrupt() {
+  boost::thread outer(outer_thread_func);
+  outer.interrupt();
+  outer.join();
+}
+
+int main() {
+  std::cout << "Start" << std::endl;
+  double_interrupt();
+  std::cout << "End" << std::endl;
+
+  std::cout << "g_sum:    " << g_count_work << std::endl;
+  std::cout << "g_sensor: " << g_sensor << std::endl;
+  return 0;
+}


### PR DESCRIPTION
With reference to https://github.com/boostorg/thread/issues/366 and
https://github.com/boostorg/thread/pull/367

This fix is narrower than the linked PR in that it only prevents interruption exceptions from being raised inside the thread_guard destructor.