### PR TITLE
Switch to `boost::core::invoke_swap`

### DIFF
--- a/include/boost/thread/externally_locked.hpp
+++ b/include/boost/thread/externally_locked.hpp
@@ -18,7 +18,7 @@
 #include <boost/static_assert.hpp>
 #include <boost/type_traits/is_same.hpp>
 #include <boost/throw_exception.hpp>
-#include <boost/core/swap.hpp>
+#include <boost/core/invoke_swap.hpp>
 
 #include <boost/config/abi_prefix.hpp>
 
@@ -105,8 +105,8 @@ namespace boost
 
     void swap(externally_locked& rhs) //BOOST_NOEXCEPT_IF(BOOST_NOEXCEPT_EXPR)
     {
-      swap(obj_, rhs.obj_);
-      swap(mtx_, rhs.mtx_);
+      boost::core::invoke_swap(obj_, rhs.obj_);
+      boost::core::invoke_swap(mtx_, rhs.mtx_);
     }
 
     /**
@@ -245,8 +245,8 @@ namespace boost
 
     void swap(externally_locked& rhs) BOOST_NOEXCEPT
     {
-      swap(obj_, rhs.obj_);
-      swap(mtx_, rhs.mtx_);
+      boost::core::invoke_swap(obj_, rhs.obj_);
+      boost::core::invoke_swap(mtx_, rhs.mtx_);
     }
     /**
      * Requires: The lk parameter must be locking the associated mtx.

--- a/include/boost/thread/synchronized_value.hpp
+++ b/include/boost/thread/synchronized_value.hpp
@@ -17,8 +17,8 @@
 #include <boost/thread/lock_algorithms.hpp>
 #include <boost/thread/lock_factories.hpp>
 #include <boost/thread/strict_lock.hpp>
-#include <boost/core/swap.hpp>
-#include <boost/utility/declval.hpp>
+#include <boost/core/invoke_swap.hpp>
+#include <boost/type_traits/declval.hpp>
 //#include <boost/type_traits.hpp>
 //#include <boost/thread/detail/is_nothrow_default_constructible.hpp>
 //#if ! defined BOOST_NO_CXX11_HDR_TYPE_TRAITS
@@ -582,7 +582,7 @@ namespace boost
       unique_lock<mutex_type> lk1(mtx_, defer_lock);
       unique_lock<mutex_type> lk2(rhs.mtx_, defer_lock);
       lock(lk1,lk2);
-      boost::swap(value_, rhs.value_);
+      boost::core::invoke_swap(value_, rhs.value_);
     }
     /**
      * Swap with the underlying value type
@@ -592,7 +592,7 @@ namespace boost
     void swap(value_type & rhs)
     {
       strict_lock<mutex_type> lk(mtx_);
-      boost::swap(value_, rhs);
+      boost::core::invoke_swap(value_, rhs);
     }
 
     /**

--- a/test/sync/mutual_exclusion/synchronized_value/swap_T_pass.cpp
+++ b/test/sync/mutual_exclusion/synchronized_value/swap_T_pass.cpp
@@ -12,7 +12,7 @@
 #define BOOST_THREAD_VERSION 4
 
 #include <boost/thread/synchronized_value.hpp>
-
+#include <boost/core/invoke_swap.hpp>
 #include <boost/detail/lightweight_test.hpp>
 
 int main()
@@ -21,14 +21,14 @@ int main()
   {
     boost::synchronized_value<int> v1(1);
     int v2(2);
-    boost::swap(v1,v2);
+    boost::core::invoke_swap(v1,v2);
     BOOST_TEST(v1.value() == 2);
     BOOST_TEST(v2 == 1);
   }
   {
     boost::synchronized_value<int> v1(1);
     int v2(2);
-    boost::swap(v2,v1);
+    boost::core::invoke_swap(v2,v1);
     BOOST_TEST(v1.value() == 2);
     BOOST_TEST(v2 == 1);
   }


### PR DESCRIPTION
`boost::swap` is deprecated and will be removed. Use `boost::core::invoke_swap` as a replacement.