### PR TITLE
Replace GetSystemTimeAsFileTime with GetSystemTimePreciseAsFileTime

### DIFF
--- a/include/boost/thread/detail/platform_time.hpp
+++ b/include/boost/thread/detail/platform_time.hpp
@@ -294,7 +294,7 @@ inline FP init_steady_clock(kern_return_t & err)
       {
 #if defined(BOOST_THREAD_CHRONO_WINDOWS_API)
         boost::winapi::FILETIME_ ft;
-        boost::winapi::GetSystemTimeAsFileTime(&ft);  // never fails
+        boost::winapi::GetSystemPreciseTimeAsFileTime(&ft);  // never fails
         boost::time_max_t ns = ((((static_cast<boost::time_max_t>(ft.dwHighDateTime) << 32) | ft.dwLowDateTime) - 116444736000000000LL) * 100LL);
         return real_platform_timepoint(ns);
 #elif defined(BOOST_THREAD_CHRONO_MAC_API)


### PR DESCRIPTION
According to Microsoft documentation this variant of GetSystemTime guarantiees to get highest posible level of precision (<1us). https://learn.microsoft.com/en-us/windows/win32/api/sysinfoapi/nf-sysinfoapi-getsystemtimepreciseasfiletime