### PR TITLE
Avoid compiler warning about unused variable

### DIFF
--- a/src/win32/thread.cpp
+++ b/src/win32/thread.cpp
@@ -577,7 +577,7 @@ namespace boost
                 } Reason;
             } REASON_CONTEXT, *PREASON_CONTEXT;
             typedef BOOL (WINAPI *setwaitabletimerex_t)(HANDLE, const LARGE_INTEGER *, LONG, PTIMERAPCROUTINE, LPVOID, PREASON_CONTEXT, ULONG);
-            static inline BOOL WINAPI SetWaitableTimerEx_emulation(HANDLE hTimer, const LARGE_INTEGER *lpDueTime, LONG lPeriod, PTIMERAPCROUTINE pfnCompletionRoutine, LPVOID lpArgToCompletionRoutine, PREASON_CONTEXT WakeContext, ULONG TolerableDelay)
+            static inline BOOL WINAPI SetWaitableTimerEx_emulation(HANDLE hTimer, const LARGE_INTEGER *lpDueTime, LONG lPeriod, PTIMERAPCROUTINE pfnCompletionRoutine, LPVOID lpArgToCompletionRoutine, PREASON_CONTEXT, ULONG)
             {
                 return SetWaitableTimer(hTimer, lpDueTime, lPeriod, pfnCompletionRoutine, lpArgToCompletionRoutine, FALSE);
             }


### PR DESCRIPTION
When compiling in Visual Studio 2022 with "treat warnings as errors", I'm getting the following error which this PR should address. (The other option is to comment out the name.)

(I would be grateful if a fix could end up in 1.82.0.)

```
boost\libs\thread\src\win32\thread.cpp(580,236): error C2220: the following warning is treated as an error
boost\libs\thread\src\win32\thread.cpp(580,236): error C2220:             static inline BOOL WINAPI SetWaitableTimerEx_emulation(HANDLE hTimer, const LARGE_INTEGER *lpDueTime, LONG lPeriod, PTIMERAPCROUTINE pfnCompletionRoutine, LPVOID lpArgToCompletionRoutine, PREASON_CONTEXT WakeContext, ULONG TolerableDelay)
boost\libs\thread\src\win32\thread.cpp(580,236): error C2220:                                                                                                                                                                                                                                            ^
boost\libs\thread\src\win32\thread.cpp(580,236): warning C4100: 'TolerableDelay': unreferenced formal parameter
boost\libs\thread\src\win32\thread.cpp(580,217): warning C4100: 'WakeContext': unreferenced formal parameter
boost\libs\thread\src\win32\thread.cpp(580,217): warning C4100:             static inline BOOL WINAPI SetWaitableTimerEx_emulation(HANDLE hTimer, const LARGE_INTEGER *lpDueTime, LONG lPeriod, PTIMERAPCROUTINE pfnCompletionRoutine, LPVOID lpArgToCompletionRoutine, PREASON_CONTEXT WakeContext, ULONG TolerableDelay)
boost\libs\thread\src\win32\thread.cpp(580,217): warning C4100:                                                                                                                                                                                                                         ^
```