### PR TITLE
fix run_it rvalue assignment operator - https://github.com/boostorg/thread/issues/402

### DIFF
--- a/include/boost/thread/future.hpp
+++ b/include/boost/thread/future.hpp
@@ -4668,7 +4668,7 @@ namespace detail
       }
       run_it& operator=(BOOST_THREAD_RV_REF(run_it) x) BOOST_NOEXCEPT {
         if (this != &x) {
-          that_=x.that;
+          that_=x.that_;
           x.that_.reset();
         }
         return *this;


### PR DESCRIPTION
fixed by replacing "x.that" with "x.that_"

fixes #402 