### PR TITLE
Set C++11 requirements

### DIFF
--- a/build/Jamfile.v2
+++ b/build/Jamfile.v2
@@ -35,6 +35,7 @@
 import os ;
 import indirect ;
 import path ;
+import config : requires ;
 import configure ; 
 import threadapi-feature ;
 
@@ -307,13 +308,19 @@ alias thread_sources
 
 explicit thread_sources ;
 
+local cxx_requirements = [ requires
+    cxx11_noexcept # from lexical_cast, possibly through date_time
+] ;
+
 lib boost_thread
     : thread_sources
     : <conditional>@requirements
+      $(cxx_requirements)
     :
     : <link>shared:<define>BOOST_THREAD_USE_DLL=1
       <link>static:<define>BOOST_THREAD_USE_LIB=1
       <conditional>@usage-requirements
+      $(cxx_requirements)
     ;
 
 boost-install boost_thread ;

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -18,6 +18,7 @@
 
 # bring in rules for testing
 import testing ;
+import config : requires ;
 import regex ;
 import path ;
 import os ;
@@ -268,6 +269,10 @@ rule generate_self_contained_header_tests
 
     if ! [ os.environ BOOST_THREAD_TEST_WITHOUT_SELF_CONTAINED_HEADER_TESTS ]
     {
+        local cxx_requirements = [ requires
+          cxx11_static_assert # from atomic
+        ] ;
+
         local headers_path = [ path.make $(BOOST_ROOT)/libs/thread/include/boost/thread ] ;
         for file in [ path.glob-tree $(headers_path) : *.hpp : detail pthread win32 ]
         {
@@ -276,8 +281,8 @@ rule generate_self_contained_header_tests
             #       All '/' are replaced with '-' because apparently test scripts have a problem with test names containing slashes.
             local test_name = [ regex.replace ~hdr/$(rel_file) "/" "-" ] ;
             #ECHO $(rel_file) ;
-            all_rules += [ compile self_contained_header.cpp : <define>"BOOST_THREAD_TEST_HEADER=$(rel_file)" <dependency>$(file) : $(test_name) ] ;
-            all_rules += [ compile self_contained_header.cpp : <define>"BOOST_THREAD_TEST_HEADER=$(rel_file)" <define>"BOOST_THREAD_TEST_POST_WINDOWS_H" <dependency>$(file) <conditional>@windows-cygwin-specific : $(test_name)-post_winh ] ;
+            all_rules += [ compile self_contained_header.cpp : <define>"BOOST_THREAD_TEST_HEADER=$(rel_file)" <dependency>$(file) $(cxx_requirements) : $(test_name) ] ;
+            all_rules += [ compile self_contained_header.cpp : <define>"BOOST_THREAD_TEST_HEADER=$(rel_file)" <define>"BOOST_THREAD_TEST_POST_WINDOWS_H" <dependency>$(file) <conditional>@windows-cygwin-specific $(cxx_requirements) : $(test_name)-post_winh ] ;
         }
     }
 


### PR DESCRIPTION
Due to lexical_cast the library requires C++11 which it doesn't advertise making dependents fail in C++03 CI

This sets the requirements manually (atomic and lexical_cast is [used] header-only so we don't get them automatically)

I had an alternative which I want to mention here which basically removes the dependency on lexical_cast:

```
diff --git a/CMakeLists.txt b/CMakeLists.txt
index d724ea36..38c137e8 100644
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,7 +83,6 @@ target_link_libraries(boost_thread
 
   PRIVATE
     Boost::algorithm
-    Boost::lexical_cast
 )
 
 target_compile_definitions(boost_thread
diff --git a/src/pthread/thread.cpp b/src/pthread/thread.cpp
index c17aca2c..6d75a5ec 100644
--- a/src/pthread/thread.cpp
+++ b/src/pthread/thread.cpp
@@ -35,9 +35,9 @@
 
 #include <boost/algorithm/string/split.hpp>
 #include <boost/algorithm/string/trim.hpp>
-#include <boost/lexical_cast.hpp>
 
 #include <fstream>
+#include <sstream>
 #include <string>
 #include <set>
 #include <vector>
@@ -47,6 +47,17 @@ namespace boost
 {
     namespace detail
     {
+        template<typename Target>
+        Target classic_convert(const std::string& src)
+        {
+            std::istringstream s(src);
+            s.imbue(std::locale::classic());
+            Target res;
+            if(s >> res)
+                return res;
+            throw std::bad_cast("Cannot convert " + src);
+        }
+
         thread_data_base::~thread_data_base()
         {
             for (notify_list_t::iterator i = notify.begin(), e = notify.end();
@@ -547,12 +558,12 @@ namespace boost
                 boost::trim(value);
 
                 if (key == physical_id) {
-                    current_core_entry.first = boost::lexical_cast<unsigned>(value);
+                    current_core_entry.first = classic_cast<unsigned>(value);
                     continue;
                 }
 
                 if (key == core_id) {
-                    current_core_entry.second = boost::lexical_cast<unsigned>(value);
+                    current_core_entry.second = classic_cast<unsigned>(value);
                     cores.insert(current_core_entry);
                     continue;
```

Might be worth a consideration as I'm not sure `lexical_cast` (IIRC localized conversion) is correct here.