### PR TITLE
Move GCC 8+ warning supression to winAPI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ on:
 
 env:
   UBSAN_OPTIONS: print_stacktrace=1
+  ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
 
 jobs:
   posix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,14 +41,14 @@ jobs:
             os: ubuntu-22.04
             install: clang-15
           - toolset: clang
-            os: macos-11
-            cxxstd: 11
-          - toolset: clang
             os: macos-12
             cxxstd: 14
           - toolset: clang
             os: macos-13
             cxxstd: 17
+          - toolset: clang
+            os: macos-14
+            cxxstd: "11,14,17,20,2b"
 
     runs-on: ${{matrix.os}}
     container: ${{matrix.container}}

--- a/src/win32/thread_primitives.cpp
+++ b/src/win32/thread_primitives.cpp
@@ -93,24 +93,8 @@ ticks_type BOOST_WINAPI_WINAPI_CC get_tick_count_init()
     boost::winapi::HMODULE_ hKernel32 = boost::winapi::GetModuleHandleW(L"kernel32.dll");
     if (hKernel32)
     {
-      // GetProcAddress returns a pointer to some function. It can return
-      // pointers to different functions, so it has to return something that is
-      // suitable to store any pointer to function. Microsoft chose FARPROC,
-      // which is int (WINAPI *)() on 32-bit Windows. The user is supposed to
-      // know the signature of the function he requests and perform a cast
-      // (which is a nop on this platform). The result is a pointer to function
-      // with the required signature, which is bitwise equal to what
-      // GetProcAddress returned.
-      // However, gcc >= 8 warns about that.
-#if defined(BOOST_GCC) && BOOST_GCC >= 80000
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wcast-function-type"
-#endif
         boost::detail::win32::detail::gettickcount64_t p =
-            (boost::detail::win32::detail::gettickcount64_t)boost::winapi::get_proc_address(hKernel32, "GetTickCount64");
-#if defined(BOOST_GCC) && BOOST_GCC >= 80000
-#pragma GCC diagnostic pop
-#endif
+            boost::winapi::get_proc_address<boost::detail::win32::detail::gettickcount64_t>(hKernel32, "GetTickCount64");
         if (p)
         {
             // Use native API


### PR DESCRIPTION
This is useful for other libraries too.

- [x] Requires https://github.com/boostorg/winapi/pull/95