### PR TITLE
Conditionally set C++11 requirements

### DIFF
--- a/build/Jamfile.v2
+++ b/build/Jamfile.v2
@@ -35,6 +35,7 @@
 import os ;
 import indirect ;
 import path ;
+import config : requires ;
 import configure ; 
 import threadapi-feature ;
 
@@ -249,13 +250,17 @@ rule usage-requirements ( properties * )
     return $(result) ;
 }
 
+local cxx_requirements = [ requires
+    cxx11_noexcept # from lexical_cast
+] ;
+
 rule requirements ( properties * )
 {
     local result ;
 
     if <threadapi>pthread in $(properties)
     {
-        result += <define>BOOST_THREAD_POSIX ;
+        result += <define>BOOST_THREAD_POSIX $(cxx_requirements) ;
         if <target-os>windows in $(properties)
         {
             local paths = [ win32_pthread_paths $(properties) ] ;

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -18,6 +18,7 @@
 
 # bring in rules for testing
 import testing ;
+import config : requires ;
 import regex ;
 import path ;
 import os ;
@@ -268,6 +269,10 @@ rule generate_self_contained_header_tests
 
     if ! [ os.environ BOOST_THREAD_TEST_WITHOUT_SELF_CONTAINED_HEADER_TESTS ]
     {
+        local cxx_requirements = [ requires
+          cxx11_static_assert # from atomic
+        ] ;
+
         local headers_path = [ path.make $(BOOST_ROOT)/libs/thread/include/boost/thread ] ;
         for file in [ path.glob-tree $(headers_path) : *.hpp : detail pthread win32 ]
         {
@@ -276,8 +281,8 @@ rule generate_self_contained_header_tests
             #       All '/' are replaced with '-' because apparently test scripts have a problem with test names containing slashes.
             local test_name = [ regex.replace ~hdr/$(rel_file) "/" "-" ] ;
             #ECHO $(rel_file) ;
-            all_rules += [ compile self_contained_header.cpp : <define>"BOOST_THREAD_TEST_HEADER=$(rel_file)" <dependency>$(file) : $(test_name) ] ;
-            all_rules += [ compile self_contained_header.cpp : <define>"BOOST_THREAD_TEST_HEADER=$(rel_file)" <define>"BOOST_THREAD_TEST_POST_WINDOWS_H" <dependency>$(file) <conditional>@windows-cygwin-specific : $(test_name)-post_winh ] ;
+            all_rules += [ compile self_contained_header.cpp : <define>"BOOST_THREAD_TEST_HEADER=$(rel_file)" <dependency>$(file) $(cxx_requirements) : $(test_name) ] ;
+            all_rules += [ compile self_contained_header.cpp : <define>"BOOST_THREAD_TEST_HEADER=$(rel_file)" <define>"BOOST_THREAD_TEST_POST_WINDOWS_H" <dependency>$(file) <conditional>@windows-cygwin-specific $(cxx_requirements) : $(test_name)-post_winh ] ;
         }
     }
 


### PR DESCRIPTION
Reduced variant of #395 where the requirements are only set when lexical_cast is directly used, i.e. in the pthread case.

However this [fails/failed on Appveyor](https://ci.appveyor.com/project/viboes/thread/builds/48013319) due to `date_time` using `lexical_cast` and also `src/win32/thread_primitives.cpp` including atomic which uses `static_assert`

So to me #395 looks more correct but I wanted to provide both solutions for you to choose.