### PR TITLE
Remove dependencies on Boost.StaticAssert

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,7 +69,6 @@ target_link_libraries(boost_thread
     Boost::predef
     Boost::preprocessor
     Boost::smart_ptr
-    Boost::static_assert
     Boost::system
     Boost::throw_exception
     Boost::tuple

--- a/build.jam
+++ b/build.jam
@@ -24,7 +24,6 @@ constant boost_dependencies :
     /boost/predef//boost_predef
     /boost/preprocessor//boost_preprocessor
     /boost/smart_ptr//boost_smart_ptr
-    /boost/static_assert//boost_static_assert
     /boost/system//boost_system
     /boost/throw_exception//boost_throw_exception
     /boost/tuple//boost_tuple


### PR DESCRIPTION
Boost.StaticAssert has been merged into Boost.Config, so remove the dependency.