### PR TITLE
Fix GitHub Actions CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ on:
 
 env:
   UBSAN_OPTIONS: print_stacktrace=1
+  ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
 
 jobs:
   posix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,9 +41,6 @@ jobs:
             os: ubuntu-22.04
             install: clang-15
           - toolset: clang
-            os: macos-11
-            cxxstd: 11
-          - toolset: clang
             os: macos-12
             cxxstd: 14
           - toolset: clang


### PR DESCRIPTION
- Allow Node16
- Remove macos-11 job (no more runners)