### PR TITLE
add missing assert header in pthreads_helpers.hpp

### DIFF
--- a/include/boost/thread/pthread/pthread_helpers.hpp
+++ b/include/boost/thread/pthread/pthread_helpers.hpp
@@ -9,6 +9,7 @@
 
 #include <boost/thread/detail/config.hpp>
 #include <boost/throw_exception.hpp>
+#include <boost/assert.hpp>
 #include <pthread.h>
 #include <errno.h>
 


### PR DESCRIPTION
`BOOST_VERIFY` is used in this header, but doesn't include `<boost/assert.hpp>`. Discovered while trying to get tests to compile with Bazel.